### PR TITLE
fix ids conflicting with readded methods and scales

### DIFF
--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -7015,19 +7015,16 @@ relationship: method_of CO_331:0000354 ! reaction to high soil temperature
 id: CO_331:1000001
 name: Methods
 namespace: SweetpotatoMethod
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000002
 name: Scales
 namespace: SweetpotatoScale
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000003
 name: Variables
 namespace: SweetpotatoTrait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000004

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -3,6 +3,293 @@ date: 01:12:2016 04:15
 saved-by: vagrant
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: SweetpotatoTrait
+ontology: TEMP
+
+[Term]
+id: CO_331:0000000
+name: CGIAR sweetpotato trait ontology
+def: "A controlled vocabulary to describe each trait as a distinguishable, characteristic, quality or phenotypic feature of a developing or mature sweetpotato plant." []
+
+[Term]
+id: CO_331:0000001
+name: plant type
+def: "Length of the main vines" []
+synonym: "Main vine length" EXACT []
+synonym: "PtTyp" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000004
+name: ground cover
+def: "Soil area covered by plant canopy" []
+synonym: "VnFolGRnv" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000007
+name: twining
+def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics" []
+synonym: "PtTwg" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000010
+name: predominant vine color
+def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color" []
+synonym: "VnColP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000013
+name: secondary vine color
+def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color" []
+synonym: "VnColS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000016
+name: vine tips pubescence
+def: "Degree of hairiness of immature leaves recorded at the apex of the vines" []
+synonym: "VnTipP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000019
+name: general outline of the leaf
+def: "Outline i.e., shape of a leaf located in the middle section of the vine" []
+synonym: "LfOut" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000022
+name: leaf lobe type
+def: "Type of the lobe of a leaf located in the middle section of the vine" []
+synonym: "LfLbT" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000025
+name: leaf lobe number
+def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine" []
+synonym: "LfLbN" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000028
+name: shape of central leaf lobe
+def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine" []
+synonym: "LfLCS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000031
+name: mature leaf size
+def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave." []
+synonym: "LfLMS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000034
+name: abaxial leaf vein pigmentation
+def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf" []
+synonym: "LfAVP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000037
+name: mature leaf color
+def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants." []
+synonym: "LfCMt" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000040
+name: immature leaf color
+def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants." []
+synonym: "LfColI" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000043
+name: petiole pigmentation
+def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first." []
+synonym: "FrPtP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000046
+name: flower color
+def: "The most representative color in the flowers" []
+synonym: "FRnol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000049
+name: predominant skin color
+def: "The most representative skin color  of the root" []
+synonym: "RtSknColP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000052
+name: intensity of predominant skin color
+def: "Intensity of Predominant Skin color of the root" []
+synonym: "RtSknColPI" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000055
+name: secondary skin color
+def: "The less representative skin color of the root" []
+synonym: "RtSknColS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000058
+name: predominant flesh color
+def: "The most representative flesh color of the root" []
+synonym: "RtFlsColP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000061
+name: secondary flesh color
+def: "The less representative flesh color of the root" []
+synonym: "RtFlsColS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000064
+name: distribution of secondary flesh color
+def: "Distribution of Secondary Flesh color of the root" []
+synonym: "RtFlsColSD" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000067
+name: storage root shape
+def: "Overall assessment of storage root shape" []
+synonym: "RtShp" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000069
+name: storage root shape (primary)
+def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots" []
+synonym: "RtShpP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000070
+name: latex production in storage roots
+def: "Amount of latex observed after cross sectioning medium-sized storage roots" []
+synonym: "RtLxP" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000073
+name: oxidation in storage roots
+def: "Amount of browning due to oxidation" []
+synonym: "RtOxi" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000076
+name: storage root size
+def: "Overall assessment of storage root size based on inspection of the harvested roots" []
+synonym: "RtSiz" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000079
+name: total number of root
+def: "Total number of root after harvest" []
+synonym: "RtTtN" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: CloneSelector2015
+
+[Term]
+id: CO_331:0000082
+name: yield of total roots
+def: "Yield evaluated in the harvest" []
+synonym: "RtYld" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000085
+name: harvest index
+def: "Harvest index" []
+synonym: "IxHrv" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000088
+name: reaction to sweet potato weevil
+def: "Overall assessment of weevil damage based on inspection of the harvested roots; early." []
+synonym: "RnWvl" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000091
+name: reaction to early blight: (alternaria spp)
+def: "Alternaria symptoms evaluation" []
+synonym: "RnAlt" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000094
+name: virus symptoms
+def: "Virus symptoms evaluation" []
+synonym: "RnVir" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000097
+name: storage root cracking
+def: "Storage root cracking" []
+synonym: "RtCrk" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000100
+name: protein content
+def: "Protein content of the root" []
+synonym: "RtFlsPrt" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
 
 [Term]
 id: CO_331:00001000
@@ -228,6 +515,14 @@ namespace: SweetpotatoMethod
 def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato stem borer" []
 is_a: CO_331:1000014 ! Estimation
 relationship: method_of CO_331:0000369 ! reaction to sweet potato stem borer
+
+[Term]
+id: CO_331:0000103
+name: iron content
+def: "Content of iron on dry weight basis of the root" []
+synonym: "RtFlsFe" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
 
 [Term]
 id: CO_331:00001030
@@ -456,6 +751,14 @@ is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
 
 [Term]
+id: CO_331:0000106
+name: zinc content
+def: "Content of zinc on dry weight basis of the root" []
+synonym: "RtFlsZn" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
 id: CO_331:00001060
 name: visual estimation of the plant response to  scab
 namespace: SweetpotatoMethod
@@ -682,6 +985,14 @@ is_a: CO_331:1000014 ! Estimation
 relationship: method_of CO_331:0000400 ! reaction to witches broom
 
 [Term]
+id: CO_331:0000109
+name: beta-carotene content
+def: "Beta carotene content of the root" []
+synonym: "RtFlsBC" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
 id: CO_331:00001090
 name: rcwb 5 pt. scale
 namespace: SweetpotatoScale
@@ -721,43 +1032,42 @@ relationship: method_of CO_331:0000408 ! appearance of hearbarium
 id: CO_331:00001094
 name: rttsgc
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001095
 name: plant picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001096
 name: flower picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001097
 name: root picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001098
 name: seeds picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001099
 name: leaf picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
-relationship: scale_of CO_331:00001093 ! taking standardized photo
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
@@ -765,7 +1075,7 @@ id: CO_331:00001100
 name: observation of most frequennt storage root shape
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000069 ! storage root shape (primary)
 
 [Term]
@@ -780,7 +1090,7 @@ id: CO_331:00001102
 name: observation of 2nd most frequent storage root shape
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000441 ! storage root shape (secondary)
 
 [Term]
@@ -795,7 +1105,7 @@ id: CO_331:00001104
 name: observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000409 ! storage root shape uniformity
 
 [Term]
@@ -810,8 +1120,8 @@ id: CO_331:00001106
 name: observation of an average or all storage roots within a single plant or plot
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001 ! Method
-relationship: method_of CO_331:0000410 ! storage root stalk
+is_a: CO_331:1000001
+relationship: method_of CO_331:0000410 ! storage root stalk length
 relationship: method_of CO_331:0000411 ! storage root attachment
 relationship: method_of CO_331:0000412 ! length to diameter ratio of roots
 relationship: method_of CO_331:0000413 ! skin color of roots
@@ -820,7 +1130,7 @@ relationship: method_of CO_331:0000415 ! flesh color (carotenoids)
 relationship: method_of CO_331:0000416 ! flesh color (anthocyanins)
 relationship: method_of CO_331:0000417 ! deep of eyes of roots
 relationship: method_of CO_331:0000418 ! number of lenticels
-relationship: method_of CO_331:0000423 ! storage root defects
+relationship: method_of CO_331:0000423 ! storage root defects (primary)
 relationship: method_of CO_331:0000424 ! relative storage root yield
 relationship: method_of CO_331:0000426 ! storage root appearance
 relationship: method_of CO_331:0000427 ! growing season
@@ -844,7 +1154,7 @@ relationship: scale_of CO_331:00001106 ! observation of an average or all storag
 id: CO_331:00001109
 name: scale_of CO_331:00001106
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
 
@@ -895,7 +1205,7 @@ id: CO_331:00001116
 name: observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000419 ! reaction to streptomyces soil rot
 
 [Term]
@@ -910,7 +1220,7 @@ id: CO_331:00001118
 name: visual estimation of the roots response to  root-knot nematode
 namespace: SweetpotatoMethod
 def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Root-knot nematode" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
 relationship: method_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
 
@@ -920,6 +1230,14 @@ name: rcmgrkn  6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
+
+[Term]
+id: CO_331:0000112
+name: total carotenoids
+def: "Total carotenoids content of the root" []
+synonym: "RtFlsTC" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
 
 [Term]
 id: CO_331:00001120
@@ -933,7 +1251,7 @@ id: CO_331:00001121
 name: visual estimation of the roots response to  fusarium oxysporum
 namespace: SweetpotatoMethod
 def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Fusarium oxysporum" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000422 ! reaction to fusarium oxysporum
 
 [Term]
@@ -968,28 +1286,28 @@ relationship: scale_of CO_331:00001106 ! observation of an average or all storag
 id: CO_331:00001126
 name: amylose - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000428 ! amylose content
 
 [Term]
 id: CO_331:00001127
 name: g/100 g fw
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001126 ! amylose - method
 
 [Term]
 id: CO_331:00001128
 name: asparagine - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000429 ! asparagine content
 
 [Term]
 id: CO_331:00001129
 name: mg/g dw
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001128 ! asparagine - method
 relationship: scale_of CO_331:00001130 ! cyanidin - method
 relationship: scale_of CO_331:00001131 ! total monomeric anthocyanins - method
@@ -1001,35 +1319,35 @@ relationship: scale_of CO_331:00001134 ! phenol - method
 id: CO_331:00001130
 name: cyanidin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000430 ! cyanidin content
 
 [Term]
 id: CO_331:00001131
 name: total monomeric anthocyanins - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000431 ! total monomeric anthocyanin content
 
 [Term]
 id: CO_331:00001132
 name: peonidin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000432 ! peonidin content
 
 [Term]
 id: CO_331:00001133
 name: anthocyanin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000433 ! anthocyanin content
 
 [Term]
 id: CO_331:00001134
 name: phenol - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000434 ! phenol content
 
 [Term]
@@ -1043,7 +1361,7 @@ relationship: method_of CO_331:0000435 ! nodes per vine
 id: CO_331:00001136
 name: nodes/plant
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001135 ! nodes per vine evaluation
 
 [Term]
@@ -1057,7 +1375,7 @@ relationship: method_of CO_331:0000436 ! leaves per plant
 id: CO_331:00001138
 name: leaf/plant
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001137 ! leaves per plant evaluation
 
 [Term]
@@ -1065,14 +1383,14 @@ id: CO_331:00001139
 name: color of leave picture
 namespace: SweetpotatoMethod
 def: "Taking picture" []
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 relationship: method_of CO_331:0000437 ! color of leave
 
 [Term]
 id: CO_331:00001140
 name: picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:00001139 ! color of leave picture
 
 [Term]
@@ -1103,6 +1421,3565 @@ name: rtsinsdam  5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:00001143 ! soils insect evaluation
+
+[Term]
+id: CO_331:0000115
+name: storage root starch content
+def: "Storage root starch content evaluated in percentage dry weight" []
+synonym: "RtFlsSta" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000118
+name: fructose content
+def: "Fructose content of the root" []
+synonym: "RtFlsFru" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000121
+name: glucose content
+def: "Glucose content of the root" []
+synonym: "RtFlsGlu" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000124
+name: sucrose content
+def: "Sucrose content  of the root" []
+synonym: "RtFlsSuc" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000127
+name: maltose content
+def: "Maltose content  of the root" []
+synonym: "RtFlsMal" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000130
+name: fiber content
+def: "Fiber content in fresh samples" []
+synonym: "RtFlsFf" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000133
+name: color of boiled roots
+def: "Color of boiled roots" []
+synonym: "RtCb" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: R.Kapinga
+
+[Term]
+id: CO_331:0000136
+name: texture of boiled storage root flesh
+def: "Storage root texture after boiled" []
+synonym: "RtFlsTxH" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000139
+name: sweetness of boiled storage root flesh
+def: "Sweetness of boiled root" []
+synonym: "RtFlsSwt" EXACT []
+synonym: "Storage root sweetness" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman,W. Grueneberg
+
+[Term]
+id: CO_331:0000142
+name: storage root dry matter content
+def: "Storage root dry matter content" []
+synonym: "RtDMC" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000147
+name: Plant Type estimating 3-9
+def: "Length of the main vines. 3= Erect (<75 cm), 5= Semi-erect (75-150 cm), 7= Spreading (151-250 cm), 9= Extremely spreading (> 250 cm)" []
+synonym: "PLANT" EXACT []
+synonym: "PtTyp_Et_3to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000001 ! plant type
+relationship: variable_of CO_331:0000812 ! observation of plant type
+relationship: variable_of CO_331:0000813 ! plttyp 4 pt. scale
+
+[Term]
+id: CO_331:0000148
+name: Ground Cover estimating 3-9
+def: "Soil area covered by plant canopy. 3= Low (<50%), 5= Medium (<50-74%), 7= High (75-90%), 9= Total (> 90%)" []
+synonym: "GRNDCOVR" EXACT []
+synonym: "VnFolGRnv_Et_3to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000004 ! ground cover
+relationship: variable_of CO_331:0000814 ! observation of ground cover
+relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
+
+[Term]
+id: CO_331:0000149
+name: Twining  estimating 0-9
+def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics. 0= Non-Twining, 3= Slightly twining, 5 = Moderately twining, 7= Twining, 9 = Very twining" []
+synonym: "PtTwg_Et_0to9" EXACT []
+synonym: "TWING" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000007 ! twining
+relationship: variable_of CO_331:0000816 ! observation of twining
+relationship: variable_of CO_331:0000817 ! plttwg 5 pt. scale
+
+[Term]
+id: CO_331:0000150
+name: Predominant Vine Color estimating 1-9
+def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color. 1= Green, 3= Green with few purple spots, 4= Green with many purple spots, 5= Green with many dark purple spots, 6 = Mostly purple, 7= Mostly dark purple, 8= Totally purple, 9= Totally dark purple" []
+synonym: "VINCO1" EXACT []
+synonym: "VnColP_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000010 ! predominant vine color
+relationship: variable_of CO_331:0000818 ! observation of predominant vine color
+relationship: variable_of CO_331:0000819 ! vinclp 9 pt. scale
+
+[Term]
+id: CO_331:0000151
+name: Secondary Vine Color estimating 0-7
+def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color. 0 = Absent, 1 = Green base, 2 = Green tip, 3 = Green nodes, 4 = Purple base, 5 = Purple tip, 6 = Purple nodes, 7 = Other" []
+synonym: "VINCO2" EXACT []
+synonym: "VnColS_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000013 ! secondary vine color
+relationship: variable_of CO_331:0000820 ! observation of secondary vine color
+relationship: variable_of CO_331:0000821 ! vincls 8 pt. scale
+
+[Term]
+id: CO_331:0000152
+name: Vine Tips Pubescence estimating 0-7
+def: "Degree of hairiness of immature leaves recorded at the apex of the vines. 0= Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
+synonym: "VINPUBS" EXACT []
+synonym: "VnTipP_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000016 ! vine tips pubescence
+relationship: variable_of CO_331:0000822 ! observation of vine tips pubescence
+relationship: variable_of CO_331:0000823 ! vintpp 8 pt. scale
+
+[Term]
+id: CO_331:0000153
+name: vine internode length
+def: "Measurement of the vine internode length" []
+synonym: "VnInLg" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000156
+name: Vine internode length estimating 1-9
+def: "Measurement of the vine internode length. 1= Very short (<3 cm), 3= Short (3-5 cm), 5=Intermediate (6-9 cm), 7=Long (10-12 cm), 9 =Very long (>12 cm)" []
+synonym: "VINLG" EXACT []
+synonym: "VnInLg_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000153 ! vine internode length
+relationship: variable_of CO_331:0000824 ! average length of at least three internodes located in the middle section of the vine
+relationship: variable_of CO_331:0000825 ! vininlg 5 pt. scale
+
+[Term]
+id: CO_331:0000157
+name: vine internode diameter
+def: "Measurement of the vine internode diameter" []
+synonym: "VnInD" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000160
+name: Vine internode diameter estimating 1-9
+def: "Measurement of the vine internode diameter. 1= Very thin (<4 mm), 3= Thin (4-6 mm), 5=Intermediate (7-9 mm), 7=Thick (10-12 mm), 9=Very thick (>12 mm)" []
+synonym: "VINDIA" EXACT []
+synonym: "VnInD_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000157 ! vine internode diameter
+relationship: variable_of CO_331:0000826 ! average diameter of at least three internodes located in the middle section of the vine
+relationship: variable_of CO_331:0000827 ! vinind 5 pt. scale
+
+[Term]
+id: CO_331:0000161
+name: General Outline of the Leaf estimating 1-7
+def: "Outline i.e., shape of a leaf located in the middle section of the vine. 1= Rounded, 2= Reniform (kidney-shaped), 3 = Chordate (heart-shaped), 4 = Triangular, 5= Hastate, 6 = Lobed, 7 = Almost divided" []
+synonym: "LEAFSHAP1" EXACT []
+synonym: "LfOut_Et_1to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000019 ! general outline of the leaf
+relationship: variable_of CO_331:0000828 ! observation of general outline of the leaf
+relationship: variable_of CO_331:0000829 ! lefout 7 pt. scale
+
+[Term]
+id: CO_331:0000162
+name: Leaf Lobes Type estimating 0-9
+def: "Type of the lobe of a leaf located in the middle section of the vine. 0 = No lateral lobes (entire), 1 = Very slight (teeth), 3 = Slight, 5 = Moderate, 7 = Deep, 9= Very deep" []
+synonym: "LEAFSHAP2" EXACT []
+synonym: "LfLbT_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000022 ! leaf lobe type
+relationship: variable_of CO_331:0000830 ! observation of leaf lobes type
+relationship: variable_of CO_331:0000831 ! leflbt  6 pt. scale
+
+[Term]
+id: CO_331:0000163
+name: Leaf Lobe Number estimating 1-9
+def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine. 1= 1 Lobe, 3 = 3 Lobe, 5 = 5 Lobe, 7 = 7 Lobe, 9 = 9 Lobe" []
+synonym: "LEAFSHAP3" EXACT []
+synonym: "LfLbN_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000025 ! leaf lobe number
+relationship: variable_of CO_331:0000832 ! observation of leaf lobe number
+relationship: variable_of CO_331:0000833 ! leflbn 5 pt. scale
+
+[Term]
+id: CO_331:0000164
+name: Shape of Central Leaf Lobe estimating 0-9
+def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine. 0 = Absent, 1 = Toothed, 2 = Triangular, 3 = Semi-circular, 4 = Semi-elliptic, 5 = Elliptic, 6 = Lanceolate, 7 = Oblanceolate, 8 = Linear (broad), 9 = Linear (narrow)" []
+synonym: "LEAFSHAP4" EXACT []
+synonym: "LfLCS_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000028 ! shape of central leaf lobe
+relationship: variable_of CO_331:0000834 ! observation of shape of central leaf lobe
+relationship: variable_of CO_331:0000835 ! leflcs 10 pt. scale
+
+[Term]
+id: CO_331:0000165
+name: Mature Leaf Size estimating 3-9
+def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave.. 3 = Small (<8 cm), 5 = Medium (8-15 cm), 7 = Large (16-25 cm), 9 = Very large (> 25 cm)" []
+synonym: "LfLMS_Et_3to9" EXACT []
+synonym: "LFSIZE" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000031 ! mature leaf size
+relationship: variable_of CO_331:0000836 ! observation of mature leaf size
+relationship: variable_of CO_331:0000837 ! leflms 9 pt. scale
+
+[Term]
+id: CO_331:0000166
+name: Abaxial Leaf Vein Pigmentation estimating 1-9
+def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf. 1 = Yellow, 2 = Green, 3 = Purple spot in the base of main rib, 4 = Purple spot in several veins, 5 = Main rib partially purple, 6 = Main rib mostly or totally purple, 7 = All veins partial purple, 8 = All veins mostly or totally purple, 9 = Lower surface and veins totally purple" []
+synonym: "LfAVP_Et_1to9" EXACT []
+synonym: "LFVEIN" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000034 ! abaxial leaf vein pigmentation
+relationship: variable_of CO_331:0000838 ! observation of abaxial leaf vein pigmentation
+relationship: variable_of CO_331:0000839 ! lefavp 9 pt. scale
+
+[Term]
+id: CO_331:0000167
+name: Mature Leaf Color estimating 1-9
+def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
+synonym: "LfCMt_Et_1to9" EXACT []
+synonym: "LFMATCO" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000037 ! mature leaf color
+relationship: variable_of CO_331:0000840 ! observation of mature leaf color
+relationship: variable_of CO_331:0000841 ! lefcmt 9 pt. scale
+
+[Term]
+id: CO_331:0000168
+name: Immature Leaf Color estimating 1-9
+def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
+synonym: "LfColI_Et_1to9" EXACT []
+synonym: "LFINMCO" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000040 ! immature leaf color
+relationship: variable_of CO_331:0000842 ! observation of immature leaf color
+relationship: variable_of CO_331:0000843 ! lefcim 9 pt. scale
+
+[Term]
+id: CO_331:0000169
+name: Petiole Pigmentation estimating 1-9
+def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first.. 1 = Green, 2 = Green with purple near steam, 3 = Green width purple near leaf, 4 = Green with purple both ends, 5 = Green with purple spots throughout petiole, 6 = Green with multiple stripes, 7 = Purple with green near leaf, 8 = Some petioles purple others green, 9 = Totally or mostly purple" []
+synonym: "FrPtP_Et_1to9" EXACT []
+synonym: "PTIOPG" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000043 ! petiole pigmentation
+relationship: variable_of CO_331:0000844 ! observation of petiole pigmentation
+relationship: variable_of CO_331:0000845 ! flrptp 9 pt. scale
+
+[Term]
+id: CO_331:0000170
+name: petiole length
+def: "Petiole length from the base to the insertion with the blade" []
+synonym: "FrPtL" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000173
+name: Petiole length estimating 1-9
+def: "Petiole length from the base to the insertion with the blade. 1=Very short (<10 cm), 3=Short (10-20 cm), 5=Intermediate (21-30 cm), 7=Long (31-40 cm), 9=Very long (>40 cm)" []
+synonym: "FrPtL_Et_1to9" EXACT []
+synonym: "PETIOL" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000170 ! petiole length
+relationship: variable_of CO_331:0000846 ! average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
+relationship: variable_of CO_331:0000847 ! flrptl 5 pt. scale
+
+[Term]
+id: CO_331:0000174
+name: Flower color estimating 1-6
+def: "The most representative color in the flowers. 1= White, 2 = White limb with purple throat, 3 = White limb with pale purple ring and purple throat, 4 = Pale purple limb with purple throat, 5 = Purple, 6 = Other" []
+synonym: "FLORCOL" EXACT []
+synonym: "FRnol_Et_1to6" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000046 ! flower color
+relationship: variable_of CO_331:0000848 ! observation of newly opened flowers
+relationship: variable_of CO_331:0000849 ! flrcol  6 pt. scale
+
+[Term]
+id: CO_331:0000175
+name: Predominant Skin color estimating 1-9
+def: "The most representative skin color of the root. 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
+synonym: "RTSKN1, SCOL" EXACT []
+synonym: "RtSknColP_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000049 ! predominant skin color
+relationship: variable_of CO_331:0000850 ! observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
+relationship: variable_of CO_331:0000851 ! prdskncol 9 pt. scale
+
+[Term]
+id: CO_331:0000176
+name: Intensity of Predominant Skin color estimating 1-3
+def: "Intensity of Predominant Skin color of the root. 1= Pale, 2 = Intermediate, 3 = Dark" []
+synonym: "RTSKN2" EXACT []
+synonym: "RtSknColPI_Et_1to3" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000052 ! intensity of predominant skin color
+relationship: variable_of CO_331:0000852 ! observation of intensity of predominant skin color
+relationship: variable_of CO_331:0000853 ! skncpi  3 pt. scale
+
+[Term]
+id: CO_331:0000177
+name: Secondary Skin color estimating 1-10
+def: "The less representative skin color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
+synonym: "RTSKN3" EXACT []
+synonym: "RtSknColS_Et_1to10" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000055 ! secondary skin color
+relationship: variable_of CO_331:0000854 ! observation of secondary skin color
+relationship: variable_of CO_331:0000855 ! skncsc  10 pt. scale
+
+[Term]
+id: CO_331:0000178
+name: Predominant Flesh color estimating 1-9
+def: "The most representative flesh color of the root. 1 = White, 2 = Cream, 3 = Dark cream, 4 = Pale yellow, 5 = Dark yellow, 6 = Pale orange, 7 = Intermediate orange, 8 = Dark orange, 9 = Strongly pigmented with anthocyanins" []
+synonym: "RtFlsColP_Et_1to9" EXACT []
+synonym: "RTFSH1, FCOL" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000058 ! predominant flesh color
+relationship: variable_of CO_331:0000856 ! observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
+relationship: variable_of CO_331:0000857 ! prdflshcol 9 pt. scale
+
+[Term]
+id: CO_331:0000179
+name: Secondary Flesh color estimating 0-9
+def: "The less representative flesh color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Pink, 6 = Red, 7 = Purple-red, 8 = Purple, 9 = Dark purple" []
+synonym: "RtFlsColS_Et_0to9" EXACT []
+synonym: "RTFSH2" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000061 ! secondary flesh color
+relationship: variable_of CO_331:0000858 ! observation of secondary flesh color
+relationship: variable_of CO_331:0000859 ! flscsc 10 pt. scale
+
+[Term]
+id: CO_331:0000180
+name: Distribution of Secondary Flesh color estimating 0-9
+def: "Distribution of Secondary Flesh color of the root. 0 = Absent, 1 = Narrow ring in cortex, 2 = Broad ring in cortex, 3 = Scattered spots in flesh, 4 = Narrow ring in flesh, 5 = Broad ring in flesh, 6 = Ring and other areas in flesh, 7 = In longitudinal sections, 8 = Covering most of the flesh, 9 = Covering all flesh" []
+synonym: "RtFlsColSD_Et_1to9" EXACT []
+synonym: "RTFSH3" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000064 ! distribution of secondary flesh color
+relationship: variable_of CO_331:0000860 ! observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
+relationship: variable_of CO_331:0000861 ! flscsd 10 pt. scale
+
+[Term]
+id: CO_331:0000181
+name: Storage Root Shape estimating 1-9
+def: "Overall assessment of storage root shape. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Ovate, 5 = Obovate, 6 = Oblong, 7 = Long oblong, 8 = Long elliptic, 9 = Long irregular or curved" []
+synonym: "RTSHP" EXACT []
+synonym: "RtShp_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000067 ! storage root shape
+relationship: variable_of CO_331:0000862 ! observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
+relationship: variable_of CO_331:0000863 ! rtshp 9 pt. scale
+
+[Term]
+id: CO_331:0000182
+name: Latex Production in Storage Roots estimating 3-7
+def: "Amount of latex observed after cross sectioning medium-sized storage roots. 3 = Little, 5 = Some, 7 = Abundant" []
+synonym: "RTLATX" EXACT []
+synonym: "RtLxP_Et_3to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000070 ! latex production in storage roots
+relationship: variable_of CO_331:0000864 ! observation of latex production in storage roots
+relationship: variable_of CO_331:0000865 ! rtlat 3 pt. scale
+
+[Term]
+id: CO_331:0000183
+name: Oxidation in Storage Roots estimating 3-7
+def: "Amount of browning due to oxidation. 3 = Little, 5 = Some, 7 = Abundant" []
+synonym: "RtOxi_Et_3to7" EXACT []
+synonym: "RTOXID" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000073 ! oxidation in storage roots
+relationship: variable_of CO_331:0000866 ! observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
+relationship: variable_of CO_331:0000867 ! rtoxi 3 pt. scale
+
+[Term]
+id: CO_331:0000184
+name: Storage root size estimating 1-9
+def: "Overall assessment of storage root size based on inspection of the harvested roots. 1 = Excellent, 3 = Good, 5 = Fair, 7 = Poor, 9 = terrible" []
+synonym: "RS" EXACT []
+synonym: "RtSiz_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000076 ! storage root size
+relationship: variable_of CO_331:0000868 ! storage root size - method
+relationship: variable_of CO_331:0000869 ! rtsize 5 pt. scale
+
+[Term]
+id: CO_331:0000189
+name: number of plants established
+def: "Number of plants established" []
+synonym: "PltEst" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000192
+name: Plants established counting number per plot
+def: "Number of plants established" []
+synonym: "NOPE" EXACT []
+synonym: "PltEst_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000189 ! number of plants established
+relationship: variable_of CO_331:0000870 ! evaluation of plant vine establishment
+relationship: variable_of CO_331:0000871 ! plants/plot
+
+[Term]
+id: CO_331:0000193
+name: Virus symptoms 1 estimating 1-9
+def: "Virus symptoms evaluation. 1= No virus symptoms, 2= Unclear virus symptoms, 3= Clear virus symptoms < 5% of plants per plot, 4= Clear virus symptoms at 6 to 15% of plants per plot, 5= Clear virus symptoms at 16 to 33% of plants per plot, 6= Clear virus symptoms at 34 to 66% of plants per plot (more than 1/3 less than 2/3), 7= Clear virus symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8= Clear virus symptoms at all plants per plot (not stunted), 9= Severe virus symptoms in all plants per plot (stunted)." []
+synonym: "VIR1" EXACT []
+synonym: "VirSm1_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000094 ! virus symptoms
+relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
+relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
+
+[Term]
+id: CO_331:0000194
+name: vine vigor
+def: "Vine vigor evaluation" []
+synonym: "VnVg" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000197
+name: Vine vigor  estimating 1-9
+def: "Vine vigor evaluation. 1= Nearly no vines, 2= Weak vines, 3= Weak to medium strong vines, medium thick stems, and long internode distances, 4= Medium strong vines, medium thick stems, and medium internode distances, 5= Medium strong vines, thick vines, and long internode distances, 6= Medium strong vines, thick stems, and medium internode distances, 7= Strong vines, thick stems, short internode distances, and medium-long vines, 8= Strong vines, thick stems, short internode distances, and long vines,, 9= Very strong vine strength, thick stems, short internode distances, and very long vines" []
+synonym: "VnVg_Et_1to9" EXACT []
+synonym: "VV1" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000194 ! vine vigor
+relationship: variable_of CO_331:0000875 ! observation of plant vigour
+relationship: variable_of CO_331:0000876 ! vinvgr 9 pt. scale
+
+[Term]
+id: CO_331:0000198
+name: Reaction to Alternaria symptom estimating 1-9
+def: "Alternaria symptoms evaluation. 1 = No symptoms, 2 = Unclear symptoms, 3 = Clear symptoms at <5% per plot, 4 = Clear symptoms at 6 to 15% of plants per plot, 5 = Clear symptoms at 16 to 33% of plants per plot (less than 1/3), 6 = Clear symptoms at 34 to 66% of plants per plot (more than 1/3, 7 = Clear symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8 = Clear symptoms at all plants (not fully defoliated), 9 = Severe symptoms at all plants per plot (fully defoliated)" []
+synonym: "ALT1, AS1" EXACT []
+synonym: "RnAlt_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000091 ! reaction to early blight: (alternaria spp)
+relationship: variable_of CO_331:0000877 ! early blight evaluation: (alternaria)
+relationship: variable_of CO_331:0000878 ! altsm 9 pt. scale
+
+[Term]
+id: CO_331:0000199
+name: storage root form
+def: "Overall assessment of storage root form" []
+synonym: "RtFrm" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000202
+name: Storage root form estimating 1-9
+def: "Overall assessment of storage root form. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+synonym: "RF" EXACT []
+synonym: "RtFrm_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000199 ! storage root form
+relationship: variable_of CO_331:0000879 ! storage root form - method
+relationship: variable_of CO_331:0000880 ! rtform 9 pt. scale
+
+[Term]
+id: CO_331:0000203
+name: number of storage root damages
+def: "Root with structural damages" []
+synonym: "RtDam" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000206
+name: Storage root damages estimating 1-9
+def: "Root with structural damages. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
+synonym: "DAMR" EXACT []
+synonym: "RtDam_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000203 ! number of storage root damages
+relationship: variable_of CO_331:0000881 ! storage root damage
+relationship: variable_of CO_331:0000882 ! rtsdam 9 pt. scale
+
+[Term]
+id: CO_331:0000207
+name: Reaction to Sweet potato weevil symptoms estimating 1-9
+def: "Overall assessment of weevil damage based on inspection of the harvested roots; early.. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
+synonym: "RnWvl_Et_1to9" EXACT []
+synonym: "WED1, WED" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000088 ! reaction to sweet potato weevil
+relationship: variable_of CO_331:0000883 ! weevil damage evaluation
+relationship: variable_of CO_331:0000884 ! rtdam 9 pt. scale
+
+[Term]
+id: CO_331:0000208
+name: number of plants with storage roots
+def: "Number of plants with storage roots" []
+synonym: "PtRt" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000211
+name: Plants with storage roots counting number per plot
+def: "Number of plants with storage roots" []
+synonym: "NOPR" EXACT []
+synonym: "PtRt_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000208 ! number of plants with storage roots
+relationship: variable_of CO_331:0000871 ! plants/plot
+relationship: variable_of CO_331:0000885 ! evaluation of plants
+
+[Term]
+id: CO_331:0000212
+name: number of commercial storage roots
+def: "Roots 12-20 cm long and 10 cm in diameter" []
+synonym: "RtCmN" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000214
+name: Number of commercial storage roots counting number per plot
+def: "Number of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+synonym: "NOCR" EXACT []
+synonym: "RtCmN_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000212 ! number of commercial storage roots
+relationship: variable_of CO_331:0000886 ! evaluation of roots
+relationship: variable_of CO_331:0000887 ! roots/plot
+
+[Term]
+id: CO_331:0000215
+name: number of non-commercial storage roots
+def: "Number of small and large roots (10 > x < 20 cm long)" []
+synonym: "RtNCmN" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000217
+name: Number of non-commercial storage roots counting number per plot
+def: "Number of root shorter than 10 cm long and greater than 20 cm long." []
+synonym: "NONC" EXACT []
+synonym: "RtNCmN_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000215 ! number of non-commercial storage roots
+relationship: variable_of CO_331:0000886 ! evaluation of roots
+relationship: variable_of CO_331:0000887 ! roots/plot
+
+[Term]
+id: CO_331:0000218
+name: weight of commercial storage roots
+def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+synonym: "RtCmW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000220
+name: Weight of commercial storage roots measuring kg per plot
+def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+synonym: "CRW" EXACT []
+synonym: "RtCmW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000218 ! weight of commercial storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000221
+name: weight of non-commercial storage roots
+def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
+synonym: "RtNCmW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000223
+name: Weight of non-commercial storage roots measuring kg per plot
+def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
+synonym: "NCRW" EXACT []
+synonym: "RtNCmW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000221 ! weight of non-commercial storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000224
+name: weight of vines
+def: "Weight of vines" []
+synonym: "VnW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000227
+name: Weight of vines measuring kg per plot
+def: "Weight of vines" []
+synonym: "VnW_Ms_kgplot" EXACT []
+synonym: "VW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000224 ! weight of vines
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0000894 ! measurements of vine mass
+
+[Term]
+id: CO_331:0000230
+name: Total number of roots computation per plant
+def: "Total number of root after harvest" []
+synonym: "RtTtN_Ct_rtplant" EXACT []
+synonym: "TNROOT,NRPP" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000079 ! total number of root
+relationship: variable_of CO_331:0000890 ! estimated number per plant - method
+relationship: variable_of CO_331:0000891 ! roots/ plant
+
+[Term]
+id: CO_331:0000233
+name: Total number of root counting per plot
+def: "Total number of root after harvest" []
+synonym: "RtTtN_Ct_rtplot" EXACT []
+synonym: "TNRPLOT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000079 ! total number of root
+relationship: variable_of CO_331:0000888 ! estimated number per plot - method
+relationship: variable_of CO_331:0000889 ! roots/ plot
+
+[Term]
+id: CO_331:0000234
+name: total root weight
+def: "Total weight of root  after harvest" []
+synonym: "RtTWt" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: CloneSelector2015
+
+[Term]
+id: CO_331:0000237
+name: Total root weight computation per plot
+def: "Total weight of root after harvest" []
+synonym: "RtTWt_Cp_plot" EXACT []
+synonym: "TRW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000234 ! total root weight
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0000895 ! estimated weight per plot - method
+
+[Term]
+id: CO_331:0000239
+name: Storage root cracking estimating 0-7
+def: "Storage root cracking. 0 = Absent, 3 = Few cracks, 5 = Medium number of cracks, 7 = Many cracks" []
+synonym: "RtCrk_Et_0to7" EXACT []
+synonym: "SGROOT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000097 ! storage root cracking
+relationship: variable_of CO_331:0000902 ! estimation of cracking roots
+relationship: variable_of CO_331:0000903 ! rtscr 4 pt. scale
+
+[Term]
+id: CO_331:0000240
+name: Fresh weight of storage root
+def: "Weight of storage root samples" []
+synonym: "RtFWt" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000243
+name: Fresh weight of storage root samples measuring g of sample
+def: "Weight of storage root samples" []
+synonym: "DMF" EXACT []
+synonym: "RtFWt_Ms_g" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000240 ! Fresh weight of storage root
+relationship: variable_of CO_331:0000904 ! measurements of fresh root mass
+relationship: variable_of CO_331:0000905 ! g
+
+[Term]
+id: CO_331:0000244
+name: Dry weight of storage root
+def: "Weight of storage root samples" []
+synonym: "RtDWt" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000247
+name: Dry weight of storage root samples measuring g of sample
+def: "Weight of storage root samples" []
+synonym: "DMD" EXACT []
+synonym: "RtDWt_Ms_g" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000244 ! Dry weight of storage root
+relationship: variable_of CO_331:0000905 ! g
+relationship: variable_of CO_331:0000906 ! measurements of dry root mass
+
+[Term]
+id: CO_331:0000248
+name: Fresh weight of vines
+def: "Weight of vines samples" []
+synonym: "VnFWt" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000251
+name: Fresh weight of vines measuring g of sample
+def: "Weight of vines samples" []
+synonym: "DMFV" EXACT []
+synonym: "VnFWt_Et_g" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000248 ! Fresh weight of vines
+relationship: variable_of CO_331:0000905 ! g
+relationship: variable_of CO_331:0000907 ! measurements of fresh vine mass
+
+[Term]
+id: CO_331:0000252
+name: Dry weight of vines
+def: "Weight of vines samples" []
+synonym: "VnDWt" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000255
+name: Dry weight of vines measuring g of sample
+def: "Weight of vines samples" []
+synonym: "DMDV" EXACT []
+synonym: "VnDWt_Ms_g" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000252 ! Dry weight of vines
+relationship: variable_of CO_331:0000905 ! g
+relationship: variable_of CO_331:0000908 ! measurements of dry vine mass
+
+[Term]
+id: CO_331:0000256
+name: fiber cooked
+def: "Fiber content in cooked samples" []
+synonym: "RtFlsFbC" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000259
+name: Fibers in cooked samples estimating 1-9
+def: "Fiber content in cooked samples. 1= Non-fibrous, 2= Non-fibrous to slightly fibrous, 3= Slightly fibrous, 4= Slightly to moderately fibrous, 5= Moderately fibrous, 6= Moderately fibrous to fibrous, 7= Fibrous, 8= Fibrous to very fibrous, 9= Very fibrous" []
+synonym: "COOF" EXACT []
+synonym: "RtFlsFbC_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000256 ! fiber cooked
+relationship: variable_of CO_331:0000909 ! evaluation of cooked samples for fibers
+relationship: variable_of CO_331:0000910 ! rtfbr 9 pt. scale
+
+[Term]
+id: CO_331:0000260
+name: Fibers content in fresh samples measuring percent
+def: "Fiber content in fresh samples" []
+synonym: "FIBER" EXACT []
+synonym: "RtFlsFf_Ms_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000130 ! fiber content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
+
+[Term]
+id: CO_331:0000261
+name: Storage root sweetness estimating 1-9
+def: "Sweetness of boiled root. 1 = Not at all sweet, 2= Non-sweet to slightly sweet, 3 = Slightly sweet, 4= Slightly to moderately sweet, 5 = Moderately sweet, 6= Moderately sweet to sweet, 7 = Sweet, 8= Sweet to very sweet, 9= Very sweet" []
+synonym: "RtFlsSwt_Et_1to9" EXACT []
+synonym: "TASTE, COOSU" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000139 ! sweetness of boiled storage root flesh
+relationship: variable_of CO_331:0000912 ! evaluation of cooked samples for sweetness
+relationship: variable_of CO_331:0000913 ! rtswt 9 pt. scale
+
+[Term]
+id: CO_331:0000263
+name: Storage root texture estimating 1-9 by Huaman
+def: "Storage root texture after boiled. 1 = Dry, 3 = Somewhat dry, 5 = Intermediate, 7 = Moist, 9 = Very moist" []
+synonym: "RtFlsTxH_Et_1to9" EXACT []
+synonym: "RTTEXT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
+relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
+relationship: variable_of CO_331:0000915 ! flstxch 5 pt. scale
+
+[Term]
+id: CO_331:0000265
+name: Storage root texture estimating 1-9 by Grueneberg
+def: "Storage root texture after boiled. 1= very moist, 2= Very moist to moist, 3= Moist, 4= Moist to moderately dry, 5= Moderately dry, 6= Moderately dry to dry, 7= Dry, 8= Dry to very dry, 9= Very dry" []
+synonym: "RtFlsTxG_Et_1to9" EXACT []
+synonym: "TEXTBR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
+relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
+relationship: variable_of CO_331:0000916 ! flstxcg 9 pt. scale
+
+[Term]
+id: CO_331:0000266
+name: overall taste of cooked sample
+def: "Overall taste of cooked sample" []
+synonym: "RtFlsTs" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000269
+name: Overall taste of cooked sample estimating 1-9
+def: "Overall taste of cooked sample. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+synonym: "COOT" EXACT []
+synonym: "RtFlsTs_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000266 ! overall taste of cooked sample
+relationship: variable_of CO_331:0000917 ! evaluation of cooked samples for taste
+relationship: variable_of CO_331:0000918 ! rttst 9 pt. scale
+
+[Term]
+id: CO_331:0000270
+name: overall appearance of cooked sample
+def: "Appearance of cooked sample" []
+synonym: "RtFlsAp" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000273
+name: Overall appearance of cooked sample estimating 1-9
+def: "Appearance of cooked sample. 1= Very appealing, 2= Very appealing to appealing, 3= Appealing, 4= Appealing to somewhat appealing, 5= Somewhat appealing, 6= Somewhat appealing to unappealing, 7= Unappealing, 8= Unappealing to very unappealing, 9= Very unappealing" []
+synonym: "COOAP" EXACT []
+synonym: "RtFlsAp_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000270 ! overall appearance of cooked sample
+relationship: variable_of CO_331:0000919 ! evaluation of cooked samples for appearance
+relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
+
+[Term]
+id: CO_331:0000274
+name: sprouting ability
+def: "ability to produce new sprout" []
+synonym: "RtSpA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000277
+name: Sprouting ability estimating 1-9
+def: "ability to produce new sprout. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+synonym: "RSPR" EXACT []
+synonym: "RtSpA_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000274 ! sprouting ability
+relationship: variable_of CO_331:0000921 ! evaluation of roots for sprouting ability
+relationship: variable_of CO_331:0000922 ! rtsprt 9 pt. scale
+
+[Term]
+id: CO_331:0000278
+name: Protein content measuring percent
+def: "Protein content of the root" []
+synonym: "PRO, PROTEIN" EXACT []
+synonym: "RtFlsPrt_Ms_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000100 ! protein content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000923 ! protein content - method
+
+[Term]
+id: CO_331:0000279
+name: Content of iron on dry weight basis measuring mg per 100g
+def: "Content of iron on dry weight basis of the root" []
+synonym: "FeDW" EXACT []
+synonym: "RtFlsFe_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000103 ! iron content
+relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
+relationship: variable_of CO_331:0000925 ! mg/100g
+
+[Term]
+id: CO_331:0000280
+name: Content of zinc on dry weight basis measuring mg per 100g
+def: "Content of zinc on dry weight basis of the root" []
+synonym: "RtFlsZn_Ms_mg100gDW" EXACT []
+synonym: "ZnDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000106 ! zinc content
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0000927 ! content of zinc in dry weight basis - method
+
+[Term]
+id: CO_331:0000281
+name: calcium content
+def: "Content of calcium on dry weight basis of the root" []
+synonym: "RtFlsCa" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000284
+name: Content of calcium on dry weight basis measuringm g per 100g
+def: "Content of calcium on dry weight basis of the root" []
+synonym: "CaDW" EXACT []
+synonym: "RtFlsCa_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000281 ! calcium content
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
+
+[Term]
+id: CO_331:0000285
+name: magnesium content
+def: "Content of magnesium on dry weight basis of the root" []
+synonym: "RtFlsMg" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000288
+name: Content of magnesium on dry weight basis measuring mg per 100g
+def: "Content of magnesium on dry weight basis of the root" []
+synonym: "MgDW" EXACT []
+synonym: "RtFlsMg_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000285 ! magnesium content
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
+
+[Term]
+id: CO_331:0000289
+name: Beta carotene content measuring mg per 100g
+def: "Beta carotene content of the root" []
+synonym: "BCDW" EXACT []
+synonym: "RtFlsBC_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000109 ! beta-carotene content
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0000930 ! beta carotene content - method
+
+[Term]
+id: CO_331:0000290
+name: Total carotenoids measuring mg per 100g
+def: "Total carotenoids content of the root" []
+synonym: "RtFlsTC_Ms_mg100gDW" EXACT []
+synonym: "TCDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000112 ! total carotenoids
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0000931 ! total carotenoids - method
+
+[Term]
+id: CO_331:0000291
+name: Storage root starch content measuring percent
+def: "Storage root starch content evaluated in percentage dry weight" []
+synonym: "RtFlsSta_Ms_pct" EXACT []
+synonym: "STAR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000115 ! storage root starch content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000932 ! storage root starch content - method
+
+[Term]
+id: CO_331:0000292
+name: Fructose content measuring percent
+def: "Fructose content of the root" []
+synonym: "FRUC" EXACT []
+synonym: "RtFlsFru_Ms_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000118 ! fructose content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000933 ! fructose content - method
+
+[Term]
+id: CO_331:0000293
+name: Glucose content measuring percent
+def: "Glucose content of the root" []
+synonym: "GLUC" EXACT []
+synonym: "RtFlsGlu_Ms_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000121 ! glucose content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000934 ! glucose content - method
+
+[Term]
+id: CO_331:0000294
+name: Sucrose content measuring percent
+def: "Sucrose content of the root" []
+synonym: "RtFlsSuc_Ms_pct" EXACT []
+synonym: "SUCR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000124 ! sucrose content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000935 ! sucrose content - method
+
+[Term]
+id: CO_331:0000295
+name: Maltose content measuring percent
+def: "Maltose content of the root" []
+synonym: "MALT" EXACT []
+synonym: "RtFlsMal_Ms_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000127 ! maltose content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000936 ! maltose content - method
+
+[Term]
+id: CO_331:0000296
+name: Yield of total roots per hectar computing tons per ha
+def: "Yield evaluated in the harvest" []
+synonym: "RtYld_Cp_tha" EXACT []
+synonym: "RYTHA" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000082 ! yield of total roots
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0000937 ! estimated yield per hectare - method
+
+[Term]
+id: CO_331:0000297
+name: Storage root dry matter content computing percent
+def: "Storage root dry matter content" []
+synonym: "DM" EXACT []
+synonym: "RtDMC_Cp_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000142 ! storage root dry matter content
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000938 ! storage root dry matter content - method
+
+[Term]
+id: CO_331:0000298
+name: survival index
+def: "Survival index" []
+synonym: "IxSrv" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000301
+name: Survival index computing percent
+def: "Survival index" []
+synonym: "IxSrv_Cp_pct" EXACT []
+synonym: "SHI" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000298 ! survival index
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000939 ! survival index - method
+
+[Term]
+id: CO_331:0000302
+name: Harvest index computing percent
+def: "Harvest index" []
+synonym: "HI" EXACT []
+synonym: "IxHrv_Cp_pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000085 ! harvest index
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0000940 ! harvest index evaluation  - method
+
+[Term]
+id: CO_331:0000303
+name: number of plants planted
+def: "Number of plants planted" []
+synonym: "PltPld" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000304
+name: number of plants harvested
+def: "Number of plants harvested" []
+synonym: "PtHrv" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000307
+name: marketable root yield
+def: "Marketable root yield" []
+synonym: "RtCYld" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000308
+name: average commercial root weight
+def: "Average commercial root weight evaluated in the harvest" []
+synonym: "RtACRW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000309
+name: yield of total roots 2
+def: "Yield of total roots calculated after harvest" []
+synonym: "RtYPP" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000310
+name: percentage of marketable roots
+def: "Percentage of marketable roots after harvest" []
+synonym: "RtCI" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000311
+name: biomass yield
+def: "Biomass yield" []
+synonym: "BioYld" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000312
+name: foliage total yield
+def: "Foliage total yield" []
+synonym: "VnFolYld" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000326
+name: storage root surface defects
+def: "Storage Root Surface Defects" []
+synonym: "RtSDef" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000327
+name: storage root cortex thickness
+def: "Storage Root Cortex Thickness" []
+synonym: "RtCThk" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000328
+name: flowering habit
+def: "An behavior pattern of the plant to produce flowers" []
+synonym: "FrHab" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000329
+name: flower size
+def: "Flower size" []
+synonym: "FrSiz" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000330
+name: shape of limb
+def: "Shape of limb" []
+synonym: "FrShL" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000331
+name: equality of sepal length
+def: "Equality of sepal length" []
+synonym: "FrSepEql" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000332
+name: number of sepal veins
+def: "Number of veins observed in the sepals" []
+synonym: "FrSepNVn" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000333
+name: sepal shape
+def: "Sepal shape" []
+synonym: "FrSepShp" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000334
+name: sepal apex
+def: "Sepal apex" []
+synonym: "FrSepApx" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000335
+name: sepal pubescence
+def: "Degree of hairiness registered in the sepals" []
+synonym: "FrSepPub" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000336
+name: sepal color
+def: "Anthocyanin (purple) pigmentation present in the sepal" []
+synonym: "FrSepCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000337
+name: color of stigma
+def: "Color of stigma" []
+synonym: "FrStgCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000338
+name: color of style
+def: "Color of style" []
+synonym: "FrStyCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000339
+name: stigma exertion
+def: "The relative position of the stigma as compared to the highest anther." []
+synonym: "FrStgExt" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000340
+name: seed capsule set
+def: "Seed capsule set" []
+synonym: "FrSdCp" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000341
+name: storage root formation
+def: "Arrangement of the storage roots on the underground stems." []
+synonym: "RtFrm" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000342
+name: storage root stalk
+def: "Length of stalk joining the storage roots to the stems" []
+synonym: "RtStk" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000343
+name: variability of storage root shape
+def: "Variability of storage root shape" []
+synonym: "RtShV" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000344
+name: variability of storage root size
+def: "Variability of storage root size" []
+synonym: "RtSzV" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000345
+name: keeping quality of storage roots
+def: "Keeping quality of storage roots" []
+synonym: "RtKQl" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000346
+name: consistency of boiled storage root
+def: "Consistency of boiled storage root" []
+synonym: "RtBlCu" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000347
+name: undesirable color of boiled storage root
+def: "Undesirable color of boiled storage root" []
+synonym: "RtBlCd" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000348
+name: reaction to drought
+def: "Response to damage by water restriction." []
+synonym: "RnDrt" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000349
+name: reaction to flooding
+def: "Response of plant to inundation by water of all or part of the plant" []
+synonym: "RnFld" EXACT []
+synonym: "waterlogging response" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000350
+name: reaction to heat
+def: "Response of a plant or plant part to damage by higher than normal temperatures" []
+synonym: "RnHeat" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000351
+name: reaction to salinity
+def: "Response of a plant to damage by high concentration salt" []
+synonym: "RnSlt" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000352
+name: reaction to shade
+def: "Response of plant to damage by shade" []
+synonym: "RnShd" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000353
+name: reaction to soil
+def: "Response of plant to damage by ph soil" []
+synonym: "RnSph" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000354
+name: reaction to high soil temperature
+def: "Response of a plant to damage by high concentration salt" []
+synonym: "RnSTp" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000355
+name: reaction to west indian sweet potato weevil
+def: "Reaction to West Indian sweet potato weevil" []
+synonym: "RnWISPW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000356
+name: reaction to striped sweet potato weevil
+def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil" []
+synonym: "RnSSPW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000357
+name: reaction to sweet potato wire worms
+def: "Reaction to Sweet potato wire worms" []
+synonym: "RnSPWW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000358
+name: reaction to wire worms
+def: "Reaction to Wire worms" []
+synonym: "RnWW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000359
+name: reaction to sweet potato flea beetles
+def: "Reaction to Sweet potato flea beetles" []
+synonym: "RnSPFB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000360
+name: reaction to flea beetles
+def: "Reaction to flea beetles" []
+synonym: "RnFB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000361
+name: reaction to sweet potato leaf beetles
+def: "Reaction to Sweet potato leaf beetles" []
+synonym: "RnSPLB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000362
+name: reaction to beetles
+def: "Reaction to Beetles" []
+synonym: "RnBTL" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000363
+name: reaction to grubworm
+def: "The reaction of the root to damage caused by Grub worm" []
+synonym: "RnGrbW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000364
+name: reaction to hornworm
+def: "The reaction of the root to damage caused by Hornworm" []
+synonym: "RnHrnw" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000365
+name: reaction to aphids
+def: "The reaction of the plant or plant part to damage caused by Aphis" []
+synonym: "RnAph" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000366
+name: reaction to sweet potato white fly
+def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly" []
+synonym: "RnSPWF" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000367
+name: reaction to sweet potato moth
+def: "Reaction to Sweet potato moth" []
+synonym: "RnSPMth" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000368
+name: reaction to moth
+def: "Reaction to Moth" []
+synonym: "RnMth" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000369
+name: reaction to sweet potato stem borer
+def: "Reaction to Sweet potato stem borer" []
+synonym: "RnSPSB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000370
+name: reaction to other insects
+def: "Reaction to Other insects" []
+synonym: "RnIns" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000371
+name: reaction to reniform nematode
+def: "Reaction to Reniform nematode" []
+synonym: "RnRFN" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000372
+name: reaction to sting nematode
+def: "Reaction to Sting nematode" []
+synonym: "RnStN" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000373
+name: reaction to brown ring rot
+def: "Reaction to Brown ring rot" []
+synonym: "RnBRR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000374
+name: reaction to root lesion nematode
+def: "Reaction to Root lesion nematode" []
+synonym: "RnRLN" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000375
+name: reaction to other nematodes
+def: "Reaction to other nematodes" []
+synonym: "RnON" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000376
+name: reaction to wilt rot
+def: "Reaction to Wilt rot" []
+synonym: "RnWR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000377
+name: reaction to fusarium surface rot
+def: "Reaction to Fusarium surface rot" []
+synonym: "RnFRS" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000378
+name: reaction to fusarium root rot
+def: "Reaction to Fusarium root rot" []
+synonym: "RnFRR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000379
+name: reaction to sclerotial blight and circular spot
+def: "Reaction to Sclerotial blight and circular spot" []
+synonym: "RnSBC" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000380
+name: reaction to black rot
+def: "Reaction to Black rot" []
+synonym: "RnBR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000381
+name: reaction to scurf
+def: "Reaction to Scurf" []
+synonym: "RnScrf" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000382
+name: reaction to soft rot
+def: "Reaction to Soft rot" []
+synonym: "RnSR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000383
+name: reaction to java black rot
+def: "Reaction to Java black rot" []
+synonym: "RnJBR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000384
+name: reaction to diaporthe dry rot
+def: "Reaction to Diaporthe dry rot" []
+synonym: "RnDDR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000385
+name: reaction to scab
+def: "Reaction to Scab" []
+synonym: "RnScb" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000386
+name: reaction to leaf spot
+def: "Reaction to leaf spot" []
+synonym: "RnLS" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000387
+name: reaction to white rust
+def: "Reaction to White rust" []
+synonym: "RnWR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000388
+name: reaction to foot rot
+def: "Reaction to Foot rot" []
+synonym: "RnFR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000389
+name: reaction to charcoal rot
+def: "Reaction to Charcoal rot" []
+synonym: "RnCR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000390
+name: reaction to other fungi
+def: "Reaction to Other fungi" []
+synonym: "RnOF" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000391
+name: reaction to pox or soil rot
+def: "Reaction to Pox or soil rot" []
+synonym: "RnPSR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000392
+name: reaction to bacterial stem and root rot
+def: "Reaction to Bacterial stem and root rot" []
+synonym: "RnBSRt" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000393
+name: reaction to bacterial wilt
+def: "Reaction to Bacterial wilt" []
+synonym: "RnBW" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000394
+name: reaction to other bacteria
+def: "Reaction to Other bacteria" []
+synonym: "RnOB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000395
+name: reaction to sweet potato feathery mottle virus (spmv)
+def: "Reaction to Sweet potato feathery mottle virus (SPMV)" []
+synonym: "RnSPMV" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000396
+name: reaction to sweet potato mild mottle virus (spmmv)
+def: "Reaction to Sweet potato mild mottle virus (SPMMV)" []
+synonym: "RnSPMMV" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000397
+name: reaction to sweet potato vein mottle virus (spvmv)
+def: "Reaction to Sweet potato vein mottle virus (SPVMV)" []
+synonym: "RnSPVMV" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000398
+name: reaction to sweet potato virus disease complex (spvd complex)
+def: "Reaction to Sweet potato virus disease complex (SPVD complex)" []
+synonym: "RnSPVD" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000399
+name: reaction to other virus
+def: "Reaction to Other virus" []
+synonym: "RnOV" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000400
+name: reaction to witches broom
+def: "Reaction to Witches broom" []
+synonym: "RnWB" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000401
+name: reaction to other mycoplasma
+def: "Reaction to Other mycoplasma" []
+synonym: "RnOM" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000402
+name: total sugar content
+def: "Total sugar content" []
+synonym: "RtTSgC" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000403
+name: appearance of plant
+def: "Appearance of plant" []
+synonym: "PtHbt" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000404
+name: appearance of flower
+def: "Appearance of flower" []
+synonym: "FrCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000405
+name: appearance of roots
+def: "Appearance of roots" []
+synonym: "RtCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000406
+name: appearance of seeds
+def: "Appearance of seeds" []
+synonym: "FrSds" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000407
+name: appearance of leaves
+def: "Appearance of leaves" []
+synonym: "Lf" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000408
+name: appearance of hearbarium
+def: "Appearance of hearbarium" []
+synonym: "PtHrb" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: G. Rossel
+
+[Term]
+id: CO_331:0000409
+name: storage root shape uniformity
+def: "Storage Root Shape uniformity within a single plant or plot" []
+synonym: "RtShpU" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000410
+name: storage root stalk length
+def: "Length of stalk joining the storage roots to the stems" []
+synonym: "RtStlk" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000411
+name: storage root attachment
+def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off" []
+synonym: "RtAtt" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000412
+name: length to diameter ratio of roots
+def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
+synonym: "RtLDR" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000413
+name: skin color of roots
+def: "The most representative skin color observed is recorded" []
+synonym: "RtSknCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000414
+name: skin texture of roots
+def: "Storage root skin feel, appearance, or consistency by visual observation and touch" []
+synonym: "RtSknTxt" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000415
+name: flesh color (carotenoids)
+def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
+synonym: "RtFlsColC" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000416
+name: flesh color (anthocyanins)
+def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
+synonym: "RtFlsColA" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000417
+name: deep of eyes of roots
+def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface" []
+synonym: "RtAdvB" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000418
+name: number of lenticels
+def: "Overall assessment of visible lenticels at the storage root interface" []
+synonym: "RtLtcl" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000419
+name: reaction to streptomyces soil rot
+def: "Streptomyces ipomoeae symptom evaluation" []
+synonym: "RnPSR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000420
+name: reaction to root knot nematode meloidogyne spp
+def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation" []
+synonym: "RnMgRKN" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000421
+name: reaction to root knot nematode meloidogyne incognita
+def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation" []
+synonym: "RnMgIRKN" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: A.Gonzales
+
+[Term]
+id: CO_331:0000422
+name: reaction to fusarium oxysporum
+def: "Reaction to Fusarium oxysporum batatas symptom evaluation" []
+synonym: "RnFR" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000423
+name: storage root defects (primary)
+def: "Type and/or name of primary visible storage root defect" []
+synonym: "RtDam" EXACT []
+synonym: "RtDefP" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000424
+name: relative storage root yield
+def: "Overall visual assessment of storage root yield" []
+synonym: "RtYldR" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000425
+name: storage root yield relative to check
+def: "Overall calculation of relative root yield" []
+synonym: "RtYldChk" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000426
+name: storage root appearance
+def: "Overall visual assessment of storage root yield appearance" []
+synonym: "RtApr" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000427
+name: growing season
+def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season" []
+synonym: "PtMtSs" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000428
+name: amylose content
+def: "Amylose content in sweetpotato" []
+synonym: "RtFlsAmy" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000429
+name: asparagine content
+def: "peonidin content of purple flesh sweetpotato" []
+synonym: "RtFlsAsp" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000430
+name: cyanidin content
+def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
+synonym: "RtFlsCya" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000431
+name: total monomeric anthocyanin content
+def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
+synonym: "RtFlsAntM" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000432
+name: peonidin content
+def: "Peonidin content of purple flesh sweetpotato" []
+synonym: "RtFlsPeo" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000433
+name: anthocyanin content
+def: "Anthocyanin content of purple flesh sweetpotato" []
+synonym: "RtFlsAnt" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000434
+name: phenol content
+def: "Phenol content of purple flesh sweetpotato" []
+synonym: "RtFlsPhe" EXACT []
+is_a: CO_331:1000009 ! Biochemical_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000435
+name: nodes per vine
+def: "Nodes per vine" []
+synonym: "VnNds" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: D. Gemenet
+
+[Term]
+id: CO_331:0000436
+name: leaves per plant
+def: "Leaves per plant" []
+synonym: "PtLvs" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: D. Gemenet
+
+[Term]
+id: CO_331:0000437
+name: color of leave
+def: "Color of leave" []
+synonym: "LfCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: D. Gemenet
+
+[Term]
+id: CO_331:0000438
+name: millipede damage
+def: "Observation of damage caused by Millipede in roots" []
+synonym: "RtMillDam" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: T.Carey
+
+[Term]
+id: CO_331:0000439
+name: alcidodes sp. damage
+def: "Observation of damage caused by Alcidodes sp,  causes crown enlargement/galling or death by girdling" []
+synonym: "RtAlcDam" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: T.Carey
+
+[Term]
+id: CO_331:0000440
+name: soil insect damage
+def: "Observation of damage caused by soil insect" []
+synonym: "RtSInsDam" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: T.Carey
+
+[Term]
+id: CO_331:0000441
+name: storage root shape (secondary)
+def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots" []
+synonym: "RtShpS" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000600
+name: Overall storage root disease symptoms estimating 1-9
+def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
+synonym: "DISEASE" EXACT []
+synonym: "RtDSm_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
+created_by: C. Yencho
+creation_date: 2016-12-01T04:02:09Z
+
+[Term]
+id: CO_331:0000678
+name: Plants planted counting number per plot
+def: "Number of plants planted" []
+synonym: "NOPS" EXACT []
+synonym: "PltPld_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000303 ! number of plants planted
+relationship: variable_of CO_331:0000871 ! plants/plot
+relationship: variable_of CO_331:0000872 ! recording planting materials
+
+[Term]
+id: CO_331:0000679
+name: Plants harvested counting number per plot
+def: "Number of plants harvested" []
+synonym: "NOPH" EXACT []
+synonym: "PtHrv_Ct_plplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000304 ! number of plants harvested
+relationship: variable_of CO_331:0000871 ! plants/plot
+relationship: variable_of CO_331:0000885 ! evaluation of plants
+
+[Term]
+id: CO_331:0000680
+name: Storage root marketable yield weight computation tons per ha
+def: "Average commercial root weight evaluated in the harvest" []
+synonym: "ACRW" EXACT []
+synonym: "RtACRW_Cp_g" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000308 ! average commercial root weight
+relationship: variable_of CO_331:0000896 ! estimated marketable yield per hectare - method
+relationship: variable_of CO_331:0000897 ! t/ha
+
+[Term]
+id: CO_331:0000681
+name: Storage root total yield computation tons per ha
+def: "Yield of total roots calculated after harvest" []
+synonym: "RtYPP_Cp_kpl" EXACT []
+synonym: "YPP" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000309 ! yield of total roots 2
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0000898 ! estimated yield of total roots per hectare - method
+
+[Term]
+id: CO_331:0000682
+name: Storage root marketable yield fraction computation percent
+def: "Percentage of marketable roots after harvest" []
+synonym: "CI" EXACT []
+synonym: "RtCI_Cp_Pct" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000310 ! percentage of marketable roots
+relationship: variable_of CO_331:0000899 ! percentage of marketable - method
+relationship: variable_of CO_331:0000900 ! %
+
+[Term]
+id: CO_331:0000683
+name: Biomass yield weight computation tons per ha
+def: "Biomass yield" []
+synonym: "BIOM" EXACT []
+synonym: "BioYld_Cp" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000311 ! biomass yield
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
+
+[Term]
+id: CO_331:0000684
+name: Foliage total yield computation tons per hectare
+def: "Foliage total yield" []
+synonym: "FYTHA" EXACT []
+synonym: "VnFolYld_Cp_tha" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000312 ! foliage total yield
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
+
+[Term]
+id: CO_331:0000685
+name: Content of iron on dry weight basis measuring mg per kg
+def: "Content of iron on dry weight basis of the root" []
+synonym: "FeDW" EXACT []
+synonym: "RtFlsFe_Ms_mgkgDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000103 ! iron content
+relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
+relationship: variable_of CO_331:0000926 ! mg/kg
+
+[Term]
+id: CO_331:0000686
+name: Content of zinc on dry weight basis measuring mg per kg
+def: "Content of iron on dry weight basis of the root" []
+synonym: "FeDW" EXACT []
+synonym: "RtFlsZn_Ms_mgkgDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000106 ! zinc content
+relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
+relationship: variable_of CO_331:0000926 ! mg/kg
+
+[Term]
+id: CO_331:0000687
+name: Content of calcium on dry weight basis measuring mg per kg
+def: "Content of iron on dry weight basis of the root" []
+synonym: "CaDW" EXACT []
+synonym: "RtFlsCa_Ms_mgkgDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000281 ! calcium content
+relationship: variable_of CO_331:0000926 ! mg/kg
+relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
+
+[Term]
+id: CO_331:0000688
+name: Content of magnesium on dry weight basis measuring mg per kg
+def: "Content of magnesium on dry weight basis of the root" []
+synonym: "MgDW" EXACT []
+synonym: "RtFlsMg_Ms_mgkgDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000285 ! magnesium content
+relationship: variable_of CO_331:0000926 ! mg/kg
+relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
+
+[Term]
+id: CO_331:0000689
+name: Color of boiled roots estimating 0-3
+def: "Color of boiled roots. O = Orange, IO = Intermediate orange, DO = Deep orange" []
+synonym: "COLBR" EXACT []
+synonym: "RtCb_Et_0to3" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000133 ! color of boiled roots
+relationship: variable_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
+relationship: variable_of CO_331:0000942 ! rtscb 3 pt. scale
+
+[Term]
+id: CO_331:0000690
+name: Storage Root Surface Defects estimating 1-9
+def: "Storage Root Surface Defects. 0 = Absent, 1 = Alligator-like skin, 2 = Veins, 3 = Shallow horizontal constrictions, 4 = Deep horizontal constrictions, 5 =Shallow longitudinal grooves, 6 = Deep longitudinal grooves, 7 = Deep constrictions and deep grooves, 8 = Other" []
+synonym: "RtSDef_Et_1to9" EXACT []
+synonym: "RTSUR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000326 ! storage root surface defects
+relationship: variable_of CO_331:0000943 ! observation of storage root surface defects
+relationship: variable_of CO_331:0000944 ! rtssdef 9 pt. scale
+
+[Term]
+id: CO_331:0000691
+name: Storage Root Cortex Thickness estimating 1-9
+def: "Storage Root Cortex Thickness. 1 = Very thin (1 mm), 3 = Thin (1-2 mm), 5 = Intermediate (2-3 mm), 7 = Thick (3-4 mm), 9 = Very thick (>4 mm)" []
+synonym: "RTCOR" EXACT []
+synonym: "RtCThk_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000327 ! storage root cortex thickness
+relationship: variable_of CO_331:0000945 ! observation of storage root cortex thickness
+relationship: variable_of CO_331:0000946 ! rtscthi 5 pt. scale
+
+[Term]
+id: CO_331:0000692
+name: Flowering habit estimating 0-7
+def: "An behavior pattern of the plant to produce flowers. 0 = None, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
+synonym: "FLWHAB" EXACT []
+synonym: "FrHab_Et_0to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000328 ! flowering habit
+relationship: variable_of CO_331:0000947 ! observation of number flowers in the inflorescence
+relationship: variable_of CO_331:0000948 ! flrhab 4 pt. scale
+
+[Term]
+id: CO_331:0000693
+name: Flower size measuring cm
+def: "Flower size" []
+synonym: "FLESIZ" EXACT []
+synonym: "FrSiz_Ms_cm" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000329 ! flower size
+relationship: variable_of CO_331:0000949 ! measurement of flower length and width in cm
+relationship: variable_of CO_331:0000950 ! cm
+
+[Term]
+id: CO_331:0000694
+name: Shape of limb estimating 3-7
+def: "Shape of limb. 3 = Semi-stellate, 5= Pentagonal, 7 = Rounded" []
+synonym: "FLLMB" EXACT []
+synonym: "FrShL_Et_3to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000330 ! shape of limb
+relationship: variable_of CO_331:0000951 ! observation of shape limb in the flowers in the inflorescence
+relationship: variable_of CO_331:0000952 ! flrshl 3 pt. scale
+
+[Term]
+id: CO_331:0000695
+name: Equality of sepal length estimating 1-2
+def: "Equality of sepal length. 1 = Outer two shorter, 2 = Equal" []
+synonym: "FrSepEql_Et_1to2" EXACT []
+synonym: "SEPLEQ" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000331 ! equality of sepal length
+relationship: variable_of CO_331:0000953 ! equality of sepal length
+relationship: variable_of CO_331:0000954 ! sepeql 2 pt. scale
+
+[Term]
+id: CO_331:0000696
+name: Sepal veins counting number
+def: "Number of veins observed in the sepals" []
+synonym: "FrSepNVn_Ct_perSpl" EXACT []
+synonym: "SEPVNM" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000332 ! number of sepal veins
+relationship: variable_of CO_331:0000955 ! record the most frequent number in ten typical flowers
+relationship: variable_of CO_331:0000956 ! number
+
+[Term]
+id: CO_331:0000697
+name: Sepal shape estimating 1-9
+def: "Sepal shape. 1 = Ovate, 3 = Elliptic, 5 = Obovate, 7 = Oblong, 9 = Lanceolate" []
+synonym: "FrSepShp_Et_1to9" EXACT []
+synonym: "SEPSHP" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000333 ! sepal shape
+relationship: variable_of CO_331:0000957 ! observation of  sepal shape
+relationship: variable_of CO_331:0000958 ! sepshp 5 pt. scale
+
+[Term]
+id: CO_331:0000698
+name: Sepal apex estimating 1-7
+def: "Sepal apex. 1 = Acute, 3 = Obtuse, 5 = Acuminate, 7 = Caudate" []
+synonym: "FrSepApx_Et_1to7" EXACT []
+synonym: "SEPAPX" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000334 ! sepal apex
+relationship: variable_of CO_331:0000959 ! observation of sepal apex
+relationship: variable_of CO_331:0000960 ! sepapx 4 pt. scale
+
+[Term]
+id: CO_331:0000699
+name: Sepal pubescence estimating 0-7
+def: "Degree of hairiness registered in the sepals. 0 = Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
+synonym: "FrSepPub_Et_0to7" EXACT []
+synonym: "SEPPUB" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000335 ! sepal pubescence
+relationship: variable_of CO_331:0000961 ! observation of sepal pubescence
+relationship: variable_of CO_331:0000962 ! seppub 4 pt. scale
+
+[Term]
+id: CO_331:0000700
+name: Sepal color estimating 1-9
+def: "Anthocyanin (purple) pigmentation present in the sepal. 1 = Green, 2 = Green with purple edge, 3 = Green with purple spots, 5 = Green with purple areas, 6 = Sorne sepals green, others purple, 9 = Totally pigrnented - dark purple" []
+synonym: "FrSepCol_Et_3to7" EXACT []
+synonym: "SEPCOL" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000336 ! sepal color
+relationship: variable_of CO_331:0000963 ! observation of sepal color
+relationship: variable_of CO_331:0000964 ! sepcol 7 pt. scale
+
+[Term]
+id: CO_331:0000701
+name: Color of stigma estimating 1-9
+def: "Color of stigma. 1 = White, 5 = Pale purple, 9 = Purple" []
+synonym: "FrStgCol_Et_1to9" EXACT []
+synonym: "STGCOL" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000337 ! color of stigma
+relationship: variable_of CO_331:0000965 ! observation of stigma color
+relationship: variable_of CO_331:0000966 ! stgcol 3 pt. scale
+
+[Term]
+id: CO_331:0000702
+name: Color of style estimating 1-9
+def: "Color of style. 1 = White, 3 = White with purple at the base, 5 = White with purple at the top, 7 = White with purple spots throughout, 9 = Purple" []
+synonym: "FrStyCol_Et_1to9" EXACT []
+synonym: "STYCOL" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000338 ! color of style
+relationship: variable_of CO_331:0000967 ! observation of style color
+relationship: variable_of CO_331:0000968 ! stycol 5 pt. scale
+
+[Term]
+id: CO_331:0000703
+name: Stigma exertion estimating 1-7
+def: "The relative position of the stigma as compared to the highest anther.. 1 = Inserted (shorter than longest anther), 3 = Same height as highest anther, 5 = Slighty exerted, 7 = Exerted (longer than longest anther)" []
+synonym: "FrStgExt_Et_1to7" EXACT []
+synonym: "STGEXT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000339 ! stigma exertion
+relationship: variable_of CO_331:0000969 ! observation of stigma exertion
+relationship: variable_of CO_331:0000970 ! stgext 4 pt. scale
+
+[Term]
+id: CO_331:0000704
+name: Seed capsule set estimating 0-7
+def: "Seed capsule set. 0 = None, 1 = Scarce, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
+synonym: "FrSdCp_Et_0to7" EXACT []
+synonym: "SEDCAP" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000340 ! seed capsule set
+relationship: variable_of CO_331:0000971 ! observation of seed capsule set
+relationship: variable_of CO_331:0000972 ! sedcap 5 pt. scale
+
+[Term]
+id: CO_331:0000705
+name: Storage root formation estimating 1-7
+def: "Arrangement of the storage roots on the underground stems.. 1 = Closed cluster, 3 = Open cluster, 5 = Dispersed, 7 = Very dispersed" []
+synonym: "RTFORM" EXACT []
+synonym: "RtFrm_Et_1to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000341 ! storage root formation
+relationship: variable_of CO_331:0000973 ! observation of storage root formation
+relationship: variable_of CO_331:0000974 ! strfor 4 pt. scale
+
+[Term]
+id: CO_331:0000706
+name: Storage root stalk estimating 0-7
+def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
+synonym: "RTSTFM" EXACT []
+synonym: "RtStk_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000342 ! storage root stalk
+relationship: variable_of CO_331:0000975 ! observation of storage root stalk
+relationship: variable_of CO_331:0000976 ! strstk 6 pt. scale
+
+[Term]
+id: CO_331:0000707
+name: Variability of storage root shape estimating 3-7
+def: "Variability of storage root shape. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
+synonym: "RTSHPV" EXACT []
+synonym: "RtShV_Et_3to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000343 ! variability of storage root shape
+relationship: variable_of CO_331:0000977 ! observation of variability of storage root shape
+relationship: variable_of CO_331:0000978 ! vrtssh 3 pt. scale
+
+[Term]
+id: CO_331:0000708
+name: Variability of storage root size estimating 3-7
+def: "Variability of storage root size. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
+synonym: "RTSIZV" EXACT []
+synonym: "RtSzV_Et_3to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000344 ! variability of storage root size
+relationship: variable_of CO_331:0000979 ! observation of variability of storage root size
+relationship: variable_of CO_331:0000980 ! vrtssiz 3 pt. scale
+
+[Term]
+id: CO_331:0000709
+name: Keeping quality of storage roots estimating 3-7
+def: "Keeping quality of storage roots. 3 = Poor, 5 = Medium, 7 = Good" []
+synonym: "RTKQL" EXACT []
+synonym: "RtKQl_Et_3to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000345 ! keeping quality of storage roots
+relationship: variable_of CO_331:0000981 ! observation of keeping quality of storage roots
+relationship: variable_of CO_331:0000982 ! kqtyrts 3 pt. scale
+
+[Term]
+id: CO_331:0000710
+name: Consistency of boiled storage root estimating 1-9
+def: "Consistency of boiled storage root. 1 = Watery, 2 = Extremely soft, 3 = Very soft, 4 = Soft, 5 = Slighty hard, 6 = Moderately hard, 7 = Hard, 8 = Very hard, 9 = Very hard and non-cooked" []
+synonym: "RTBCOLD" EXACT []
+synonym: "RtBlCu_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000346 ! consistency of boiled storage root
+relationship: variable_of CO_331:0000983 ! observation of consistency of boiled storage root
+relationship: variable_of CO_331:0000984 ! cbolrts 9 pt. scale
+
+[Term]
+id: CO_331:0000711
+name: Undesirable color of boiled storage root estimating 0-9
+def: "Undesirable color of boiled storage root. 0 = None, 1 = Sorne beige, 2 = Much beige, 3 = Slighty green or grey, 4 = Green, 5 = Grey, 6 = Beige and green, 7 = Beige and grey, 8 = Beige and purple, 9 = Purple" []
+synonym: "RTBCOLU" EXACT []
+synonym: "RtBlCd_Et_0to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000347 ! undesirable color of boiled storage root
+relationship: variable_of CO_331:0000985 ! observation of undesirable color of boiled storage root
+relationship: variable_of CO_331:0000986 ! ucolbrts 10 pt. scale
+
+[Term]
+id: CO_331:0000712
+name: Reaction to drought estimating 1-9
+def: "Response to damage by water restriction.. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "DROUGHT" EXACT []
+synonym: "RnDrt_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000348 ! reaction to drought
+relationship: variable_of CO_331:0000987 ! visual estimation of the plant response to  limited water availability
+relationship: variable_of CO_331:0000988 ! rctdro 5 pt. scale
+
+[Term]
+id: CO_331:0000713
+name: Reaction to flooding estimating 1-9
+def: "Response of plant to inundation by water of all or part of the plant. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FLOOD" EXACT []
+synonym: "RnFld_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000349 ! reaction to flooding
+relationship: variable_of CO_331:0000989 ! visual estimation of the plant response to  flooding (watering saturated soil)
+relationship: variable_of CO_331:0000990 ! rctflo 5 pt. scale
+
+[Term]
+id: CO_331:0000714
+name: Reaction to heat estimating 1-9
+def: "Response of a plant or plant part to damage by higher than normal temperatures. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "HEAT" EXACT []
+synonym: "RnHeat_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000350 ! reaction to heat
+relationship: variable_of CO_331:0000991 ! visual estimation of the plant response to  hot season with night temperatures of more than 22°c
+relationship: variable_of CO_331:0000992 ! rctheat 5 pt. scale
+
+[Term]
+id: CO_331:0000715
+name: Reaction to salinity estimating 1-9
+def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSlt_Et_1to9" EXACT []
+synonym: "SALINITY" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000351 ! reaction to salinity
+relationship: variable_of CO_331:0000993 ! visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
+relationship: variable_of CO_331:0000994 ! rctsty 5 pt. scale
+
+[Term]
+id: CO_331:0000716
+name: Reaction to shade estimating 1-9
+def: "Response of plant to damage by shade. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnShd_Et_1to9" EXACT []
+synonym: "SHADE" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000352 ! reaction to shade
+relationship: variable_of CO_331:0000995 ! visual estimation of the plant response to  shape
+relationship: variable_of CO_331:0000996 ! rctshd 5 pt. scale
+
+[Term]
+id: CO_331:0000717
+name: Reaction to soil pH estimating 1-9
+def: "Response of plant to damage by ph soil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSph_Et_1to9" EXACT []
+synonym: "SOILPH" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000353 ! reaction to soil
+relationship: variable_of CO_331:0000997 ! visual estimation of the plant response to  acid and heavy ph soil below 5
+relationship: variable_of CO_331:0000998 ! rctsph 5 pt. scale
+
+[Term]
+id: CO_331:0000718
+name: Reaction to high soil temperature estimating 1-9
+def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSTp_Et_1to9" EXACT []
+synonym: "SOILTEMP" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001000 ! rctstp 5 pt. scale
+relationship: variable_of CO_331:0000354 ! reaction to high soil temperature
+relationship: variable_of CO_331:0000999 ! visual estimation of the plant response to  hight soil temperature (40 °c)
+
+[Term]
+id: CO_331:0000719
+name: Reaction to West Indian sweet potato weevil estimating 1-9
+def: "Reaction to West Indian sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnWISPW_Et_1to9" EXACT []
+synonym: "WISPWV" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001001 ! visual estimation of the plant response to  west indian sweet potato weevil
+relationship: variable_of CO_331:00001002 ! rcwispw 5 pt. scale
+relationship: variable_of CO_331:0000355 ! reaction to west indian sweet potato weevil
+
+[Term]
+id: CO_331:0000720
+name: Reaction to Striped sweet potato weevil estimating 1-9
+def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSSPW_Et_1to9" EXACT []
+synonym: "STSPWV" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001003 ! visual estimation of the plant response to  striped sweet potato weevil
+relationship: variable_of CO_331:00001004 ! rcsspw 5 pt. scale
+relationship: variable_of CO_331:0000356 ! reaction to striped sweet potato weevil
+
+[Term]
+id: CO_331:0000721
+name: Reaction to Sweet potato wire worms estimating 1-9
+def: "Reaction to Sweet potato wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPWW_Et_1to9" EXACT []
+synonym: "SPWW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001005 ! visual estimation of the plant response to  sweet potato wire worms
+relationship: variable_of CO_331:00001006 ! rcspww 5 pt. scale
+relationship: variable_of CO_331:0000357 ! reaction to sweet potato wire worms
+
+[Term]
+id: CO_331:0000722
+name: Reaction to Wire worms estimating 1-9
+def: "Reaction to Wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnWW_Et_1to9" EXACT []
+synonym: "WIREWORMS" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001007 ! visual estimation of the plant response to  wire worms
+relationship: variable_of CO_331:00001008 ! rcww 5 pt. scale
+relationship: variable_of CO_331:0000358 ! reaction to wire worms
+
+[Term]
+id: CO_331:0000723
+name: Reaction to Sweet potato flea beetles estimating 1-9
+def: "Reaction to Sweet potato flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPFB_Et_1to9" EXACT []
+synonym: "SPFB" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001009 ! visual estimation of the plant response to  sweet potato flea beetles
+relationship: variable_of CO_331:00001010 ! rcspfb 5 pt. scale
+relationship: variable_of CO_331:0000359 ! reaction to sweet potato flea beetles
+
+[Term]
+id: CO_331:0000724
+name: Reaction to flea beetles estimating 1-9
+def: "Reaction to flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FLEABEETLE" EXACT []
+synonym: "RnFB_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001011 ! visual estimation of the plant response to  flea beetles
+relationship: variable_of CO_331:00001012 ! rcfb 5 pt. scale
+relationship: variable_of CO_331:0000360 ! reaction to flea beetles
+
+[Term]
+id: CO_331:0000725
+name: Reaction to Sweet potato leaf beetles estimating 1-9
+def: "Reaction to Sweet potato leaf beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPLB_Et_1to9" EXACT []
+synonym: "SPFB" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001013 ! visual estimation of the plant response to  sweet potato leaf beetles
+relationship: variable_of CO_331:00001014 ! rcsplb 5 pt. scale
+relationship: variable_of CO_331:0000361 ! reaction to sweet potato leaf beetles
+
+[Term]
+id: CO_331:0000726
+name: Reaction to Beetles estimating 1-9
+def: "Reaction to Beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BEETLES" EXACT []
+synonym: "RnBTL_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001015 ! visual estimation of the plant response to  beetles
+relationship: variable_of CO_331:00001016 ! rcbtl 5 pt. scale
+relationship: variable_of CO_331:0000362 ! reaction to beetles
+
+[Term]
+id: CO_331:0000727
+name: Reaction to Grubworm estimating 1-9
+def: "The reaction of the root to damage caused by Grub worm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "GRUBW" EXACT []
+synonym: "RnGrbW_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001017 ! visual estimation of the root response to  grub worm
+relationship: variable_of CO_331:00001018 ! rcgrbw 5 pt. scale
+relationship: variable_of CO_331:0000363 ! reaction to grubworm
+
+[Term]
+id: CO_331:0000728
+name: Reaction to Hornworm estimating 1-9
+def: "The reaction of the root to damage caused by Hornworm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "HORNW" EXACT []
+synonym: "RnHrnw_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001019 ! visual estimation of the root response to  hornworm
+relationship: variable_of CO_331:00001020 ! rchrnw 5 pt. scale
+relationship: variable_of CO_331:0000364 ! reaction to hornworm
+
+[Term]
+id: CO_331:0000729
+name: Reaction to Aphids estimating 1-9
+def: "The reaction of the plant or plant part to damage caused by Aphis. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "APHIDS" EXACT []
+synonym: "RnAph_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001021 ! visual estimation of the plant response to  aphis
+relationship: variable_of CO_331:00001022 ! rcaph 5 pt. scale
+relationship: variable_of CO_331:0000365 ! reaction to aphids
+
+[Term]
+id: CO_331:0000730
+name: Reaction to Sweet potato white fly estimating 1-9
+def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPWF_Et_1to9" EXACT []
+synonym: "SPWF" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001023 ! visual estimation of the plant response to  sweet potato white fly
+relationship: variable_of CO_331:00001024 ! rcspwf 5 pt. scale
+relationship: variable_of CO_331:0000366 ! reaction to sweet potato white fly
+
+[Term]
+id: CO_331:0000731
+name: Reaction to Sweet potato moth estimating 1-9
+def: "Reaction to Sweet potato moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPMth_Et_1to9" EXACT []
+synonym: "SPMOTH" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001025 ! visual estimation of the plant response to  sweet potato moth
+relationship: variable_of CO_331:00001026 ! rcspmth 5 pt. scale
+relationship: variable_of CO_331:0000367 ! reaction to sweet potato moth
+
+[Term]
+id: CO_331:0000732
+name: Reaction to Moth estimating 1-9
+def: "Reaction to Moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "MOTH" EXACT []
+synonym: "RnMth_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001027 ! visual estimation of the plant response to  moth
+relationship: variable_of CO_331:00001028 ! rcmth 5 pt. scale
+relationship: variable_of CO_331:0000368 ! reaction to moth
+
+[Term]
+id: CO_331:0000733
+name: Reaction to Sweet potato stem borer estimating 1-9
+def: "Reaction to Sweet potato stem borer. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPSB_Et_1to9" EXACT []
+synonym: "SPSB" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001029 ! visual estimation of the plant response to  sweet potato stem borer
+relationship: variable_of CO_331:00001030 ! rcspsb 5 pt. scale
+relationship: variable_of CO_331:0000369 ! reaction to sweet potato stem borer
+
+[Term]
+id: CO_331:0000734
+name: Reaction to Other insects estimating 1-9
+def: "Reaction to Other insects. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "INSECTS" EXACT []
+synonym: "RnIns_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001031 ! visual estimation of the plant response to  other insects
+relationship: variable_of CO_331:00001032 ! rcins 5 pt. scale
+relationship: variable_of CO_331:0000370 ! reaction to other insects
+
+[Term]
+id: CO_331:0000735
+name: Reaction to Reniform nematode estimating 1-9
+def: "Reaction to Reniform nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RENIN" EXACT []
+synonym: "RnRFN_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001033 ! visual estimation of the root response to  reniform nematode
+relationship: variable_of CO_331:00001034 ! rcrfn 5 pt. scale
+relationship: variable_of CO_331:0000371 ! reaction to reniform nematode
+
+[Term]
+id: CO_331:0000736
+name: Reaction to Sting nematode estimating 1-9
+def: "Reaction to Sting nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnStN_Et_1to9" EXACT []
+synonym: "STINGN" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001035 ! visual estimation of the root response to  sting nematode
+relationship: variable_of CO_331:00001036 ! rcstn 5 pt. scale
+relationship: variable_of CO_331:0000372 ! reaction to sting nematode
+
+[Term]
+id: CO_331:0000737
+name: Reaction to Brown ring rot estimating 1-9
+def: "Reaction to Brown ring rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BRROT" EXACT []
+synonym: "RnBRR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001037 ! visual estimation of the root response to  brown ring rot
+relationship: variable_of CO_331:00001038 ! rcbrr 5 pt. scale
+relationship: variable_of CO_331:0000373 ! reaction to brown ring rot
+
+[Term]
+id: CO_331:0000738
+name: Reaction to Root lesion nematode estimating 1-9
+def: "Reaction to Root lesion nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnRLN_Et_1to9" EXACT []
+synonym: "ROOTLN" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
+relationship: variable_of CO_331:00001040 ! rcrln 5 pt. scale
+relationship: variable_of CO_331:0000374 ! reaction to root lesion nematode
+
+[Term]
+id: CO_331:0000739
+name: Reaction to other nematodes estimating 1-9
+def: "Reaction to other nematodes. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "NEMATODS" EXACT []
+synonym: "RnON_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
+relationship: variable_of CO_331:00001041 ! rcon 5 pt. scale
+relationship: variable_of CO_331:0000375 ! reaction to other nematodes
+
+[Term]
+id: CO_331:0000740
+name: Reaction to Wilt rot estimating 1-9
+def: "Reaction to Wilt rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnWR_Et_1to9" EXACT []
+synonym: "WILT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001042 ! visual estimation of the root response to  wilt rot
+relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
+relationship: variable_of CO_331:0000376 ! reaction to wilt rot
+
+[Term]
+id: CO_331:0000741
+name: Reaction to Fusarium surface rot estimating 1-9
+def: "Reaction to Fusarium surface rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FUSSURF" EXACT []
+synonym: "RnFRS_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001044 ! visual estimation of the root response to  fusarium surface rot
+relationship: variable_of CO_331:00001045 ! rcfrs 5 pt. scale
+relationship: variable_of CO_331:0000377 ! reaction to fusarium surface rot
+
+[Term]
+id: CO_331:0000742
+name: Reaction to Fusarium root rot estimating 1-9
+def: "Reaction to Fusarium root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FUSROOT" EXACT []
+synonym: "RnFRR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001046 ! visual estimation of the root response to  fusarium root rot
+relationship: variable_of CO_331:00001047 ! rcfrr 5 pt. scale
+relationship: variable_of CO_331:0000378 ! reaction to fusarium root rot
+
+[Term]
+id: CO_331:0000743
+name: Reaction to Sclerotial blight and circular spot estimating 1-9
+def: "Reaction to Sclerotial blight and circular spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSBC_Et_1to9" EXACT []
+synonym: "SCLBLT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001048 ! visual estimation of the root response to  sclerotial blight and circular spot
+relationship: variable_of CO_331:00001049 ! rcsbc 5 pt. scale
+relationship: variable_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
+
+[Term]
+id: CO_331:0000744
+name: Reaction to Black rot estimating 1-9
+def: "Reaction to Black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BLACKROT" EXACT []
+synonym: "RnBR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001050 ! visual estimation of the root response to  black rot
+relationship: variable_of CO_331:00001051 ! rcbr 5 pt. scale
+relationship: variable_of CO_331:0000380 ! reaction to black rot
+
+[Term]
+id: CO_331:0000745
+name: Reaction to Scurf estimating 1-9
+def: "Reaction to Scurf. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnScrf_Et_1to9" EXACT []
+synonym: "SCURF" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001052 ! visual estimation of the root response to  scurf
+relationship: variable_of CO_331:00001053 ! rcscrf 5 pt. scale
+relationship: variable_of CO_331:0000381 ! reaction to scurf
+
+[Term]
+id: CO_331:0000746
+name: Reaction to Soft rot estimating 1-9
+def: "Reaction to Soft rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSR_Et_1to9" EXACT []
+synonym: "SOFTROT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001054 ! appearance of roots in response soft rot
+relationship: variable_of CO_331:00001055 ! rcsr 5 pt. scale
+relationship: variable_of CO_331:0000382 ! reaction to soft rot
+
+[Term]
+id: CO_331:0000747
+name: Reaction to Java black rot estimating 1-9
+def: "Reaction to Java black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "JAVABR" EXACT []
+synonym: "RnJBR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001056 ! appearance of roots in response java black rot
+relationship: variable_of CO_331:00001057 ! rcjbr 5 pt. scale
+relationship: variable_of CO_331:0000383 ! reaction to java black rot
+
+[Term]
+id: CO_331:0000748
+name: Reaction to Diaporthe dry rot estimating 1-9
+def: "Reaction to Diaporthe dry rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "DIAPORTHE" EXACT []
+synonym: "RnDDR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
+relationship: variable_of CO_331:00001059 ! rcddr 5 pt. scale
+relationship: variable_of CO_331:0000384 ! reaction to diaporthe dry rot
+
+[Term]
+id: CO_331:0000749
+name: Reaction to Scab estimating 1-9
+def: "Reaction to Scab. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnScb_Et_1to9" EXACT []
+synonym: "SCAB" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001060 ! visual estimation of the plant response to  scab
+relationship: variable_of CO_331:00001061 ! rcscb 5 pt. scale
+relationship: variable_of CO_331:0000385 ! reaction to scab
+
+[Term]
+id: CO_331:0000750
+name: Reaction to leaf spot estimating 1-9
+def: "Reaction to leaf spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "LEAFSPOT" EXACT []
+synonym: "RnLS_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001062 ! visual estimation of the plant response to  leaf spot
+relationship: variable_of CO_331:00001063 ! rcls 5 pt. scale
+relationship: variable_of CO_331:0000386 ! reaction to leaf spot
+
+[Term]
+id: CO_331:0000751
+name: Reaction to White rust estimating 1-9
+def: "Reaction to White rust. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnWR_Et_1to9" EXACT []
+synonym: "WHITERUST" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
+relationship: variable_of CO_331:00001064 ! visual estimation of the plant response to  white rust
+relationship: variable_of CO_331:0000387 ! reaction to white rust
+
+[Term]
+id: CO_331:0000752
+name: Reaction to Foot rot estimating 1-9
+def: "Reaction to Foot rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FOOTROT" EXACT []
+synonym: "RnFR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001065 ! visual estimation of the plant response to  foot rot
+relationship: variable_of CO_331:00001066 ! rcfr 5 pt. scale
+relationship: variable_of CO_331:0000388 ! reaction to foot rot
+
+[Term]
+id: CO_331:0000753
+name: Reaction to Charcoal rot estimating 1-9
+def: "Reaction to Charcoal rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "CHARCROT" EXACT []
+synonym: "RnCR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001067 ! visual estimation of the plant response to  charcoal rot
+relationship: variable_of CO_331:00001068 ! rccr 5 pt. scale
+relationship: variable_of CO_331:0000389 ! reaction to charcoal rot
+
+[Term]
+id: CO_331:0000754
+name: Reaction to Other fungi estimating 1-9
+def: "Reaction to Other fungi. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "FUNGI" EXACT []
+synonym: "RnOF_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001069 ! visual estimation of the plant response to  other fungi
+relationship: variable_of CO_331:00001070 ! rcof 5 pt. scale
+relationship: variable_of CO_331:0000390 ! reaction to other fungi
+
+[Term]
+id: CO_331:0000755
+name: Reaction to Pox or soil rot estimating 1-9
+def: "Reaction to Pox or soil rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "POXROT" EXACT []
+synonym: "RnPSR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001071 ! visual estimation of the plant response to  pox or soil rot
+relationship: variable_of CO_331:00001072 ! rcpsr 5 pt. scale
+relationship: variable_of CO_331:0000391 ! reaction to pox or soil rot
+
+[Term]
+id: CO_331:0000756
+name: Reaction to Bacterial stem and root rot estimating 1-9
+def: "Reaction to Bacterial stem and root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnBSRt_Et_1to9" EXACT []
+synonym: "STEMROT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001073 ! visual estimation of the plant response to  bacterial stem and root rot
+relationship: variable_of CO_331:00001074 ! rcbsrt 5 pt. scale
+relationship: variable_of CO_331:0000392 ! reaction to bacterial stem and root rot
+
+[Term]
+id: CO_331:0000757
+name: Reaction to Bacterial wilt estimating 1-9
+def: "Reaction to Bacterial wilt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BACWILT" EXACT []
+synonym: "RnBW_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001075 ! visual estimation of the plant response to  bacterial wilt
+relationship: variable_of CO_331:00001076 ! rcbw 5 pt. scale
+relationship: variable_of CO_331:0000393 ! reaction to bacterial wilt
+
+[Term]
+id: CO_331:0000758
+name: Reaction to Other bacteria estimating 1-9
+def: "Reaction to Other bacteria. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BACTERIA" EXACT []
+synonym: "RnOB_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001077 ! visual estimation of the plant response to  other bacteria
+relationship: variable_of CO_331:00001078 ! rcob 5 pt. scale
+relationship: variable_of CO_331:0000394 ! reaction to other bacteria
+
+[Term]
+id: CO_331:0000759
+name: Reaction to Sweet potato feathery mottle virus (SPMV)
+def: "Reaction to Sweet potato feathery mottle virus (SPMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPMV_Et_1to9" EXACT []
+synonym: "SPMV" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001079 ! visual estimation of the plant response to  sweet potato feathery mottle virus
+relationship: variable_of CO_331:00001080 ! rcspmv 5 pt. scale
+relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus (spmv)
+
+[Term]
+id: CO_331:0000760
+name: Reaction to Sweet potato mild mottle virus (SPMMV) estimating 1-9
+def: "Reaction to Sweet potato mild mottle virus (SPMMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPMMV_Et_1to9" EXACT []
+synonym: "SPMMV" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001081 ! visual estimation of the plant response to  sweet potato mild mottle virus
+relationship: variable_of CO_331:00001082 ! rcspmmv 5 pt. scale
+relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle virus (spmmv)
+
+[Term]
+id: CO_331:0000761
+name: Reaction to Sweet potato vein mottle virus (SPVMV) estimating 1-9
+def: "Reaction to Sweet potato vein mottle virus (SPVMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPVMV_Et_1to9" EXACT []
+synonym: "SPVMV" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001083 ! visual estimation of the plant response to  sweet potato vein mottle virus
+relationship: variable_of CO_331:00001084 ! rcspvmv 5 pt. scale
+relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle virus (spvmv)
+
+[Term]
+id: CO_331:0000762
+name: Reaction to Sweet potato virus disease complex (SPVD complex) estimating 1-9
+def: "Reaction to Sweet potato virus disease complex (SPVD complex). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnSPVD_Et_1to9" EXACT []
+synonym: "SPVD" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001085 ! visual estimation of the plant response to  sweet potato virus disease complex
+relationship: variable_of CO_331:00001086 ! rcspvd 5 pt. scale
+relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus disease complex (spvd complex)
+
+[Term]
+id: CO_331:0000763
+name: Reaction to Other virus estimating 1-9
+def: "Reaction to Other virus. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "RnOV_Et_1to9" EXACT []
+synonym: "VIRUS" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001087 ! visual estimation of the plant response to  other virus
+relationship: variable_of CO_331:00001088 ! rcov 5 pt. scale
+relationship: variable_of CO_331:0000399 ! reaction to other virus
+
+[Term]
+id: CO_331:0000764
+name: Reaction to Witches broom estimating 1-9
+def: "Reaction to Witches broom. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "BROOM" EXACT []
+synonym: "RnWB_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001089 ! visual estimation of the plant response to  witches broom
+relationship: variable_of CO_331:00001090 ! rcwb 5 pt. scale
+relationship: variable_of CO_331:0000400 ! reaction to witches broom
+
+[Term]
+id: CO_331:0000765
+name: Reaction to Other mycoplasma estimating 1-9
+def: "Reaction to Other mycoplasma. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+synonym: "MYCOPLASMA" EXACT []
+synonym: "RnOM_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001091 ! visual estimation of the plant response to  to other mycoplasma
+relationship: variable_of CO_331:00001092 ! rcom 5 pt. scale
+relationship: variable_of CO_331:0000401 ! reaction to other mycoplasma
+
+[Term]
+id: CO_331:0000766
+name: Total sugar content estimating 1-9
+def: "Total sugar content" []
+synonym: "RtTSgC_Et_1to9" EXACT []
+synonym: "TOTSUG" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001094 ! rttsgc
+relationship: variable_of CO_331:0000402 ! total sugar content
+
+[Term]
+id: CO_331:0000767
+name: Habitus measuring image
+def: "Appearance of plant" []
+synonym: "FOTHAB" EXACT []
+synonym: "PtHbt_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001095 ! plant picture
+relationship: variable_of CO_331:0000403 ! appearance of plant
+
+[Term]
+id: CO_331:0000768
+name: Flower measuring image
+def: "Appearance of flower" []
+synonym: "FOTFLW" EXACT []
+synonym: "FrCol_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001096 ! flower picture
+relationship: variable_of CO_331:0000404 ! appearance of flower
+
+[Term]
+id: CO_331:0000769
+name: Root measuring image
+def: "Appearance of roots" []
+synonym: "FOTROT" EXACT []
+synonym: "RtCol_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001097 ! root picture
+relationship: variable_of CO_331:0000405 ! appearance of roots
+
+[Term]
+id: CO_331:0000770
+name: Seeds measuring image
+def: "Appearance of seeds" []
+synonym: "FOTSDS" EXACT []
+synonym: "FrSds_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001098 ! seeds picture
+relationship: variable_of CO_331:0000406 ! appearance of seeds
+
+[Term]
+id: CO_331:0000771
+name: Leaf measuring image
+def: "Appearance of leaves" []
+synonym: "FOTLEA" EXACT []
+synonym: "Lf_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001099 ! leaf picture
+relationship: variable_of CO_331:0000407 ! appearance of leaves
+
+[Term]
+id: CO_331:0000772
+name: Herbarium measuring image
+def: "Appearance of hearbarium" []
+synonym: "FOTHRB" EXACT []
+synonym: "PtHrb_Ms_img" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001093 ! taking standardized photo
+relationship: variable_of CO_331:00001099 ! leaf picture
+relationship: variable_of CO_331:0000408 ! appearance of hearbarium
+
+[Term]
+id: CO_331:0000774
+name: Storage Root Shape primary estimating 1-8
+def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
+synonym: "RTSHP1" EXACT []
+synonym: "RtShpP_Et_1to8" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000069 ! storage root shape (primary)
+relationship: variable_of CO_331:00001100 ! observation of most frequennt storage root shape
+relationship: variable_of CO_331:00001101 ! rtshpp 8 pt. scale
+
+[Term]
+id: CO_331:0000775
+name: Storage Root Shape secondary estimating 1-8
+def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
+synonym: "RTSHP2" EXACT []
+synonym: "RtShpS_Et_1to8" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001102 ! observation of 2nd most frequent storage root shape
+relationship: variable_of CO_331:00001103 ! rtshps 8 pt. scale
+relationship: variable_of CO_331:0000441 ! storage root shape (secondary)
+
+[Term]
+id: CO_331:0000776
+name: Storage Root Shape Uniformity estimating 1-9
+def: "Storage Root Shape uniformity within a single plant or plot. 1 = Very Poor, 2 = Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
+synonym: "RTSHPU" EXACT []
+synonym: "RtShpU_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001104 ! observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
+relationship: variable_of CO_331:00001105 ! rtshpu 9 pt. scale
+relationship: variable_of CO_331:0000409 ! storage root shape uniformity
+
+[Term]
+id: CO_331:0000777
+name: Storage Root Stalk estimating 0-9
+def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
+synonym: "RTSTALK" EXACT []
+synonym: "RtStlk_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001107 ! rtstlk 6 pt. scale
+relationship: variable_of CO_331:0000410 ! storage root stalk length
+
+[Term]
+id: CO_331:0000778
+name: Storage Root Attachement estimating 0-9
+def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off. 1 = Very tight, 3 = Tight, 5 = Moderate, 6.0, 7 = Light, 8.0, 9 = Very Light" []
+synonym: "RtAtt_Et_1to9" EXACT []
+synonym: "RTATTACH" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001108 ! rtatt 9 pt. scale
+relationship: variable_of CO_331:0000411 ! storage root attachment
+
+[Term]
+id: CO_331:0000779
+name: Length to Diameter Ratio computation
+def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
+synonym: "LDR" EXACT []
+synonym: "RtLDR_Cp_ratio" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
+relationship: variable_of CO_331:0000412 ! length to diameter ratio of roots
+
+[Term]
+id: CO_331:0000780
+name: Skin Color estimating 1-12
+def: "The most representative skin color observed is recorded. 1 = White, 2 = Cream, 3 = Yellow, 4 = Tan, 5 = Orange, 6 = Rose, 7 = Pink, 8 = Red, 9 = Light Purple, 10 = Purple, 11 = Dark Purple, 12 = Brown" []
+synonym: "RtSknCol_Et_1to12" EXACT []
+synonym: "SKINCOLOR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001110 ! rtskncol 12 pt. scale
+relationship: variable_of CO_331:0000413 ! skin color of roots
+
+[Term]
+id: CO_331:0000781
+name: Skin Texture estimating 1-9
+def: "Storage root skin feel, appearance, or consistency by visual observation and touch. 1 = Very Rough, 2.0, 3 = Moderately Rough, 4.0, 5 = Moderately Smooth, 6.0, 7 = Smooth, 8.0, 9 = Very Smooth" []
+synonym: "RTSKNTEX" EXACT []
+synonym: "RtSknTxt_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001111 ! rtskntxt 9 pt. scale
+relationship: variable_of CO_331:0000414 ! skin texture of roots
+
+[Term]
+id: CO_331:0000782
+name: Flesh Color Carotenoids estimating 0-4
+def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = White, 0.5, 1 = Cream, 2 = Yellow, 2.5 = Yellow with orange, 2.75 = Orange with yellow, 3 = Orange, 3.5 = Dark Orange, 4 = Very Dark Orange" []
+synonym: "RTFLESH1" EXACT []
+synonym: "RtFlsColC_Et_0to4" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001112 ! rtflscolc 9 pt. scale
+relationship: variable_of CO_331:0000415 ! flesh color (carotenoids)
+
+[Term]
+id: CO_331:0000783
+name: Flesh Color Anthocyanins estimating 0-4
+def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = No Anthocyanins, 0.5, 1 = Light Purple, 1.5, 2 = Moderate Purple, 2.5, 3 = Dark Purple, 3.5, 4 = Very Dark Purple" []
+synonym: "RTFLESH2" EXACT []
+synonym: "RtFlsColA_Et_0to4" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001113 ! rtflscola 9 pt. scale
+relationship: variable_of CO_331:0000416 ! flesh color (anthocyanins)
+
+[Term]
+id: CO_331:0000784
+name: Adventitious buds estimating 1-9
+def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface. 1 = Very Deep, 3 = Deep, 5 = Moderate, 7 = Shallow, 9 = Very Shallow" []
+synonym: "EYES" EXACT []
+synonym: "RtAdvB_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001114 ! rtadvb 5 pt. scale
+relationship: variable_of CO_331:0000417 ! deep of eyes of roots
+
+[Term]
+id: CO_331:0000785
+name: Lenticels estimating 1-9
+def: "Overall assessment of visible lenticels at the storage root interface. 1 = Very Prominent, 2.0, 3 = Prominent, 4.0, 5 = Moderate, 6.0, 7 = Few, 8.0, 9 = None" []
+synonym: "LENTS" EXACT []
+synonym: "RtLtcl_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001115 ! ses 9 pt. scale
+relationship: variable_of CO_331:0000418 ! number of lenticels
+
+[Term]
+id: CO_331:0000786
+name: Streptomyces Soil Rot estimating 0-5
+def: "Streptomyces ipomoeae symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+synonym: "RnPSR_Et_0to5" EXACT []
+synonym: "SSR" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001116 ! observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
+relationship: variable_of CO_331:00001117 ! ses 6 pt. scale
+relationship: variable_of CO_331:0000419 ! reaction to streptomyces soil rot
+
+[Term]
+id: CO_331:0000787
+name: Root Knot Nematode  Meloidogyne estimating 0-5
+def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+synonym: "RKN" EXACT []
+synonym: "RnMgRKN_Et_0to5" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
+relationship: variable_of CO_331:00001119 ! rcmgrkn  6 pt. scale
+relationship: variable_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
+
+[Term]
+id: CO_331:0000788
+name: Root Knot Nematode  Meloidogyne incognita estimating 0-7
+def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation. 1= highly resistant (HR), 2= Resistant (1-10%), 3 = Moderate resistant (MR)(11-25%), 4 = Susceptible (S) (26-75%), 5= (HS) Highly susceptible (>76%)" []
+synonym: "RKN, MELOI" EXACT []
+synonym: "RnMgIRKN_Et_0to7" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
+relationship: variable_of CO_331:00001120 ! rcmigrkn  5 pt. scale
+relationship: variable_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
+
+[Term]
+id: CO_331:0000789
+name: Reaction to Fusarium Wilt estimating 0-5
+def: "Reaction to Fusarium oxysporum batatas symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+synonym: "FWILT" EXACT []
+synonym: "RnFR_Et_0to5" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001121 ! visual estimation of the roots response to  fusarium oxysporum
+relationship: variable_of CO_331:00001122 ! rnfr 6 pt. scale
+relationship: variable_of CO_331:0000422 ! reaction to fusarium oxysporum
+
+[Term]
+id: CO_331:0000790
+name: Storage Root Defects primary estimating 1-18
+def: "Type and/or name of primary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
+synonym: "RTDEF1" EXACT []
+synonym: "RtDefP_Et_1to18" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001123 ! rtdam 14 pt. scale
+relationship: variable_of CO_331:0000423 ! storage root defects (primary)
+
+[Term]
+id: CO_331:0000791
+name: Relative Storage Root Yield estimating 1-9
+def: "Overall visual assessment of storage root yield. 1 = Very Poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = Excellent" []
+synonym: "RTRYIELD" EXACT []
+synonym: "RtYldR_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001124 ! rtyldr 5 pt. scale
+relationship: variable_of CO_331:0000424 ! relative storage root yield
+
+[Term]
+id: CO_331:0000792
+name: Yield as percent of check
+def: "Overall calculation of relative root yield" []
+synonym: "RtYldChk_Cp_pct" EXACT []
+synonym: "RTYLDPCT" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
+relationship: variable_of CO_331:0000425 ! storage root yield relative to check
+relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
+
+[Term]
+id: CO_331:0000793
+name: Storage Root Appearance estimating 1-9
+def: "Overall visual assessment of storage root yield appearance. 1 = Very Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
+synonym: "RTAPPEAR" EXACT []
+synonym: "RtApr_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:0000426 ! storage root appearance
+relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
+
+[Term]
+id: CO_331:0000794
+name: Season maturity estimating 0-4
+def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season. 0 = Late Season, 1 = Mid to Late Season, 2 = Mid Season, 3 = Early to Mid Season, 4 = Early Season" []
+synonym: "PtMtSs_Et_0to4" EXACT []
+synonym: "SEASON" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001125 ! ptmtss 5 pt. scale
+relationship: variable_of CO_331:0000427 ! growing season
+
+[Term]
+id: CO_331:0000795
+name: Amylose content measuring  mg per g DW
+def: "Amylose content in sweetpotato" []
+synonym: "AMY" EXACT []
+synonym: "RtFlsAmy_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001126 ! amylose - method
+relationship: variable_of CO_331:00001127 ! g/100 g fw
+relationship: variable_of CO_331:0000428 ! amylose content
+
+[Term]
+id: CO_331:0000796
+name: Asparagine content measuring  mg per g DW
+def: "peonidin content of purple flesh sweetpotato" []
+synonym: "ASP" EXACT []
+synonym: "RtFlsAsp_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001128 ! asparagine - method
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:0000429 ! asparagine content
+
+[Term]
+id: CO_331:0000797
+name: Cyanidin content measuring  mg per g DW
+def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
+synonym: "CYAN" EXACT []
+synonym: "RtFlsCya_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:00001130 ! cyanidin - method
+relationship: variable_of CO_331:0000430 ! cyanidin content
+
+[Term]
+id: CO_331:0000798
+name: Total Monomeric Anthocyanin content measuring  mg per g DW
+def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
+synonym: "RtFlsAntM_Ms_mgpergDW" EXACT []
+synonym: "TMA" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:00001131 ! total monomeric anthocyanins - method
+relationship: variable_of CO_331:0000431 ! total monomeric anthocyanin content
+
+[Term]
+id: CO_331:0000799
+name: Peonidin content measuring  mg per g DW
+def: "Peonidin content of purple flesh sweetpotato" []
+synonym: "PEO" EXACT []
+synonym: "RtFlsPeo_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:00001132 ! peonidin - method
+relationship: variable_of CO_331:0000432 ! peonidin content
+
+[Term]
+id: CO_331:0000800
+name: Anthocyanin content measuring  mg per g DW
+def: "Anthocyanin content of purple flesh sweetpotato" []
+synonym: "ANTHO" EXACT []
+synonym: "RtFlsAnt_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:00001133 ! anthocyanin - method
+relationship: variable_of CO_331:0000433 ! anthocyanin content
+
+[Term]
+id: CO_331:0000801
+name: Phenol content measuring  mg per g DW
+def: "Phenol content of purple flesh sweetpotato" []
+synonym: "PHEN" EXACT []
+synonym: "RtFlsPhe_Ms_mgpergDW" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001129 ! mg/g dw
+relationship: variable_of CO_331:00001134 ! phenol - method
+relationship: variable_of CO_331:0000434 ! phenol content
+
+[Term]
+id: CO_331:0000802
+name: Node number counting nodes per vine
+def: "Nodes per vine" []
+synonym: "VINTND" EXACT []
+synonym: "VnNds_Ct_pervine" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001135 ! nodes per vine evaluation
+relationship: variable_of CO_331:00001136 ! nodes/plant
+relationship: variable_of CO_331:0000435 ! nodes per vine
+
+[Term]
+id: CO_331:0000803
+name: Total number of leaves counting per plant
+def: "Leaves per plant" []
+synonym: "LEFTPP" EXACT []
+synonym: "PtLvs_ct_perplant" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001137 ! leaves per plant evaluation
+relationship: variable_of CO_331:00001138 ! leaf/plant
+relationship: variable_of CO_331:0000436 ! leaves per plant
+
+[Term]
+id: CO_331:0000804
+name: Leaf color by picture measuring by picture using method
+def: "Color of leave" []
+synonym: "LEFCPC" EXACT []
+synonym: "LfCol_Ms_image" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001139 ! color of leave picture
+relationship: variable_of CO_331:00001140 ! picture
+relationship: variable_of CO_331:0000437 ! color of leave
+
+[Term]
+id: CO_331:0000805
+name: Millipede damage estimating 1-9
+def: "Observation of damage caused by Millipede in roots. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+synonym: "MILLDAM" EXACT []
+synonym: "RtsMillDam_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+relationship: variable_of CO_331:00001141 ! rtsmilldam 5 pt. scale
+relationship: variable_of CO_331:0000438 ! millipede damage
+
+[Term]
+id: CO_331:0000806
+name: Alcidodes sp. damage estimating 1-9
+def: "Observation of damage caused by Alcidodes sp, causes crown enlargement/galling or death by girdling. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+synonym: "ALCDAM" EXACT []
+synonym: "RtAlcDam_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001142 ! rtalcdam 5 pt. scale
+relationship: variable_of CO_331:0000439 ! alcidodes sp. damage
+relationship: variable_of CO_331:0000883 ! weevil damage evaluation
+
+[Term]
+id: CO_331:0000807
+name: Soil insect damage estimating 1-9
+def: "Observation of damage caused by soil insect. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+synonym: "INSDAM" EXACT []
+synonym: "RtSInsDam_Et_1to9" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:00001143 ! soils insect evaluation
+relationship: variable_of CO_331:00001144 ! rtsinsdam  5 pt. scale
+relationship: variable_of CO_331:0000440 ! soil insect damage
+
+[Term]
+id: CO_331:0000808
+name: overall storage root disease symptoms
+def: "Overall storage root disease symptoms evaluation" []
+synonym: "RtDSm" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+created_by: C. Yencho
+creation_date: 2016-12-01T02:33:40Z
+
+[Term]
+id: CO_331:0000809
+name: Storage root total marketable yield weight computation tons per ha
+def: "Marketable root yield" []
+synonym: "RtCYld_Cp_tha" EXACT []
+synonym: "RYTHA" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000307 ! marketable root yield
+created_by: W. Grueneberg
+creation_date: 2016-11-30T21:23:23Z
+
+[Term]
+id: CO_331:0000810
+name: Storage Root Defects secondary estimating 1-18
+def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
+synonym: "RTDEF2" EXACT []
+synonym: "RtDefS_Et_1to18" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
+created_by: C. Yencho
+creation_date: 2016-11-30T20:44:25Z
+
+[Term]
+id: CO_331:0000811
+name: storage root defects (secondary)
+def: "Type and/or name of secondary visible storage root defect" []
+synonym: "RtDefS" EXACT []
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+created_by: C. Yencho
+creation_date: 2016-11-30T20:41:53Z
 
 [Term]
 id: CO_331:0000812
@@ -1555,7 +5432,6 @@ is_a: CO_331:1000019 ! Numerical
 relationship: scale_of CO_331:0000870 ! evaluation of plant vine establishment
 relationship: scale_of CO_331:0000872 ! recording planting materials
 relationship: scale_of CO_331:0000885 ! evaluation of plants
-relationship: scale_of CO_331:0000885 ! evaluation of plants
 
 [Term]
 id: CO_331:0000872
@@ -1680,7 +5556,6 @@ name: roots/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
 relationship: scale_of CO_331:0000886 ! evaluation of roots
-relationship: scale_of CO_331:0000886 ! evaluation of roots
 
 [Term]
 id: CO_331:0000888
@@ -1759,11 +5634,9 @@ relationship: method_of CO_331:0000308 ! average commercial root weight
 id: CO_331:0000897
 name: t/ha
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
-relationship: scale_of CO_331:0000896 ! estimated marketable yield per hectare - method
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000896 ! estimated marketable yield per hectare - method
 relationship: scale_of CO_331:0000898 ! estimated yield of total roots per hectare - method
-relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
 relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
 relationship: scale_of CO_331:0000937 ! estimated yield per hectare - method
 
@@ -1773,7 +5646,7 @@ name: estimated yield of total roots per hectare - method
 namespace: SweetpotatoMethod
 def: "(Weight of commercial storage roots/ plot size)*10" []
 is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000309 ! yield of total roots
+relationship: method_of CO_331:0000309 ! yield of total roots 2
 
 [Term]
 id: CO_331:0000899
@@ -1787,7 +5660,7 @@ relationship: method_of CO_331:0000310 ! percentage of marketable roots
 id: CO_331:0000900
 name: %
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000899 ! percentage of marketable - method
 relationship: scale_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
 relationship: scale_of CO_331:0000923 ! protein content - method
@@ -1822,7 +5695,7 @@ id: CO_331:0000903
 name: rtscr 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000902 ! estimation of craking roots
+relationship: scale_of CO_331:0000902 ! estimation of cracking roots
 
 [Term]
 id: CO_331:0000904
@@ -1830,7 +5703,7 @@ name: measurements of fresh root mass
 namespace: SweetpotatoMethod
 def: "Fresh weight of storage root samples (roughly 200g recommended sample size)" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000240 ! weight of storage root
+relationship: method_of CO_331:0000240 ! Fresh weight of storage root
 
 [Term]
 id: CO_331:0000905
@@ -1848,7 +5721,7 @@ name: measurements of dry root mass
 namespace: SweetpotatoMethod
 def: "Dry weight of storage root samples" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000244 ! weight of storage root
+relationship: method_of CO_331:0000244 ! Dry weight of storage root
 
 [Term]
 id: CO_331:0000907
@@ -1856,7 +5729,7 @@ name: measurements of fresh vine mass
 namespace: SweetpotatoMethod
 def: "Fresh weight of vines" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000248 ! weight of vines
+relationship: method_of CO_331:0000248 ! Fresh weight of vines
 
 [Term]
 id: CO_331:0000908
@@ -1864,7 +5737,7 @@ name: measurements of dry vine mass
 namespace: SweetpotatoMethod
 def: "Dry weight of vines" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000252 ! weight of vines
+relationship: method_of CO_331:0000252 ! Dry weight of vines
 
 [Term]
 id: CO_331:0000909
@@ -1910,7 +5783,6 @@ name: evaluation of cooked samples for texture
 namespace: SweetpotatoMethod
 def: "Storage root texture in cooked samples, determined by taste test. Use a 1 to 9 scale with 5 scales." []
 is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000136 ! texture of boiled storage root flesh
 relationship: method_of CO_331:0000136 ! texture of boiled storage root flesh
 
 [Term]
@@ -1988,14 +5860,13 @@ namespace: SweetpotatoMethod
 def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma-optical emission spectrophotometry (ICP-OES) using a Radial View." []
 is_a: CO_331:1000011 ! Measurement
 relationship: method_of CO_331:0000103 ! iron content
-relationship: method_of CO_331:0000103 ! iron content
 relationship: method_of CO_331:0000106 ! zinc content
 
 [Term]
 id: CO_331:0000925
 name: mg/100g
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: scale_of CO_331:0000927 ! content of zinc in dry weight basis - method
 relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
@@ -2007,8 +5878,7 @@ relationship: scale_of CO_331:0000931 ! total carotenoids - method
 id: CO_331:0000926
 name: mg/kg
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
-relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
 relationship: scale_of CO_331:0000929 ! content of magnesium in dry weight basis - method
@@ -2028,7 +5898,6 @@ namespace: SweetpotatoMethod
 def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma--optical emission spectrophotometry (ICP-OES) using a Radial View." []
 is_a: CO_331:1000011 ! Measurement
 relationship: method_of CO_331:0000281 ! calcium content
-relationship: method_of CO_331:0000281 ! calcium content
 
 [Term]
 id: CO_331:0000929
@@ -2036,7 +5905,6 @@ name: content of magnesium in dry weight basis - method
 namespace: SweetpotatoMethod
 def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma--optical emission spectrophotometry (ICP-OES) using a Radial View." []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000285 ! magnesium content
 relationship: method_of CO_331:0000285 ! magnesium content
 
 [Term]
@@ -2198,7 +6066,7 @@ relationship: method_of CO_331:0000329 ! flower size
 id: CO_331:0000950
 name: cm
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000949 ! measurement of flower length and width in cm
 
 [Term]
@@ -2243,7 +6111,7 @@ relationship: method_of CO_331:0000332 ! number of sepal veins
 id: CO_331:0000956
 name: number
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 relationship: scale_of CO_331:0000955 ! record the most frequent number in ten typical flowers
 
 [Term]
@@ -2570,4404 +6438,86 @@ is_a: CO_331:1000014 ! Estimation
 relationship: method_of CO_331:0000354 ! reaction to high soil temperature
 
 [Term]
-id: CO_331:0000000
-name: CGIAR sweetpotato trait ontology
-namespace: SweetpotatoTrait
-def: "A controlled vocabulary to describe each trait as a distinguishable, characteristic, quality or phenotypic feature of a developing or mature sweetpotato plant." []
-
-[Term]
 id: CO_331:1000004
 name: Abiotic_stress_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000005
 name: Biotic_stress_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000007
 name: Quality_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000008
 name: Agronomic_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000009
 name: Biochemical_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000010
 name: Morphological_trait
-namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000011
 name: Measurement
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 
 [Term]
 id: CO_331:1000012
 name: Counting
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 
 [Term]
 id: CO_331:1000013
 name: Computation
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 
 [Term]
 id: CO_331:1000014
 name: Estimation
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Method
+is_a: CO_331:1000001
 
 [Term]
 id: CO_331:1000015
 name: Ordinal
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
+is_a: CO_331:1000002
 
 [Term]
 id: CO_331:1000019
 name: Numerical
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scale
-
-[Term]
-id: CO_331:0000001
-name: plant type
-namespace: SweetpotatoTrait
-def: "Length of the main vines" []
-synonym: "Main vine length" EXACT []
-synonym: "PtTyp" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000004
-name: ground cover
-namespace: SweetpotatoTrait
-def: "Soil area covered by plant canopy" []
-synonym: "VnFolGRnv" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000007
-name: twining
-namespace: SweetpotatoTrait
-def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics" []
-synonym: "PtTwg" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000010
-name: predominant vine color
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color" []
-synonym: "VnColP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000013
-name: secondary vine color
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color" []
-synonym: "VnColS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000016
-name: vine tips pubescence
-namespace: SweetpotatoTrait
-def: "Degree of hairiness of immature leaves recorded at the apex of the vines" []
-synonym: "VnTipP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000019
-name: general outline of the leaf
-namespace: SweetpotatoTrait
-def: "Outline i.e., shape of a leaf located in the middle section of the vine" []
-synonym: "LfOut" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000022
-name: leaf lobe type
-namespace: SweetpotatoTrait
-def: "Type of the lobe of a leaf located in the middle section of the vine" []
-synonym: "LfLbT" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000025
-name: leaf lobe number
-namespace: SweetpotatoTrait
-def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine" []
-synonym: "LfLbN" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000028
-name: shape of central leaf lobe
-namespace: SweetpotatoTrait
-def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine" []
-synonym: "LfLCS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000031
-name: mature leaf size
-namespace: SweetpotatoTrait
-def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave." []
-synonym: "LfLMS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000034
-name: abaxial leaf vein pigmentation
-namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf" []
-synonym: "LfAVP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000037
-name: mature leaf color
-namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants." []
-synonym: "LfCMt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000040
-name: immature leaf color
-namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants." []
-synonym: "LfColI" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000043
-name: petiole pigmentation
-namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first." []
-synonym: "FrPtP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000046
-name: flower color
-namespace: SweetpotatoTrait
-def: "The most representative color in the flowers" []
-synonym: "FRnol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000049
-name: predominant skin color
-namespace: SweetpotatoTrait
-def: "The most representative skin color  of the root" []
-synonym: "RtSknColP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000052
-name: intensity of predominant skin color
-namespace: SweetpotatoTrait
-def: "Intensity of Predominant Skin color of the root" []
-synonym: "RtSknColPI" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000055
-name: secondary skin color
-namespace: SweetpotatoTrait
-def: "The less representative skin color of the root" []
-synonym: "RtSknColS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000058
-name: predominant flesh color
-namespace: SweetpotatoTrait
-def: "The most representative flesh color of the root" []
-synonym: "RtFlsColP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000061
-name: secondary flesh color
-namespace: SweetpotatoTrait
-def: "The less representative flesh color of the root" []
-synonym: "RtFlsColS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000064
-name: distribution of secondary flesh color
-namespace: SweetpotatoTrait
-def: "Distribution of Secondary Flesh color of the root" []
-synonym: "RtFlsColSD" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000067
-name: storage root shape
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root shape" []
-synonym: "RtShp" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000069
-name: storage root shape (primary)
-namespace: SweetpotatoTrait
-def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtShpP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000070
-name: latex production in storage roots
-namespace: SweetpotatoTrait
-def: "Amount of latex observed after cross sectioning medium-sized storage roots" []
-synonym: "RtLxP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000073
-name: oxidation in storage roots
-namespace: SweetpotatoTrait
-def: "Amount of browning due to oxidation" []
-synonym: "RtOxi" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000076
-name: storage root size
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root size based on inspection of the harvested roots" []
-synonym: "RtSiz" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000079
-name: total number of root
-namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: CloneSelector2015
-
-[Term]
-id: CO_331:0000082
-name: yield of total roots
-namespace: SweetpotatoTrait
-def: "Yield evaluated in the harvest" []
-synonym: "RtYld" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000085
-name: harvest index
-namespace: SweetpotatoTrait
-def: "Harvest index" []
-synonym: "IxHrv" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000088
-name: reaction to sweet potato weevil
-namespace: SweetpotatoTrait
-def: "Overall assessment of weevil damage based on inspection of the harvested roots; early." []
-synonym: "RnWvl" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000091
-name: reaction to early blight: (alternaria spp)
-namespace: SweetpotatoTrait
-def: "Alternaria symptoms evaluation" []
-synonym: "RnAlt" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000094
-name: virus symptoms
-namespace: SweetpotatoTrait
-def: "Virus symptoms evaluation" []
-synonym: "RnVir" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000097
-name: storage root cracking
-namespace: SweetpotatoTrait
-def: "Storage root cracking" []
-synonym: "RtCrk" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000100
-name: protein content
-namespace: SweetpotatoTrait
-def: "Protein content of the root" []
-synonym: "RtFlsPrt" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000103
-name: iron content
-namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "RtFlsFe" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000106
-name: zinc content
-namespace: SweetpotatoTrait
-def: "Content of zinc on dry weight basis of the root" []
-synonym: "RtFlsZn" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000109
-name: beta-carotene content
-namespace: SweetpotatoTrait
-def: "Beta carotene content of the root" []
-synonym: "RtFlsBC" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000112
-name: total carotenoids
-namespace: SweetpotatoTrait
-def: "Total carotenoids content of the root" []
-synonym: "RtFlsTC" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000115
-name: storage root starch content
-namespace: SweetpotatoTrait
-def: "Storage root starch content evaluated in percentage dry weight" []
-synonym: "RtFlsSta" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000118
-name: fructose content
-namespace: SweetpotatoTrait
-def: "Fructose content of the root" []
-synonym: "RtFlsFru" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000121
-name: glucose content
-namespace: SweetpotatoTrait
-def: "Glucose content of the root" []
-synonym: "RtFlsGlu" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000124
-name: sucrose content
-namespace: SweetpotatoTrait
-def: "Sucrose content  of the root" []
-synonym: "RtFlsSuc" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000127
-name: maltose content
-namespace: SweetpotatoTrait
-def: "Maltose content  of the root" []
-synonym: "RtFlsMal" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000130
-name: fiber content
-namespace: SweetpotatoTrait
-def: "Fiber content in fresh samples" []
-synonym: "RtFlsFf" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000133
-name: color of boiled roots
-namespace: SweetpotatoTrait
-def: "Color of boiled roots" []
-synonym: "RtCb" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: R.Kapinga
-
-[Term]
-id: CO_331:0000136
-name: texture of boiled storage root flesh
-namespace: SweetpotatoTrait
-def: "Storage root texture after boiled" []
-synonym: "RtFlsTxH" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000139
-name: sweetness of boiled storage root flesh
-namespace: SweetpotatoTrait
-def: "Sweetness of boiled root" []
-synonym: "RtFlsSwt" EXACT []
-synonym: "Storage root sweetness" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman,W. Grueneberg
-
-[Term]
-id: CO_331:0000142
-name: storage root dry matter content
-namespace: SweetpotatoTrait
-def: "Storage root dry matter content" []
-synonym: "RtDMC" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000147
-name: Plant Type estimating 3-9
-namespace: SweetpotatoTrait
-def: "Length of the main vines. 3= Erect (<75 cm), 5= Semi-erect (75-150 cm), 7= Spreading (151-250 cm), 9= Extremely spreading (> 250 cm)" []
-synonym: "PLANT" EXACT []
-synonym: "PtTyp_Et_3to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000812 ! observation of plant type
-relationship: variable_of CO_331:0000813 ! plttyp 4 pt. scale
-relationship: variable_of CO_331:0000001 ! plant type
-
-[Term]
-id: CO_331:0000148
-name: Ground Cover estimating 3-9
-namespace: SweetpotatoTrait
-def: "Soil area covered by plant canopy. 3= Low (<50%), 5= Medium (<50-74%), 7= High (75-90%), 9= Total (> 90%)" []
-synonym: "GRNDCOVR" EXACT []
-synonym: "VnFolGRnv_Et_3to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000814 ! observation of ground cover
-relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
-relationship: variable_of CO_331:0000004 ! ground cover
-
-[Term]
-id: CO_331:0000149
-name: Twining  estimating 0-9
-namespace: SweetpotatoTrait
-def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics. 0= Non-Twining, 3= Slightly twining, 5 = Moderately twining, 7= Twining, 9 = Very twining" []
-synonym: "PtTwg_Et_0to9" EXACT []
-synonym: "TWING" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000816 ! observation of twining
-relationship: variable_of CO_331:0000817 ! plttwg 5 pt. scale
-relationship: variable_of CO_331:0000007 ! twining
-
-[Term]
-id: CO_331:0000150
-name: Predominant Vine Color estimating 1-9
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color. 1= Green, 3= Green with few purple spots, 4= Green with many purple spots, 5= Green with many dark purple spots, 6 = Mostly purple, 7= Mostly dark purple, 8= Totally purple, 9= Totally dark purple" []
-synonym: "VINCO1" EXACT []
-synonym: "VnColP_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000818 ! observation of predominant vine color
-relationship: variable_of CO_331:0000819 ! vinclp 9 pt. scale
-relationship: variable_of CO_331:0000010 ! predominant vine color
-
-[Term]
-id: CO_331:0000151
-name: Secondary Vine Color estimating 0-7
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color. 0 = Absent, 1 = Green base, 2 = Green tip, 3 = Green nodes, 4 = Purple base, 5 = Purple tip, 6 = Purple nodes, 7 = Other" []
-synonym: "VINCO2" EXACT []
-synonym: "VnColS_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000820 ! observation of secondary vine color
-relationship: variable_of CO_331:0000821 ! vincls 8 pt. scale
-relationship: variable_of CO_331:0000013 ! secondary vine color
-
-[Term]
-id: CO_331:0000152
-name: Vine Tips Pubescence estimating 0-7
-namespace: SweetpotatoTrait
-def: "Degree of hairiness of immature leaves recorded at the apex of the vines. 0= Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
-synonym: "VINPUBS" EXACT []
-synonym: "VnTipP_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000822 ! observation of vine tips pubescence
-relationship: variable_of CO_331:0000823 ! vintpp 8 pt. scale
-relationship: variable_of CO_331:0000016 ! vine tips pubescence
-
-[Term]
-id: CO_331:0000153
-name: vine internode length
-namespace: SweetpotatoTrait
-def: "Measurement of the vine internode length" []
-synonym: "VnInLg" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000156
-name: Vine internode length estimating 1-9
-namespace: SweetpotatoTrait
-def: "Measurement of the vine internode length. 1= Very short (<3 cm), 3= Short (3-5 cm), 5=Intermediate (6-9 cm), 7=Long (10-12 cm), 9 =Very long (>12 cm)" []
-synonym: "VINLG" EXACT []
-synonym: "VnInLg_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000824 ! average length of at least three internodes located in the middle section of the vine
-relationship: variable_of CO_331:0000825 ! vininlg 5 pt. scale
-relationship: variable_of CO_331:0000153 ! vine internode length
-
-[Term]
-id: CO_331:0000157
-name: vine internode diameter
-namespace: SweetpotatoTrait
-def: "Measurement of the vine internode diameter" []
-synonym: "VnInD" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000160
-name: Vine internode diameter estimating 1-9
-namespace: SweetpotatoTrait
-def: "Measurement of the vine internode diameter. 1= Very thin (<4 mm), 3= Thin (4-6 mm), 5=Intermediate (7-9 mm), 7=Thick (10-12 mm), 9=Very thick (>12 mm)" []
-synonym: "VINDIA" EXACT []
-synonym: "VnInD_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000826 ! average diameter of at least three internodes located in the middle section of the vine
-relationship: variable_of CO_331:0000827 ! vinind 5 pt. scale
-relationship: variable_of CO_331:0000157 ! vine internode diameter
-
-[Term]
-id: CO_331:0000161
-name: General Outline of the Leaf estimating 1-7
-namespace: SweetpotatoTrait
-def: "Outline i.e., shape of a leaf located in the middle section of the vine. 1= Rounded, 2= Reniform (kidney-shaped), 3 = Chordate (heart-shaped), 4 = Triangular, 5= Hastate, 6 = Lobed, 7 = Almost divided" []
-synonym: "LEAFSHAP1" EXACT []
-synonym: "LfOut_Et_1to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000828 ! observation of general outline of the leaf
-relationship: variable_of CO_331:0000829 ! lefout 7 pt. scale
-relationship: variable_of CO_331:0000019 ! general outline of the leaf
-
-[Term]
-id: CO_331:0000162
-name: Leaf Lobes Type estimating 0-9
-namespace: SweetpotatoTrait
-def: "Type of the lobe of a leaf located in the middle section of the vine. 0 = No lateral lobes (entire), 1 = Very slight (teeth), 3 = Slight, 5 = Moderate, 7 = Deep, 9= Very deep" []
-synonym: "LEAFSHAP2" EXACT []
-synonym: "LfLbT_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000830 ! observation of leaf lobes type
-relationship: variable_of CO_331:0000831 ! leflbt  6 pt. scale
-relationship: variable_of CO_331:0000022 ! leaf lobe type
-
-[Term]
-id: CO_331:0000163
-name: Leaf Lobe Number estimating 1-9
-namespace: SweetpotatoTrait
-def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine. 1= 1 Lobe, 3 = 3 Lobe, 5 = 5 Lobe, 7 = 7 Lobe, 9 = 9 Lobe" []
-synonym: "LEAFSHAP3" EXACT []
-synonym: "LfLbN_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000832 ! observation of leaf lobe number
-relationship: variable_of CO_331:0000833 ! leflbn 5 pt. scale
-relationship: variable_of CO_331:0000025 ! leaf lobe number
-
-[Term]
-id: CO_331:0000164
-name: Shape of Central Leaf Lobe estimating 0-9
-namespace: SweetpotatoTrait
-def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine. 0 = Absent, 1 = Toothed, 2 = Triangular, 3 = Semi-circular, 4 = Semi-elliptic, 5 = Elliptic, 6 = Lanceolate, 7 = Oblanceolate, 8 = Linear (broad), 9 = Linear (narrow)" []
-synonym: "LEAFSHAP4" EXACT []
-synonym: "LfLCS_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000834 ! observation of shape of central leaf lobe
-relationship: variable_of CO_331:0000835 ! leflcs 10 pt. scale
-relationship: variable_of CO_331:0000028 ! shape of central leaf lobe
-
-[Term]
-id: CO_331:0000165
-name: Mature Leaf Size estimating 3-9
-namespace: SweetpotatoTrait
-def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave.. 3 = Small (<8 cm), 5 = Medium (8-15 cm), 7 = Large (16-25 cm), 9 = Very large (> 25 cm)" []
-synonym: "LfLMS_Et_3to9" EXACT []
-synonym: "LFSIZE" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000836 ! observation of mature leaf size
-relationship: variable_of CO_331:0000837 ! leflms 9 pt. scale
-relationship: variable_of CO_331:0000031 ! mature leaf size
-
-[Term]
-id: CO_331:0000166
-name: Abaxial Leaf Vein Pigmentation estimating 1-9
-namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf. 1 = Yellow, 2 = Green, 3 = Purple spot in the base of main rib, 4 = Purple spot in several veins, 5 = Main rib partially purple, 6 = Main rib mostly or totally purple, 7 = All veins partial purple, 8 = All veins mostly or totally purple, 9 = Lower surface and veins totally purple" []
-synonym: "LfAVP_Et_1to9" EXACT []
-synonym: "LFVEIN" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000838 ! observation of abaxial leaf vein pigmentation
-relationship: variable_of CO_331:0000839 ! lefavp 9 pt. scale
-relationship: variable_of CO_331:0000034 ! abaxial leaf vein pigmentation
-
-[Term]
-id: CO_331:0000167
-name: Mature Leaf Color estimating 1-9
-namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
-synonym: "LfCMt_Et_1to9" EXACT []
-synonym: "LFMATCO" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000840 ! observation of mature leaf color
-relationship: variable_of CO_331:0000841 ! lefcmt 9 pt. scale
-relationship: variable_of CO_331:0000037 ! mature leaf color
-
-[Term]
-id: CO_331:0000168
-name: Immature Leaf Color estimating 1-9
-namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
-synonym: "LfColI_Et_1to9" EXACT []
-synonym: "LFINMCO" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000842 ! observation of immature leaf color
-relationship: variable_of CO_331:0000843 ! lefcim 9 pt. scale
-relationship: variable_of CO_331:0000040 ! immature leaf color
-
-[Term]
-id: CO_331:0000169
-name: Petiole Pigmentation estimating 1-9
-namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first.. 1 = Green, 2 = Green with purple near steam, 3 = Green width purple near leaf, 4 = Green with purple both ends, 5 = Green with purple spots throughout petiole, 6 = Green with multiple stripes, 7 = Purple with green near leaf, 8 = Some petioles purple others green, 9 = Totally or mostly purple" []
-synonym: "FrPtP_Et_1to9" EXACT []
-synonym: "PTIOPG" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000844 ! observation of petiole pigmentation
-relationship: variable_of CO_331:0000845 ! flrptp 9 pt. scale
-relationship: variable_of CO_331:0000043 ! petiole pigmentation
-
-[Term]
-id: CO_331:0000170
-name: petiole length
-namespace: SweetpotatoTrait
-def: "Petiole length from the base to the insertion with the blade" []
-synonym: "FrPtL" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000173
-name: Petiole length estimating 1-9
-namespace: SweetpotatoTrait
-def: "Petiole length from the base to the insertion with the blade. 1=Very short (<10 cm), 3=Short (10-20 cm), 5=Intermediate (21-30 cm), 7=Long (31-40 cm), 9=Very long (>40 cm)" []
-synonym: "FrPtL_Et_1to9" EXACT []
-synonym: "PETIOL" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000846 ! average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
-relationship: variable_of CO_331:0000847 ! flrptl 5 pt. scale
-relationship: variable_of CO_331:0000170 ! petiole length
-
-[Term]
-id: CO_331:0000174
-name: Flower color estimating 1-6
-namespace: SweetpotatoTrait
-def: "The most representative color in the flowers. 1= White, 2 = White limb with purple throat, 3 = White limb with pale purple ring and purple throat, 4 = Pale purple limb with purple throat, 5 = Purple, 6 = Other" []
-synonym: "FLORCOL" EXACT []
-synonym: "FRnol_Et_1to6" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000848 ! observation of newly opened flowers
-relationship: variable_of CO_331:0000849 ! flrcol  6 pt. scale
-relationship: variable_of CO_331:0000046 ! flower color
-
-[Term]
-id: CO_331:0000175
-name: Predominant Skin color estimating 1-9
-namespace: SweetpotatoTrait
-def: "The most representative skin color of the root. 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
-synonym: "RTSKN1, SCOL" EXACT []
-synonym: "RtSknColP_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000850 ! observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
-relationship: variable_of CO_331:0000851 ! prdskncol 9 pt. scale
-relationship: variable_of CO_331:0000049 ! predominant skin color
-
-[Term]
-id: CO_331:0000176
-name: Intensity of Predominant Skin color estimating 1-3
-namespace: SweetpotatoTrait
-def: "Intensity of Predominant Skin color of the root. 1= Pale, 2 = Intermediate, 3 = Dark" []
-synonym: "RTSKN2" EXACT []
-synonym: "RtSknColPI_Et_1to3" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000852 ! observation of intensity of predominant skin color
-relationship: variable_of CO_331:0000853 ! skncpi  3 pt. scale
-relationship: variable_of CO_331:0000052 ! intensity of predominant skin color
-
-[Term]
-id: CO_331:0000177
-name: Secondary Skin color estimating 1-10
-namespace: SweetpotatoTrait
-def: "The less representative skin color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
-synonym: "RTSKN3" EXACT []
-synonym: "RtSknColS_Et_1to10" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000854 ! observation of secondary skin color
-relationship: variable_of CO_331:0000855 ! skncsc  10 pt. scale
-relationship: variable_of CO_331:0000055 ! secondary skin color
-
-[Term]
-id: CO_331:0000178
-name: Predominant Flesh color estimating 1-9
-namespace: SweetpotatoTrait
-def: "The most representative flesh color of the root. 1 = White, 2 = Cream, 3 = Dark cream, 4 = Pale yellow, 5 = Dark yellow, 6 = Pale orange, 7 = Intermediate orange, 8 = Dark orange, 9 = Strongly pigmented with anthocyanins" []
-synonym: "RtFlsColP_Et_1to9" EXACT []
-synonym: "RTFSH1, FCOL" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000856 ! observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000857 ! prdflshcol 9 pt. scale
-relationship: variable_of CO_331:0000058 ! predominant flesh color
-
-[Term]
-id: CO_331:0000179
-name: Secondary Flesh color estimating 0-9
-namespace: SweetpotatoTrait
-def: "The less representative flesh color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Pink, 6 = Red, 7 = Purple-red, 8 = Purple, 9 = Dark purple" []
-synonym: "RtFlsColS_Et_0to9" EXACT []
-synonym: "RTFSH2" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000858 ! observation of secondary flesh color
-relationship: variable_of CO_331:0000859 ! flscsc 10 pt. scale
-relationship: variable_of CO_331:0000061 ! secondary flesh color
-
-[Term]
-id: CO_331:0000180
-name: Distribution of Secondary Flesh color estimating 0-9
-namespace: SweetpotatoTrait
-def: "Distribution of Secondary Flesh color of the root. 0 = Absent, 1 = Narrow ring in cortex, 2 = Broad ring in cortex, 3 = Scattered spots in flesh, 4 = Narrow ring in flesh, 5 = Broad ring in flesh, 6 = Ring and other areas in flesh, 7 = In longitudinal sections, 8 = Covering most of the flesh, 9 = Covering all flesh" []
-synonym: "RtFlsColSD_Et_1to9" EXACT []
-synonym: "RTFSH3" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000860 ! observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000861 ! flscsd 10 pt. scale
-relationship: variable_of CO_331:0000064 ! distribution of secondary flesh color
-
-[Term]
-id: CO_331:0000181
-name: Storage Root Shape estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root shape. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Ovate, 5 = Obovate, 6 = Oblong, 7 = Long oblong, 8 = Long elliptic, 9 = Long irregular or curved" []
-synonym: "RTSHP" EXACT []
-synonym: "RtShp_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000862 ! observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000863 ! rtshp 9 pt. scale
-relationship: variable_of CO_331:0000067 ! storage root shape
-
-[Term]
-id: CO_331:0000182
-name: Latex Production in Storage Roots estimating 3-7
-namespace: SweetpotatoTrait
-def: "Amount of latex observed after cross sectioning medium-sized storage roots. 3 = Little, 5 = Some, 7 = Abundant" []
-synonym: "RTLATX" EXACT []
-synonym: "RtLxP_Et_3to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000864 ! observation of latex production in storage roots
-relationship: variable_of CO_331:0000865 ! rtlat 3 pt. scale
-relationship: variable_of CO_331:0000070 ! latex production in storage roots
-
-[Term]
-id: CO_331:0000183
-name: Oxidation in Storage Roots estimating 3-7
-namespace: SweetpotatoTrait
-def: "Amount of browning due to oxidation. 3 = Little, 5 = Some, 7 = Abundant" []
-synonym: "RtOxi_Et_3to7" EXACT []
-synonym: "RTOXID" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000866 ! observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
-relationship: variable_of CO_331:0000867 ! rtoxi 3 pt. scale
-relationship: variable_of CO_331:0000073 ! oxidation in storage roots
-
-[Term]
-id: CO_331:0000184
-name: Storage root size estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root size based on inspection of the harvested roots. 1 = Excellent, 3 = Good, 5 = Fair, 7 = Poor, 9 = terrible" []
-synonym: "RS" EXACT []
-synonym: "RtSiz_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000868 ! storage root size - method
-relationship: variable_of CO_331:0000869 ! rtsize 5 pt. scale
-relationship: variable_of CO_331:0000076 ! storage root size
-
-[Term]
-id: CO_331:0000189
-name: number of plants established
-namespace: SweetpotatoTrait
-def: "Number of plants established" []
-synonym: "PltEst" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000192
-name: Plants established counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of plants established" []
-synonym: "NOPE" EXACT []
-synonym: "PltEst_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000870 ! evaluation of plant vine establishment
-relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000189 ! number of plants established
-
-[Term]
-id: CO_331:0000193
-name: Virus symptoms 1 estimating 1-9
-namespace: SweetpotatoTrait
-def: "Virus symptoms evaluation. 1= No virus symptoms, 2= Unclear virus symptoms, 3= Clear virus symptoms < 5% of plants per plot, 4= Clear virus symptoms at 6 to 15% of plants per plot, 5= Clear virus symptoms at 16 to 33% of plants per plot, 6= Clear virus symptoms at 34 to 66% of plants per plot (more than 1/3 less than 2/3), 7= Clear virus symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8= Clear virus symptoms at all plants per plot (not stunted), 9= Severe virus symptoms in all plants per plot (stunted)." []
-synonym: "VirSm1_Et_1to9" EXACT []
-synonym: "VIR1" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
-relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
-relationship: variable_of CO_331:0000094 ! virus symptoms
+is_a: CO_331:1000002
 
 [Term]
 id: CO_331:2000004
 name: Virus symptoms 2 estimating 1-9
-namespace: SweetpotatoTrait
 def: "Virus symptoms 2." [Grueneberg2010:Def_14]
 comment: | Context of use:  Evaluation in Trials | Growth stage: W13 | Variable status: Recommended | Scientist: W. Grueneberg | Institution: CIP, SASHA | Language of submission: EN | Date of submission: 2015-10-22.
 synonym: "VIR2" EXACT []
 synonym: "VirSm2_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
+is_a: CO_331:1000003
 relationship: variable_of CO_331:0000094 ! virus symptoms
 relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
 relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
 
-[Term]
-id: CO_331:0000194
-name: vine vigor
-namespace: SweetpotatoTrait
-def: "Vine vigor evaluation" []
-synonym: "VnVg" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000197
-name: Vine vigor  estimating 1-9
-namespace: SweetpotatoTrait
-def: "Vine vigor evaluation. 1= Nearly no vines, 2= Weak vines, 3= Weak to medium strong vines, medium thick stems, and long internode distances, 4= Medium strong vines, medium thick stems, and medium internode distances, 5= Medium strong vines, thick vines, and long internode distances, 6= Medium strong vines, thick stems, and medium internode distances, 7= Strong vines, thick stems, short internode distances, and medium-long vines, 8= Strong vines, thick stems, short internode distances, and long vines,, 9= Very strong vine strength, thick stems, short internode distances, and very long vines" []
-synonym: "VnVg_Et_1to9" EXACT []
-synonym: "VV1" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000875 ! observation of plant vigour
-relationship: variable_of CO_331:0000876 ! vinvgr 9 pt. scale
-relationship: variable_of CO_331:0000194 ! vine vigor
-
-[Term]
-id: CO_331:0000198
-name: Reaction to Alternaria symptom estimating 1-9
-namespace: SweetpotatoTrait
-def: "Alternaria symptoms evaluation. 1 = No symptoms, 2 = Unclear symptoms, 3 = Clear symptoms at <5% per plot, 4 = Clear symptoms at 6 to 15% of plants per plot, 5 = Clear symptoms at 16 to 33% of plants per plot (less than 1/3), 6 = Clear symptoms at 34 to 66% of plants per plot (more than 1/3, 7 = Clear symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8 = Clear symptoms at all plants (not fully defoliated), 9 = Severe symptoms at all plants per plot (fully defoliated)" []
-synonym: "ALT1, AS1" EXACT []
-synonym: "RnAlt_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000877 ! early blight evaluation: (alternaria)
-relationship: variable_of CO_331:0000878 ! altsm 9 pt. scale
-relationship: variable_of CO_331:0000091 ! reaction to early blight: (alternaria spp)
-
-[Term]
-id: CO_331:0000199
-name: storage root form
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root form" []
-synonym: "RtFrm" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000202
-name: Storage root form estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall assessment of storage root form. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
-synonym: "RF" EXACT []
-synonym: "RtFrm_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000879 ! storage root form - method
-relationship: variable_of CO_331:0000880 ! rtform 9 pt. scale
-relationship: variable_of CO_331:0000199 ! storage root form
-
-[Term]
-id: CO_331:0000203
-name: number of storage root damages
-namespace: SweetpotatoTrait
-def: "Root with structural damages" []
-synonym: "RtDam" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000206
-name: Storage root damages estimating 1-9
-namespace: SweetpotatoTrait
-def: "Root with structural damages. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
-synonym: "DAMR" EXACT []
-synonym: "RtDam_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000881 ! storage root damage
-relationship: variable_of CO_331:0000882 ! rtsdam 9 pt. scale
-relationship: variable_of CO_331:0000203 ! number of storage root damages
-
-[Term]
-id: CO_331:0000207
-name: Reaction to Sweet potato weevil symptoms estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall assessment of weevil damage based on inspection of the harvested roots; early.. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
-synonym: "RnWvl_Et_1to9" EXACT []
-synonym: "WED1, WED" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000883 ! weevil damage evaluation
-relationship: variable_of CO_331:0000884 ! rtdam 9 pt. scale
-relationship: variable_of CO_331:0000088 ! reaction to sweet potato weevil
-
-[Term]
-id: CO_331:0000208
-name: number of plants with storage roots
-namespace: SweetpotatoTrait
-def: "Number of plants with storage roots" []
-synonym: "PtRt" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000211
-name: Plants with storage roots counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of plants with storage roots" []
-synonym: "NOPR" EXACT []
-synonym: "PtRt_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000885 ! evaluation of plants
-relationship: variable_of CO_331:0000208 ! number of plants with storage roots
-
-[Term]
-id: CO_331:0000212
-name: number of commercial storage roots
-namespace: SweetpotatoTrait
-def: "Roots 12-20 cm long and 10 cm in diameter" []
-synonym: "RtCmN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000214
-name: Number of commercial storage roots counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of root that are 12 to 20 cm long and at least 10 cm in diameter" []
-synonym: "NOCR" EXACT []
-synonym: "RtCmN_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000886 ! evaluation of roots
-relationship: variable_of CO_331:0000887 ! roots/plot
-relationship: variable_of CO_331:0000212 ! number of commercial storage roots
-
-[Term]
-id: CO_331:0000215
-name: number of non-commercial storage roots
-namespace: SweetpotatoTrait
-def: "Number of small and large roots (10 > x < 20 cm long)" []
-synonym: "RtNCmN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000217
-name: Number of non-commercial storage roots counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of root shorter than 10 cm long and greater than 20 cm long." []
-synonym: "NONC" EXACT []
-synonym: "RtNCmN_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000886 ! evaluation of roots
-relationship: variable_of CO_331:0000887 ! roots/plot
-relationship: variable_of CO_331:0000215 ! number of non-commercial storage roots
-
-[Term]
-id: CO_331:0000218
-name: weight of commercial storage roots
-namespace: SweetpotatoTrait
-def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
-synonym: "RtCmW" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000220
-name: Weight of commercial storage roots measuring kg per plot
-namespace: SweetpotatoTrait
-def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
-synonym: "CRW" EXACT []
-synonym: "RtCmW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000892 ! measurements of root mass
-relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000218 ! weight of commercial storage roots
-
-[Term]
-id: CO_331:0000221
-name: weight of non-commercial storage roots
-namespace: SweetpotatoTrait
-def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
-synonym: "RtNCmW" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000223
-name: Weight of non-commercial storage roots measuring kg per plot
-namespace: SweetpotatoTrait
-def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
-synonym: "NCRW" EXACT []
-synonym: "RtNCmW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000892 ! measurements of root mass
-relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000221 ! weight of non-commercial storage roots
-
-[Term]
-id: CO_331:0000224
-name: weight of vines
-namespace: SweetpotatoTrait
-def: "Weight of vines" []
-synonym: "VnW" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000227
-name: Weight of vines measuring kg per plot
-namespace: SweetpotatoTrait
-def: "Weight of vines" []
-synonym: "VnW_Ms_kgplot" EXACT []
-synonym: "VW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000894 ! measurements of vine mass
-relationship: variable_of CO_331:0000224 ! weight of vines
-
-[Term]
-id: CO_331:0000230
-name: Total number of roots computation per plant
-namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN_Ct_rtplant" EXACT []
-synonym: "TNROOT,NRPP" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000890 ! estimated number per plant - method
-relationship: variable_of CO_331:0000891 ! roots/ plant
-relationship: variable_of CO_331:0000079 ! total number of root
-
-[Term]
-id: CO_331:0000233
-name: Total number of root counting per plot
-namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN_Ct_rtplot" EXACT []
-synonym: "TNRPLOT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000888 ! estimated number per plot - method
-relationship: variable_of CO_331:0000889 ! roots/ plot
-relationship: variable_of CO_331:0000079 ! total number of root
-
-[Term]
-id: CO_331:0000234
-name: total root weight
-namespace: SweetpotatoTrait
-def: "Total weight of root  after harvest" []
-synonym: "RtTWt" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: CloneSelector2015
-
-[Term]
-id: CO_331:0000237
-name: Total root weight computation per plot
-namespace: SweetpotatoTrait
-def: "Total weight of root after harvest" []
-synonym: "RtTWt_Cp_plot" EXACT []
-synonym: "TRW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000895 ! estimated weight per plot - method
-relationship: variable_of CO_331:0000234 ! total root weight
-
-[Term]
-id: CO_331:0000239
-name: Storage root cracking estimating 0-7
-namespace: SweetpotatoTrait
-def: "Storage root cracking. 0 = Absent, 3 = Few cracks, 5 = Medium number of cracks, 7 = Many cracks" []
-synonym: "RtCrk_Et_0to7" EXACT []
-synonym: "SGROOT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000902 ! estimation of craking roots
-relationship: variable_of CO_331:0000903 ! rtscr 4 pt. scale
-relationship: variable_of CO_331:0000097 ! storage root cracking
-
-[Term]
-id: CO_331:0000240
-name: Fresh weight of storage root
-namespace: SweetpotatoTrait
-def: "Weight of storage root samples" []
-synonym: "RtFWt" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000243
-name: Fresh weight of storage root samples measuring g of sample
-namespace: SweetpotatoTrait
-def: "Weight of storage root samples" []
-synonym: "DMF" EXACT []
-synonym: "RtFWt_Ms_g" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000904 ! measurements of fresh root mass
-relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000240 ! weight of storage root
-
-[Term]
-id: CO_331:0000244
-name: Dry weight of storage root
-namespace: SweetpotatoTrait
-def: "Weight of storage root samples" []
-synonym: "RtDWt" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000247
-name: Dry weight of storage root samples measuring g of sample
-namespace: SweetpotatoTrait
-def: "Weight of storage root samples" []
-synonym: "DMD" EXACT []
-synonym: "RtDWt_Ms_g" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000906 ! measurements of dry root mass
-relationship: variable_of CO_331:0000244 ! weight of storage root
-
-[Term]
-id: CO_331:0000248
-name: Fresh weight of vines
-namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
-synonym: "VnFWt" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000251
-name: Fresh weight of vines measuring g of sample
-namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
-synonym: "DMFV" EXACT []
-synonym: "VnFWt_Et_g" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000907 ! measurements of fresh vine mass
-relationship: variable_of CO_331:0000248 ! weight of vines
-
-[Term]
-id: CO_331:0000252
-name: Dry weight of vines
-namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
-synonym: "VnDWt" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000255
-name: Dry weight of vines measuring g of sample
-namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
-synonym: "DMDV" EXACT []
-synonym: "VnDWt_Ms_g" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000908 ! measurements of dry vine mass
-relationship: variable_of CO_331:0000252 ! weight of vines
-
-[Term]
-id: CO_331:0000256
-name: fiber cooked
-namespace: SweetpotatoTrait
-def: "Fiber content in cooked samples" []
-synonym: "RtFlsFbC" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000259
-name: Fibers in cooked samples estimating 1-9
-namespace: SweetpotatoTrait
-def: "Fiber content in cooked samples. 1= Non-fibrous, 2= Non-fibrous to slightly fibrous, 3= Slightly fibrous, 4= Slightly to moderately fibrous, 5= Moderately fibrous, 6= Moderately fibrous to fibrous, 7= Fibrous, 8= Fibrous to very fibrous, 9= Very fibrous" []
-synonym: "COOF" EXACT []
-synonym: "RtFlsFbC_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000909 ! evaluation of cooked samples for fibers
-relationship: variable_of CO_331:0000910 ! rtfbr 9 pt. scale
-relationship: variable_of CO_331:0000256 ! fiber cooked
-
-[Term]
-id: CO_331:0000260
-name: Fibers content in fresh samples measuring percent
-namespace: SweetpotatoTrait
-def: "Fiber content in fresh samples" []
-synonym: "FIBER" EXACT []
-synonym: "RtFlsFf_Ms_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
-relationship: variable_of CO_331:0000130 ! fiber content
-
-[Term]
-id: CO_331:0000261
-name: Storage root sweetness estimating 1-9
-namespace: SweetpotatoTrait
-def: "Sweetness of boiled root. 1 = Not at all sweet, 2= Non-sweet to slightly sweet, 3 = Slightly sweet, 4= Slightly to moderately sweet, 5 = Moderately sweet, 6= Moderately sweet to sweet, 7 = Sweet, 8= Sweet to very sweet, 9= Very sweet" []
-synonym: "RtFlsSwt_Et_1to9" EXACT []
-synonym: "TASTE, COOSU" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000912 ! evaluation of cooked samples for sweetness
-relationship: variable_of CO_331:0000913 ! rtswt 9 pt. scale
-relationship: variable_of CO_331:0000139 ! sweetness of boiled storage root flesh
-
-[Term]
-id: CO_331:0000263
-name: Storage root texture estimating 1-9 by Huaman
-namespace: SweetpotatoTrait
-def: "Storage root texture after boiled. 1 = Dry, 3 = Somewhat dry, 5 = Intermediate, 7 = Moist, 9 = Very moist" []
-synonym: "RtFlsTxH_Et_1to9" EXACT []
-synonym: "RTTEXT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
-relationship: variable_of CO_331:0000915 ! flstxch 5 pt. scale
-relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
-
-[Term]
-id: CO_331:0000265
-name: Storage root texture estimating 1-9 by Grueneberg
-namespace: SweetpotatoTrait
-def: "Storage root texture after boiled. 1= very moist, 2= Very moist to moist, 3= Moist, 4= Moist to moderately dry, 5= Moderately dry, 6= Moderately dry to dry, 7= Dry, 8= Dry to very dry, 9= Very dry" []
-synonym: "RtFlsTxG_Et_1to9" EXACT []
-synonym: "TEXTBR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
-relationship: variable_of CO_331:0000916 ! flstxcg 9 pt. scale
-relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
-
-[Term]
-id: CO_331:0000266
-name: overall taste of cooked sample
-namespace: SweetpotatoTrait
-def: "Overall taste of cooked sample" []
-synonym: "RtFlsTs" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000269
-name: Overall taste of cooked sample estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall taste of cooked sample. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
-synonym: "COOT" EXACT []
-synonym: "RtFlsTs_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000917 ! evaluation of cooked samples for taste
-relationship: variable_of CO_331:0000918 ! rttst 9 pt. scale
-relationship: variable_of CO_331:0000266 ! overall taste of cooked sample
-
-[Term]
-id: CO_331:0000270
-name: overall appearance of cooked sample
-namespace: SweetpotatoTrait
-def: "Appearance of cooked sample" []
-synonym: "RtFlsAp" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000273
-name: Overall appearance of cooked sample estimating 1-9
-namespace: SweetpotatoTrait
-def: "Appearance of cooked sample. 1= Very appealing, 2= Very appealing to appealing, 3= Appealing, 4= Appealing to somewhat appealing, 5= Somewhat appealing, 6= Somewhat appealing to unappealing, 7= Unappealing, 8= Unappealing to very unappealing, 9= Very unappealing" []
-synonym: "COOAP" EXACT []
-synonym: "RtFlsAp_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000919 ! evaluation of cooked samples for appearance
-relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
-relationship: variable_of CO_331:0000270 ! overall appearance of cooked sample
-
-[Term]
-id: CO_331:0000274
-name: sprouting ability
-namespace: SweetpotatoTrait
-def: "ability to produce new sprout" []
-synonym: "RtSpA" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000277
-name: Sprouting ability estimating 1-9
-namespace: SweetpotatoTrait
-def: "ability to produce new sprout. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
-synonym: "RSPR" EXACT []
-synonym: "RtSpA_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000921 ! evaluation of roots for sprouting ability
-relationship: variable_of CO_331:0000922 ! rtsprt 9 pt. scale
-relationship: variable_of CO_331:0000274 ! sprouting ability
-
-[Term]
-id: CO_331:0000278
-name: Protein content measuring percent
-namespace: SweetpotatoTrait
-def: "Protein content of the root" []
-synonym: "PRO, PROTEIN" EXACT []
-synonym: "RtFlsPrt_Ms_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000923 ! protein content - method
-relationship: variable_of CO_331:0000100 ! protein content
-
-[Term]
-id: CO_331:0000279
-name: Content of iron on dry weight basis measuring mg per 100g
-namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "FeDW" EXACT []
-synonym: "RtFlsFe_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000103 ! iron content
-
-[Term]
-id: CO_331:0000280
-name: Content of zinc on dry weight basis measuring mg per 100g
-namespace: SweetpotatoTrait
-def: "Content of zinc on dry weight basis of the root" []
-synonym: "RtFlsZn_Ms_mg100gDW" EXACT []
-synonym: "ZnDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000927 ! content of zinc in dry weight basis - method
-relationship: variable_of CO_331:0000106 ! zinc content
-
-[Term]
-id: CO_331:0000281
-name: calcium content
-namespace: SweetpotatoTrait
-def: "Content of calcium on dry weight basis of the root" []
-synonym: "RtFlsCa" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000284
-name: Content of calcium on dry weight basis measuringm g per 100g
-namespace: SweetpotatoTrait
-def: "Content of calcium on dry weight basis of the root" []
-synonym: "CaDW" EXACT []
-synonym: "RtFlsCa_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
-relationship: variable_of CO_331:0000281 ! calcium content
-
-[Term]
-id: CO_331:0000285
-name: magnesium content
-namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
-synonym: "RtFlsMg" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000288
-name: Content of magnesium on dry weight basis measuring mg per 100g
-namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
-synonym: "MgDW" EXACT []
-synonym: "RtFlsMg_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
-relationship: variable_of CO_331:0000285 ! magnesium content
-
-[Term]
-id: CO_331:0000289
-name: Beta carotene content measuring mg per 100g
-namespace: SweetpotatoTrait
-def: "Beta carotene content of the root" []
-synonym: "BCDW" EXACT []
-synonym: "RtFlsBC_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000930 ! beta carotene content - method
-relationship: variable_of CO_331:0000109 ! beta-carotene content
-
-[Term]
-id: CO_331:0000290
-name: Total carotenoids measuring mg per 100g
-namespace: SweetpotatoTrait
-def: "Total carotenoids content of the root" []
-synonym: "RtFlsTC_Ms_mg100gDW" EXACT []
-synonym: "TCDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000931 ! total carotenoids - method
-relationship: variable_of CO_331:0000112 ! total carotenoids
-
-[Term]
-id: CO_331:0000291
-name: Storage root starch content measuring percent
-namespace: SweetpotatoTrait
-def: "Storage root starch content evaluated in percentage dry weight" []
-synonym: "RtFlsSta_Ms_pct" EXACT []
-synonym: "STAR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000932 ! storage root starch content - method
-relationship: variable_of CO_331:0000115 ! storage root starch content
-
-[Term]
-id: CO_331:0000292
-name: Fructose content measuring percent
-namespace: SweetpotatoTrait
-def: "Fructose content of the root" []
-synonym: "FRUC" EXACT []
-synonym: "RtFlsFru_Ms_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000933 ! fructose content - method
-relationship: variable_of CO_331:0000118 ! fructose content
-
-[Term]
-id: CO_331:0000293
-name: Glucose content measuring percent
-namespace: SweetpotatoTrait
-def: "Glucose content of the root" []
-synonym: "GLUC" EXACT []
-synonym: "RtFlsGlu_Ms_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000934 ! glucose content - method
-relationship: variable_of CO_331:0000121 ! glucose content
-
-[Term]
-id: CO_331:0000294
-name: Sucrose content measuring percent
-namespace: SweetpotatoTrait
-def: "Sucrose content of the root" []
-synonym: "RtFlsSuc_Ms_pct" EXACT []
-synonym: "SUCR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000935 ! sucrose content - method
-relationship: variable_of CO_331:0000124 ! sucrose content
-
-[Term]
-id: CO_331:0000295
-name: Maltose content measuring percent
-namespace: SweetpotatoTrait
-def: "Maltose content of the root" []
-synonym: "MALT" EXACT []
-synonym: "RtFlsMal_Ms_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000936 ! maltose content - method
-relationship: variable_of CO_331:0000127 ! maltose content
-
-[Term]
-id: CO_331:0000296
-name: Yield of total roots per hectar computing tons per ha
-namespace: SweetpotatoTrait
-def: "Yield evaluated in the harvest" []
-synonym: "RtYld_Cp_tha" EXACT []
-synonym: "RYTHA" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000937 ! estimated yield per hectare - method
-relationship: variable_of CO_331:0000082 ! yield of total roots
-
-[Term]
-id: CO_331:0000297
-name: Storage root dry matter content computing percent
-namespace: SweetpotatoTrait
-def: "Storage root dry matter content" []
-synonym: "DM" EXACT []
-synonym: "RtDMC_Cp_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000938 ! storage root dry matter content - method
-relationship: variable_of CO_331:0000142 ! storage root dry matter content
-
-[Term]
-id: CO_331:0000298
-name: survival index
-namespace: SweetpotatoTrait
-def: "Survival index" []
-synonym: "IxSrv" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000301
-name: Survival index computing percent
-namespace: SweetpotatoTrait
-def: "Survival index" []
-synonym: "IxSrv_Cp_pct" EXACT []
-synonym: "SHI" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000939 ! survival index - method
-relationship: variable_of CO_331:0000298 ! survival index
-
-[Term]
-id: CO_331:0000302
-name: Harvest index computing percent
-namespace: SweetpotatoTrait
-def: "Harvest index" []
-synonym: "HI" EXACT []
-synonym: "IxHrv_Cp_pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000940 ! harvest index evaluation  - method
-relationship: variable_of CO_331:0000085 ! harvest index
-
-[Term]
-id: CO_331:0000303
-name: number of plants planted
-namespace: SweetpotatoTrait
-def: "Number of plants planted" []
-synonym: "PltPld" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000304
-name: number of plants harvested
-namespace: SweetpotatoTrait
-def: "Number of plants harvested" []
-synonym: "PtHrv" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000307
-name: marketable root yield
-namespace: SweetpotatoTrait
-def: "Marketable root yield" []
-synonym: "RtCYld" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000308
-name: average commercial root weight
-namespace: SweetpotatoTrait
-def: "Average commercial root weight evaluated in the harvest" []
-synonym: "RtACRW" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000309
-name: yield of total roots 2
-namespace: SweetpotatoTrait
-def: "Yield of total roots calculated after harvest" []
-synonym: "RtYPP" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000310
-name: percentage of marketable roots
-namespace: SweetpotatoTrait
-def: "Percentage of marketable roots after harvest" []
-synonym: "RtCI" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000311
-name: biomass yield
-namespace: SweetpotatoTrait
-def: "Biomass yield" []
-synonym: "BioYld" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000312
-name: foliage total yield
-namespace: SweetpotatoTrait
-def: "Foliage total yield" []
-synonym: "VnFolYld" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:0000326
-name: storage root surface defects
-namespace: SweetpotatoTrait
-def: "Storage Root Surface Defects" []
-synonym: "RtSDef" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000327
-name: storage root cortex thickness
-namespace: SweetpotatoTrait
-def: "Storage Root Cortex Thickness" []
-synonym: "RtCThk" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000328
-name: flowering habit
-namespace: SweetpotatoTrait
-def: "An behavior pattern of the plant to produce flowers" []
-synonym: "FrHab" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000329
-name: flower size
-namespace: SweetpotatoTrait
-def: "Flower size" []
-synonym: "FrSiz" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000330
-name: shape of limb
-namespace: SweetpotatoTrait
-def: "Shape of limb" []
-synonym: "FrShL" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000331
-name: equality of sepal length
-namespace: SweetpotatoTrait
-def: "Equality of sepal length" []
-synonym: "FrSepEql" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000332
-name: number of sepal veins
-namespace: SweetpotatoTrait
-def: "Number of veins observed in the sepals" []
-synonym: "FrSepNVn" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000333
-name: sepal shape
-namespace: SweetpotatoTrait
-def: "Sepal shape" []
-synonym: "FrSepShp" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000334
-name: sepal apex
-namespace: SweetpotatoTrait
-def: "Sepal apex" []
-synonym: "FrSepApx" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000335
-name: sepal pubescence
-namespace: SweetpotatoTrait
-def: "Degree of hairiness registered in the sepals" []
-synonym: "FrSepPub" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000336
-name: sepal color
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the sepal" []
-synonym: "FrSepCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000337
-name: color of stigma
-namespace: SweetpotatoTrait
-def: "Color of stigma" []
-synonym: "FrStgCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000338
-name: color of style
-namespace: SweetpotatoTrait
-def: "Color of style" []
-synonym: "FrStyCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000339
-name: stigma exertion
-namespace: SweetpotatoTrait
-def: "The relative position of the stigma as compared to the highest anther." []
-synonym: "FrStgExt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000340
-name: seed capsule set
-namespace: SweetpotatoTrait
-def: "Seed capsule set" []
-synonym: "FrSdCp" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000341
-name: storage root formation
-namespace: SweetpotatoTrait
-def: "Arrangement of the storage roots on the underground stems." []
-synonym: "RtFrm" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000342
-name: storage root stalk
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems" []
-synonym: "RtStk" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000343
-name: variability of storage root shape
-namespace: SweetpotatoTrait
-def: "Variability of storage root shape" []
-synonym: "RtShV" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000344
-name: variability of storage root size
-namespace: SweetpotatoTrait
-def: "Variability of storage root size" []
-synonym: "RtSzV" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000345
-name: keeping quality of storage roots
-namespace: SweetpotatoTrait
-def: "Keeping quality of storage roots" []
-synonym: "RtKQl" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000346
-name: consistency of boiled storage root
-namespace: SweetpotatoTrait
-def: "Consistency of boiled storage root" []
-synonym: "RtBlCu" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000347
-name: undesirable color of boiled storage root
-namespace: SweetpotatoTrait
-def: "Undesirable color of boiled storage root" []
-synonym: "RtBlCd" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000348
-name: reaction to drought
-namespace: SweetpotatoTrait
-def: "Response to damage by water restriction." []
-synonym: "RnDrt" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000349
-name: reaction to flooding
-namespace: SweetpotatoTrait
-def: "Response of plant to inundation by water of all or part of the plant" []
-synonym: "RnFld" EXACT []
-synonym: "waterlogging response" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000350
-name: reaction to heat
-namespace: SweetpotatoTrait
-def: "Response of a plant or plant part to damage by higher than normal temperatures" []
-synonym: "RnHeat" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000351
-name: reaction to salinity
-namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt" []
-synonym: "RnSlt" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000352
-name: reaction to shade
-namespace: SweetpotatoTrait
-def: "Response of plant to damage by shade" []
-synonym: "RnShd" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000353
-name: reaction to soil
-namespace: SweetpotatoTrait
-def: "Response of plant to damage by ph soil" []
-synonym: "RnSph" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000354
-name: reaction to high soil temperature
-namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt" []
-synonym: "RnSTp" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000355
-name: reaction to west indian sweet potato weevil
-namespace: SweetpotatoTrait
-def: "Reaction to West Indian sweet potato weevil" []
-synonym: "RnWISPW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000356
-name: reaction to striped sweet potato weevil
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil" []
-synonym: "RnSSPW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000357
-name: reaction to sweet potato wire worms
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato wire worms" []
-synonym: "RnSPWW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000358
-name: reaction to wire worms
-namespace: SweetpotatoTrait
-def: "Reaction to Wire worms" []
-synonym: "RnWW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000359
-name: reaction to sweet potato flea beetles
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato flea beetles" []
-synonym: "RnSPFB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000360
-name: reaction to flea beetles
-namespace: SweetpotatoTrait
-def: "Reaction to flea beetles" []
-synonym: "RnFB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000361
-name: reaction to sweet potato leaf beetles
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato leaf beetles" []
-synonym: "RnSPLB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000362
-name: reaction to beetles
-namespace: SweetpotatoTrait
-def: "Reaction to Beetles" []
-synonym: "RnBTL" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000363
-name: reaction to grubworm
-namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Grub worm" []
-synonym: "RnGrbW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000364
-name: reaction to hornworm
-namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Hornworm" []
-synonym: "RnHrnw" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000365
-name: reaction to aphids
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Aphis" []
-synonym: "RnAph" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000366
-name: reaction to sweet potato white fly
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly" []
-synonym: "RnSPWF" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000367
-name: reaction to sweet potato moth
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato moth" []
-synonym: "RnSPMth" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000368
-name: reaction to moth
-namespace: SweetpotatoTrait
-def: "Reaction to Moth" []
-synonym: "RnMth" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000369
-name: reaction to sweet potato stem borer
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato stem borer" []
-synonym: "RnSPSB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000370
-name: reaction to other insects
-namespace: SweetpotatoTrait
-def: "Reaction to Other insects" []
-synonym: "RnIns" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000371
-name: reaction to reniform nematode
-namespace: SweetpotatoTrait
-def: "Reaction to Reniform nematode" []
-synonym: "RnRFN" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000372
-name: reaction to sting nematode
-namespace: SweetpotatoTrait
-def: "Reaction to Sting nematode" []
-synonym: "RnStN" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000373
-name: reaction to brown ring rot
-namespace: SweetpotatoTrait
-def: "Reaction to Brown ring rot" []
-synonym: "RnBRR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000374
-name: reaction to root lesion nematode
-namespace: SweetpotatoTrait
-def: "Reaction to Root lesion nematode" []
-synonym: "RnRLN" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000375
-name: reaction to other nematodes
-namespace: SweetpotatoTrait
-def: "Reaction to other nematodes" []
-synonym: "RnON" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000376
-name: reaction to wilt rot
-namespace: SweetpotatoTrait
-def: "Reaction to Wilt rot" []
-synonym: "RnWR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000377
-name: reaction to fusarium surface rot
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium surface rot" []
-synonym: "RnFRS" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000378
-name: reaction to fusarium root rot
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium root rot" []
-synonym: "RnFRR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000379
-name: reaction to sclerotial blight and circular spot
-namespace: SweetpotatoTrait
-def: "Reaction to Sclerotial blight and circular spot" []
-synonym: "RnSBC" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000380
-name: reaction to black rot
-namespace: SweetpotatoTrait
-def: "Reaction to Black rot" []
-synonym: "RnBR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000381
-name: reaction to scurf
-namespace: SweetpotatoTrait
-def: "Reaction to Scurf" []
-synonym: "RnScrf" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000382
-name: reaction to soft rot
-namespace: SweetpotatoTrait
-def: "Reaction to Soft rot" []
-synonym: "RnSR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000383
-name: reaction to java black rot
-namespace: SweetpotatoTrait
-def: "Reaction to Java black rot" []
-synonym: "RnJBR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000384
-name: reaction to diaporthe dry rot
-namespace: SweetpotatoTrait
-def: "Reaction to Diaporthe dry rot" []
-synonym: "RnDDR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000385
-name: reaction to scab
-namespace: SweetpotatoTrait
-def: "Reaction to Scab" []
-synonym: "RnScb" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000386
-name: reaction to leaf spot
-namespace: SweetpotatoTrait
-def: "Reaction to leaf spot" []
-synonym: "RnLS" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000387
-name: reaction to white rust
-namespace: SweetpotatoTrait
-def: "Reaction to White rust" []
-synonym: "RnWR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000388
-name: reaction to foot rot
-namespace: SweetpotatoTrait
-def: "Reaction to Foot rot" []
-synonym: "RnFR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000389
-name: reaction to charcoal rot
-namespace: SweetpotatoTrait
-def: "Reaction to Charcoal rot" []
-synonym: "RnCR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000390
-name: reaction to other fungi
-namespace: SweetpotatoTrait
-def: "Reaction to Other fungi" []
-synonym: "RnOF" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000391
-name: reaction to pox or soil rot
-namespace: SweetpotatoTrait
-def: "Reaction to Pox or soil rot" []
-synonym: "RnPSR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000392
-name: reaction to bacterial stem and root rot
-namespace: SweetpotatoTrait
-def: "Reaction to Bacterial stem and root rot" []
-synonym: "RnBSRt" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000393
-name: reaction to bacterial wilt
-namespace: SweetpotatoTrait
-def: "Reaction to Bacterial wilt" []
-synonym: "RnBW" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000394
-name: reaction to other bacteria
-namespace: SweetpotatoTrait
-def: "Reaction to Other bacteria" []
-synonym: "RnOB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000395
-name: reaction to sweet potato feathery mottle virus (spmv)
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato feathery mottle virus (SPMV)" []
-synonym: "RnSPMV" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000396
-name: reaction to sweet potato mild mottle virus (spmmv)
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato mild mottle virus (SPMMV)" []
-synonym: "RnSPMMV" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000397
-name: reaction to sweet potato vein mottle virus (spvmv)
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato vein mottle virus (SPVMV)" []
-synonym: "RnSPVMV" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000398
-name: reaction to sweet potato virus disease complex (spvd complex)
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato virus disease complex (SPVD complex)" []
-synonym: "RnSPVD" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000399
-name: reaction to other virus
-namespace: SweetpotatoTrait
-def: "Reaction to Other virus" []
-synonym: "RnOV" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000400
-name: reaction to witches broom
-namespace: SweetpotatoTrait
-def: "Reaction to Witches broom" []
-synonym: "RnWB" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000401
-name: reaction to other mycoplasma
-namespace: SweetpotatoTrait
-def: "Reaction to Other mycoplasma" []
-synonym: "RnOM" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000402
-name: total sugar content
-namespace: SweetpotatoTrait
-def: "Total sugar content" []
-synonym: "RtTSgC" EXACT []
-is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000403
-name: appearance of plant
-namespace: SweetpotatoTrait
-def: "Appearance of plant" []
-synonym: "PtHbt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000404
-name: appearance of flower
-namespace: SweetpotatoTrait
-def: "Appearance of flower" []
-synonym: "FrCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000405
-name: appearance of roots
-namespace: SweetpotatoTrait
-def: "Appearance of roots" []
-synonym: "RtCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000406
-name: appearance of seeds
-namespace: SweetpotatoTrait
-def: "Appearance of seeds" []
-synonym: "FrSds" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000407
-name: appearance of leaves
-namespace: SweetpotatoTrait
-def: "Appearance of leaves" []
-synonym: "Lf" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000408
-name: appearance of hearbarium
-namespace: SweetpotatoTrait
-def: "Appearance of hearbarium" []
-synonym: "PtHrb" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000409
-name: storage root shape uniformity
-namespace: SweetpotatoTrait
-def: "Storage Root Shape uniformity within a single plant or plot" []
-synonym: "RtShpU" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000410
-name: storage root stalk length
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems" []
-synonym: "RtStlk" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000411
-name: storage root attachment
-namespace: SweetpotatoTrait
-def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off" []
-synonym: "RtAtt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000412
-name: length to diameter ratio of roots
-namespace: SweetpotatoTrait
-def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
-synonym: "RtLDR" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000413
-name: skin color of roots
-namespace: SweetpotatoTrait
-def: "The most representative skin color observed is recorded" []
-synonym: "RtSknCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000414
-name: skin texture of roots
-namespace: SweetpotatoTrait
-def: "Storage root skin feel, appearance, or consistency by visual observation and touch" []
-synonym: "RtSknTxt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000415
-name: flesh color (carotenoids)
-namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtFlsColC" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000416
-name: flesh color (anthocyanins)
-namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtFlsColA" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000417
-name: deep of eyes of roots
-namespace: SweetpotatoTrait
-def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface" []
-synonym: "RtAdvB" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000418
-name: number of lenticels
-namespace: SweetpotatoTrait
-def: "Overall assessment of visible lenticels at the storage root interface" []
-synonym: "RtLtcl" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000419
-name: reaction to streptomyces soil rot
-namespace: SweetpotatoTrait
-def: "Streptomyces ipomoeae symptom evaluation" []
-synonym: "RnPSR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000420
-name: reaction to root knot nematode meloidogyne spp
-namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation" []
-synonym: "RnMgRKN" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000421
-name: reaction to root knot nematode meloidogyne incognita
-namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation" []
-synonym: "RnMgIRKN" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: A.Gonzales
-
-[Term]
-id: CO_331:0000422
-name: reaction to fusarium oxysporum
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium oxysporum batatas symptom evaluation" []
-synonym: "RnFR" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000423
-name: storage root defects (primary)
-def: "Type and/or name of primary visible storage root defect" []
-synonym: "RtDefP" EXACT []
-synonym: "RtDam" EXACT []
-namespace: SweetpotatoTrait
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000424
-name: relative storage root yield
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield" []
-synonym: "RtYldR" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000425
-name: storage root yield relative to check
-namespace: SweetpotatoTrait
-def: "Overall calculation of relative root yield" []
-synonym: "RtYldChk" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000426
-name: storage root appearance
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield appearance" []
-synonym: "RtApr" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000427
-name: growing season
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season" []
-synonym: "PtMtSs" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000428
-name: amylose content
-namespace: SweetpotatoTrait
-def: "Amylose content in sweetpotato" []
-synonym: "RtFlsAmy" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000429
-name: asparagine content
-namespace: SweetpotatoTrait
-def: "peonidin content of purple flesh sweetpotato" []
-synonym: "RtFlsAsp" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000430
-name: cyanidin content
-namespace: SweetpotatoTrait
-def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
-synonym: "RtFlsCya" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000431
-name: total monomeric anthocyanin content
-namespace: SweetpotatoTrait
-def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
-synonym: "RtFlsAntM" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000432
-name: peonidin content
-namespace: SweetpotatoTrait
-def: "Peonidin content of purple flesh sweetpotato" []
-synonym: "RtFlsPeo" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000433
-name: anthocyanin content
-namespace: SweetpotatoTrait
-def: "Anthocyanin content of purple flesh sweetpotato" []
-synonym: "RtFlsAnt" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000434
-name: phenol content
-namespace: SweetpotatoTrait
-def: "Phenol content of purple flesh sweetpotato" []
-synonym: "RtFlsPhe" EXACT []
-is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000435
-name: nodes per vine
-namespace: SweetpotatoTrait
-def: "Nodes per vine" []
-synonym: "VnNds" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
-
-[Term]
-id: CO_331:0000436
-name: leaves per plant
-namespace: SweetpotatoTrait
-def: "Leaves per plant" []
-synonym: "PtLvs" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
-
-[Term]
-id: CO_331:0000437
-name: color of leave
-namespace: SweetpotatoTrait
-def: "Color of leave" []
-synonym: "LfCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
-
-[Term]
-id: CO_331:0000438
-name: millipede damage
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by Millipede in roots" []
-synonym: "RtMillDam" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
-
-[Term]
-id: CO_331:0000439
-name: alcidodes sp. damage
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by Alcidodes sp,  causes crown enlargement/galling or death by girdling" []
-synonym: "RtAlcDam" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
-
-[Term]
-id: CO_331:0000440
-name: soil insect damage
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by soil insect" []
-synonym: "RtSInsDam" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
-
-[Term]
-id: CO_331:0000441
-name: storage root shape (secondary)
-namespace: SweetpotatoTrait
-def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtShpS" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000678
-name: Plants planted counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of plants planted" []
-synonym: "NOPS" EXACT []
-synonym: "PltPld_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000872 ! recording planting materials
-relationship: variable_of CO_331:0000303 ! number of plants planted
-
-[Term]
-id: CO_331:0000679
-name: Plants harvested counting number per plot
-namespace: SweetpotatoTrait
-def: "Number of plants harvested" []
-synonym: "NOPH" EXACT []
-synonym: "PtHrv_Ct_plplot" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000885 ! evaluation of plants
-relationship: variable_of CO_331:0000304 ! number of plants harvested
-
-[Term]
-id: CO_331:0000680
-name: Storage root marketable yield weight computation tons per ha
-namespace: SweetpotatoTrait
-def: "Average commercial root weight evaluated in the harvest" []
-synonym: "ACRW" EXACT []
-synonym: "RtACRW_Cp_g" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000896 ! estimated marketable yield per hectare - method
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000308 ! average commercial root weight
-
-[Term]
-id: CO_331:0000681
-name: Storage root total yield computation tons per ha
-namespace: SweetpotatoTrait
-def: "Yield of total roots calculated after harvest" []
-synonym: "RtYPP_Cp_kpl" EXACT []
-synonym: "YPP" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000898 ! estimated yield of total roots per hectare - method
-relationship: variable_of CO_331:0000309 ! yield of total roots
-
-[Term]
-id: CO_331:0000682
-name: Storage root marketable yield fraction computation percent
-namespace: SweetpotatoTrait
-def: "Percentage of marketable roots after harvest" []
-synonym: "CI" EXACT []
-synonym: "RtCI_Cp_Pct" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000899 ! percentage of marketable - method
-relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000310 ! percentage of marketable roots
-
-[Term]
-id: CO_331:0000683
-name: Biomass yield weight computation tons per ha
-namespace: SweetpotatoTrait
-def: "Biomass yield" []
-synonym: "BIOM" EXACT []
-synonym: "BioYld_Cp" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
-relationship: variable_of CO_331:0000311 ! biomass yield
-
-[Term]
-id: CO_331:0000684
-name: Foliage total yield computation tons per hectare
-namespace: SweetpotatoTrait
-def: "Foliage total yield" []
-synonym: "FYTHA" EXACT []
-synonym: "VnFolYld_Cp_tha" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
-relationship: variable_of CO_331:0000312 ! foliage total yield
-
-[Term]
-id: CO_331:0000685
-name: Content of iron on dry weight basis measuring mg per kg
-namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "FeDW" EXACT []
-synonym: "RtFlsFe_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000103 ! iron content
-
-[Term]
-id: CO_331:0000686
-name: Content of zinc on dry weight basis measuring mg per kg
-namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "FeDW" EXACT []
-synonym: "RtFlsZn_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000106 ! zinc content
-
-[Term]
-id: CO_331:0000687
-name: Content of calcium on dry weight basis measuring mg per kg
-namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "CaDW" EXACT []
-synonym: "RtFlsCa_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
-relationship: variable_of CO_331:0000281 ! calcium content
-
-[Term]
-id: CO_331:0000688
-name: Content of magnesium on dry weight basis measuring mg per kg
-namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
-synonym: "MgDW" EXACT []
-synonym: "RtFlsMg_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
-relationship: variable_of CO_331:0000285 ! magnesium content
-
-[Term]
-id: CO_331:0000689
-name: Color of boiled roots estimating 0-3
-namespace: SweetpotatoTrait
-def: "Color of boiled roots. O = Orange, IO = Intermediate orange, DO = Deep orange" []
-synonym: "COLBR" EXACT []
-synonym: "RtCb_Et_0to3" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
-relationship: variable_of CO_331:0000942 ! rtscb 3 pt. scale
-relationship: variable_of CO_331:0000133 ! color of boiled roots
-
-[Term]
-id: CO_331:0000690
-name: Storage Root Surface Defects estimating 1-9
-namespace: SweetpotatoTrait
-def: "Storage Root Surface Defects. 0 = Absent, 1 = Alligator-like skin, 2 = Veins, 3 = Shallow horizontal constrictions, 4 = Deep horizontal constrictions, 5 =Shallow longitudinal grooves, 6 = Deep longitudinal grooves, 7 = Deep constrictions and deep grooves, 8 = Other" []
-synonym: "RtSDef_Et_1to9" EXACT []
-synonym: "RTSUR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000943 ! observation of storage root surface defects
-relationship: variable_of CO_331:0000944 ! rtssdef 9 pt. scale
-relationship: variable_of CO_331:0000326 ! storage root surface defects
-
-[Term]
-id: CO_331:0000691
-name: Storage Root Cortex Thickness estimating 1-9
-namespace: SweetpotatoTrait
-def: "Storage Root Cortex Thickness. 1 = Very thin (1 mm), 3 = Thin (1-2 mm), 5 = Intermediate (2-3 mm), 7 = Thick (3-4 mm), 9 = Very thick (>4 mm)" []
-synonym: "RTCOR" EXACT []
-synonym: "RtCThk_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000945 ! observation of storage root cortex thickness
-relationship: variable_of CO_331:0000946 ! rtscthi 5 pt. scale
-relationship: variable_of CO_331:0000327 ! storage root cortex thickness
-
-[Term]
-id: CO_331:0000692
-name: Flowering habit estimating 0-7
-namespace: SweetpotatoTrait
-def: "An behavior pattern of the plant to produce flowers. 0 = None, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
-synonym: "FLWHAB" EXACT []
-synonym: "FrHab_Et_0to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000947 ! observation of number flowers in the inflorescence
-relationship: variable_of CO_331:0000948 ! flrhab 4 pt. scale
-relationship: variable_of CO_331:0000328 ! flowering habit
-
-[Term]
-id: CO_331:0000693
-name: Flower size measuring cm
-namespace: SweetpotatoTrait
-def: "Flower size" []
-synonym: "FLESIZ" EXACT []
-synonym: "FrSiz_Ms_cm" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000949 ! measurement of flower length and width in cm
-relationship: variable_of CO_331:0000950 ! cm
-relationship: variable_of CO_331:0000329 ! flower size
-
-[Term]
-id: CO_331:0000694
-name: Shape of limb estimating 3-7
-namespace: SweetpotatoTrait
-def: "Shape of limb. 3 = Semi-stellate, 5= Pentagonal, 7 = Rounded" []
-synonym: "FLLMB" EXACT []
-synonym: "FrShL_Et_3to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000951 ! observation of shape limb in the flowers in the inflorescence
-relationship: variable_of CO_331:0000952 ! flrshl 3 pt. scale
-relationship: variable_of CO_331:0000330 ! shape of limb
-
-[Term]
-id: CO_331:0000695
-name: Equality of sepal length estimating 1-2
-namespace: SweetpotatoTrait
-def: "Equality of sepal length. 1 = Outer two shorter, 2 = Equal" []
-synonym: "FrSepEql_Et_1to2" EXACT []
-synonym: "SEPLEQ" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000953 ! equality of sepal length
-relationship: variable_of CO_331:0000954 ! sepeql 2 pt. scale
-relationship: variable_of CO_331:0000331 ! equality of sepal length
-
-[Term]
-id: CO_331:0000696
-name: Sepal veins counting number
-namespace: SweetpotatoTrait
-def: "Number of veins observed in the sepals" []
-synonym: "FrSepNVn_Ct_perSpl" EXACT []
-synonym: "SEPVNM" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000955 ! record the most frequent number in ten typical flowers
-relationship: variable_of CO_331:0000956 ! number
-relationship: variable_of CO_331:0000332 ! number of sepal veins
-
-[Term]
-id: CO_331:0000697
-name: Sepal shape estimating 1-9
-namespace: SweetpotatoTrait
-def: "Sepal shape. 1 = Ovate, 3 = Elliptic, 5 = Obovate, 7 = Oblong, 9 = Lanceolate" []
-synonym: "FrSepShp_Et_1to9" EXACT []
-synonym: "SEPSHP" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000957 ! observation of  sepal shape
-relationship: variable_of CO_331:0000958 ! sepshp 5 pt. scale
-relationship: variable_of CO_331:0000333 ! sepal shape
-
-[Term]
-id: CO_331:0000698
-name: Sepal apex estimating 1-7
-namespace: SweetpotatoTrait
-def: "Sepal apex. 1 = Acute, 3 = Obtuse, 5 = Acuminate, 7 = Caudate" []
-synonym: "FrSepApx_Et_1to7" EXACT []
-synonym: "SEPAPX" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000959 ! observation of sepal apex
-relationship: variable_of CO_331:0000960 ! sepapx 4 pt. scale
-relationship: variable_of CO_331:0000334 ! sepal apex
-
-[Term]
-id: CO_331:0000699
-name: Sepal pubescence estimating 0-7
-namespace: SweetpotatoTrait
-def: "Degree of hairiness registered in the sepals. 0 = Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
-synonym: "FrSepPub_Et_0to7" EXACT []
-synonym: "SEPPUB" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000961 ! observation of sepal pubescence
-relationship: variable_of CO_331:0000962 ! seppub 4 pt. scale
-relationship: variable_of CO_331:0000335 ! sepal pubescence
-
-[Term]
-id: CO_331:0000700
-name: Sepal color estimating 1-9
-namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the sepal. 1 = Green, 2 = Green with purple edge, 3 = Green with purple spots, 5 = Green with purple areas, 6 = Sorne sepals green, others purple, 9 = Totally pigrnented - dark purple" []
-synonym: "FrSepCol_Et_3to7" EXACT []
-synonym: "SEPCOL" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000963 ! observation of sepal color
-relationship: variable_of CO_331:0000964 ! sepcol 7 pt. scale
-relationship: variable_of CO_331:0000336 ! sepal color
-
-[Term]
-id: CO_331:0000701
-name: Color of stigma estimating 1-9
-namespace: SweetpotatoTrait
-def: "Color of stigma. 1 = White, 5 = Pale purple, 9 = Purple" []
-synonym: "FrStgCol_Et_1to9" EXACT []
-synonym: "STGCOL" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000965 ! observation of stigma color
-relationship: variable_of CO_331:0000966 ! stgcol 3 pt. scale
-relationship: variable_of CO_331:0000337 ! color of stigma
-
-[Term]
-id: CO_331:0000702
-name: Color of style estimating 1-9
-namespace: SweetpotatoTrait
-def: "Color of style. 1 = White, 3 = White with purple at the base, 5 = White with purple at the top, 7 = White with purple spots throughout, 9 = Purple" []
-synonym: "FrStyCol_Et_1to9" EXACT []
-synonym: "STYCOL" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000967 ! observation of style color
-relationship: variable_of CO_331:0000968 ! stycol 5 pt. scale
-relationship: variable_of CO_331:0000338 ! color of style
-
-[Term]
-id: CO_331:0000703
-name: Stigma exertion estimating 1-7
-namespace: SweetpotatoTrait
-def: "The relative position of the stigma as compared to the highest anther.. 1 = Inserted (shorter than longest anther), 3 = Same height as highest anther, 5 = Slighty exerted, 7 = Exerted (longer than longest anther)" []
-synonym: "FrStgExt_Et_1to7" EXACT []
-synonym: "STGEXT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000969 ! observation of stigma exertion
-relationship: variable_of CO_331:0000970 ! stgext 4 pt. scale
-relationship: variable_of CO_331:0000339 ! stigma exertion
-
-[Term]
-id: CO_331:0000704
-name: Seed capsule set estimating 0-7
-namespace: SweetpotatoTrait
-def: "Seed capsule set. 0 = None, 1 = Scarce, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
-synonym: "FrSdCp_Et_0to7" EXACT []
-synonym: "SEDCAP" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000971 ! observation of seed capsule set
-relationship: variable_of CO_331:0000972 ! sedcap 5 pt. scale
-relationship: variable_of CO_331:0000340 ! seed capsule set
-
-[Term]
-id: CO_331:0000705
-name: Storage root formation estimating 1-7
-namespace: SweetpotatoTrait
-def: "Arrangement of the storage roots on the underground stems.. 1 = Closed cluster, 3 = Open cluster, 5 = Dispersed, 7 = Very dispersed" []
-synonym: "RTFORM" EXACT []
-synonym: "RtFrm_Et_1to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000973 ! observation of storage root formation
-relationship: variable_of CO_331:0000974 ! strfor 4 pt. scale
-relationship: variable_of CO_331:0000341 ! storage root formation
-
-[Term]
-id: CO_331:0000706
-name: Storage root stalk estimating 0-7
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
-synonym: "RTSTFM" EXACT []
-synonym: "RtStk_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000975 ! observation of storage root stalk
-relationship: variable_of CO_331:0000976 ! strstk 6 pt. scale
-relationship: variable_of CO_331:0000342 ! storage root stalk
-
-[Term]
-id: CO_331:0000707
-name: Variability of storage root shape estimating 3-7
-namespace: SweetpotatoTrait
-def: "Variability of storage root shape. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
-synonym: "RTSHPV" EXACT []
-synonym: "RtShV_Et_3to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000977 ! observation of variability of storage root shape
-relationship: variable_of CO_331:0000978 ! vrtssh 3 pt. scale
-relationship: variable_of CO_331:0000343 ! variability of storage root shape
-
-[Term]
-id: CO_331:0000708
-name: Variability of storage root size estimating 3-7
-namespace: SweetpotatoTrait
-def: "Variability of storage root size. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
-synonym: "RTSIZV" EXACT []
-synonym: "RtSzV_Et_3to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000979 ! observation of variability of storage root size
-relationship: variable_of CO_331:0000980 ! vrtssiz 3 pt. scale
-relationship: variable_of CO_331:0000344 ! variability of storage root size
-
-[Term]
-id: CO_331:0000709
-name: Keeping quality of storage roots estimating 3-7
-namespace: SweetpotatoTrait
-def: "Keeping quality of storage roots. 3 = Poor, 5 = Medium, 7 = Good" []
-synonym: "RTKQL" EXACT []
-synonym: "RtKQl_Et_3to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000981 ! observation of keeping quality of storage roots
-relationship: variable_of CO_331:0000982 ! kqtyrts 3 pt. scale
-relationship: variable_of CO_331:0000345 ! keeping quality of storage roots
-
-[Term]
-id: CO_331:0000710
-name: Consistency of boiled storage root estimating 1-9
-namespace: SweetpotatoTrait
-def: "Consistency of boiled storage root. 1 = Watery, 2 = Extremely soft, 3 = Very soft, 4 = Soft, 5 = Slighty hard, 6 = Moderately hard, 7 = Hard, 8 = Very hard, 9 = Very hard and non-cooked" []
-synonym: "RTBCOLD" EXACT []
-synonym: "RtBlCu_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000983 ! observation of consistency of boiled storage root
-relationship: variable_of CO_331:0000984 ! cbolrts 9 pt. scale
-relationship: variable_of CO_331:0000346 ! consistency of boiled storage root
-
-[Term]
-id: CO_331:0000711
-name: Undesirable color of boiled storage root estimating 0-9
-namespace: SweetpotatoTrait
-def: "Undesirable color of boiled storage root. 0 = None, 1 = Sorne beige, 2 = Much beige, 3 = Slighty green or grey, 4 = Green, 5 = Grey, 6 = Beige and green, 7 = Beige and grey, 8 = Beige and purple, 9 = Purple" []
-synonym: "RTBCOLU" EXACT []
-synonym: "RtBlCd_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000985 ! observation of undesirable color of boiled storage root
-relationship: variable_of CO_331:0000986 ! ucolbrts 10 pt. scale
-relationship: variable_of CO_331:0000347 ! undesirable color of boiled storage root
-
-[Term]
-id: CO_331:0000712
-name: Reaction to drought estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response to damage by water restriction.. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "DROUGHT" EXACT []
-synonym: "RnDrt_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000987 ! visual estimation of the plant response to  limited water availability
-relationship: variable_of CO_331:0000988 ! rctdro 5 pt. scale
-relationship: variable_of CO_331:0000348 ! reaction to drought
-
-[Term]
-id: CO_331:0000713
-name: Reaction to flooding estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of plant to inundation by water of all or part of the plant. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FLOOD" EXACT []
-synonym: "RnFld_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000989 ! visual estimation of the plant response to  flooding (watering saturated soil)
-relationship: variable_of CO_331:0000990 ! rctflo 5 pt. scale
-relationship: variable_of CO_331:0000349 ! reaction to flooding
-
-[Term]
-id: CO_331:0000714
-name: Reaction to heat estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of a plant or plant part to damage by higher than normal temperatures. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "HEAT" EXACT []
-synonym: "RnHeat_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000991 ! visual estimation of the plant response to  hot season with night temperatures of more than 22°c
-relationship: variable_of CO_331:0000992 ! rctheat 5 pt. scale
-relationship: variable_of CO_331:0000350 ! reaction to heat
-
-[Term]
-id: CO_331:0000715
-name: Reaction to salinity estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSlt_Et_1to9" EXACT []
-synonym: "SALINITY" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000993 ! visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
-relationship: variable_of CO_331:0000994 ! rctsty 5 pt. scale
-relationship: variable_of CO_331:0000351 ! reaction to salinity
-
-[Term]
-id: CO_331:0000716
-name: Reaction to shade estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of plant to damage by shade. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnShd_Et_1to9" EXACT []
-synonym: "SHADE" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000995 ! visual estimation of the plant response to  shape
-relationship: variable_of CO_331:0000996 ! rctshd 5 pt. scale
-relationship: variable_of CO_331:0000352 ! reaction to shade
-
-[Term]
-id: CO_331:0000717
-name: Reaction to soil pH estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of plant to damage by ph soil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSph_Et_1to9" EXACT []
-synonym: "SOILPH" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000997 ! visual estimation of the plant response to  acid and heavy ph soil below 5
-relationship: variable_of CO_331:0000998 ! rctsph 5 pt. scale
-relationship: variable_of CO_331:0000353 ! reaction to soil
-
-[Term]
-id: CO_331:0000718
-name: Reaction to high soil temperature estimating 1-9
-namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSTp_Et_1to9" EXACT []
-synonym: "SOILTEMP" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001000 ! rctstp 5 pt. scale
-relationship: variable_of CO_331:0000999 ! visual estimation of the plant response to  hight soil temperature (40 °c)
-relationship: variable_of CO_331:0000354 ! reaction to high soil temperature
-
-[Term]
-id: CO_331:0000719
-name: Reaction to West Indian sweet potato weevil estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to West Indian sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnWISPW_Et_1to9" EXACT []
-synonym: "WISPWV" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001001 ! visual estimation of the plant response to  west indian sweet potato weevil
-relationship: variable_of CO_331:00001002 ! rcwispw 5 pt. scale
-relationship: variable_of CO_331:0000355 ! reaction to west indian sweet potato weevil
-
-[Term]
-id: CO_331:0000720
-name: Reaction to Striped sweet potato weevil estimating 1-9
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSSPW_Et_1to9" EXACT []
-synonym: "STSPWV" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001003 ! visual estimation of the plant response to  striped sweet potato weevil
-relationship: variable_of CO_331:00001004 ! rcsspw 5 pt. scale
-relationship: variable_of CO_331:0000356 ! reaction to striped sweet potato weevil
-
-[Term]
-id: CO_331:0000721
-name: Reaction to Sweet potato wire worms estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPWW_Et_1to9" EXACT []
-synonym: "SPWW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001005 ! visual estimation of the plant response to  sweet potato wire worms
-relationship: variable_of CO_331:00001006 ! rcspww 5 pt. scale
-relationship: variable_of CO_331:0000357 ! reaction to sweet potato wire worms
-
-[Term]
-id: CO_331:0000722
-name: Reaction to Wire worms estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnWW_Et_1to9" EXACT []
-synonym: "WIREWORMS" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001007 ! visual estimation of the plant response to  wire worms
-relationship: variable_of CO_331:00001008 ! rcww 5 pt. scale
-relationship: variable_of CO_331:0000358 ! reaction to wire worms
-
-[Term]
-id: CO_331:0000723
-name: Reaction to Sweet potato flea beetles estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPFB_Et_1to9" EXACT []
-synonym: "SPFB" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001009 ! visual estimation of the plant response to  sweet potato flea beetles
-relationship: variable_of CO_331:00001010 ! rcspfb 5 pt. scale
-relationship: variable_of CO_331:0000359 ! reaction to sweet potato flea beetles
-
-[Term]
-id: CO_331:0000724
-name: Reaction to flea beetles estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FLEABEETLE" EXACT []
-synonym: "RnFB_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001011 ! visual estimation of the plant response to  flea beetles
-relationship: variable_of CO_331:00001012 ! rcfb 5 pt. scale
-relationship: variable_of CO_331:0000360 ! reaction to flea beetles
-
-[Term]
-id: CO_331:0000725
-name: Reaction to Sweet potato leaf beetles estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato leaf beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPLB_Et_1to9" EXACT []
-synonym: "SPFB" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001013 ! visual estimation of the plant response to  sweet potato leaf beetles
-relationship: variable_of CO_331:00001014 ! rcsplb 5 pt. scale
-relationship: variable_of CO_331:0000361 ! reaction to sweet potato leaf beetles
-
-[Term]
-id: CO_331:0000726
-name: Reaction to Beetles estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BEETLES" EXACT []
-synonym: "RnBTL_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001015 ! visual estimation of the plant response to  beetles
-relationship: variable_of CO_331:00001016 ! rcbtl 5 pt. scale
-relationship: variable_of CO_331:0000362 ! reaction to beetles
-
-[Term]
-id: CO_331:0000727
-name: Reaction to Grubworm estimating 1-9
-namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Grub worm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "GRUBW" EXACT []
-synonym: "RnGrbW_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001017 ! visual estimation of the root response to  grub worm
-relationship: variable_of CO_331:00001018 ! rcgrbw 5 pt. scale
-relationship: variable_of CO_331:0000363 ! reaction to grubworm
-
-[Term]
-id: CO_331:0000728
-name: Reaction to Hornworm estimating 1-9
-namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Hornworm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "HORNW" EXACT []
-synonym: "RnHrnw_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001019 ! visual estimation of the root response to  hornworm
-relationship: variable_of CO_331:00001020 ! rchrnw 5 pt. scale
-relationship: variable_of CO_331:0000364 ! reaction to hornworm
-
-[Term]
-id: CO_331:0000729
-name: Reaction to Aphids estimating 1-9
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Aphis. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "APHIDS" EXACT []
-synonym: "RnAph_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001021 ! visual estimation of the plant response to  aphis
-relationship: variable_of CO_331:00001022 ! rcaph 5 pt. scale
-relationship: variable_of CO_331:0000365 ! reaction to aphids
-
-[Term]
-id: CO_331:0000730
-name: Reaction to Sweet potato white fly estimating 1-9
-namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPWF_Et_1to9" EXACT []
-synonym: "SPWF" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001023 ! visual estimation of the plant response to  sweet potato white fly
-relationship: variable_of CO_331:00001024 ! rcspwf 5 pt. scale
-relationship: variable_of CO_331:0000366 ! reaction to sweet potato white fly
-
-[Term]
-id: CO_331:0000731
-name: Reaction to Sweet potato moth estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPMth_Et_1to9" EXACT []
-synonym: "SPMOTH" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001025 ! visual estimation of the plant response to  sweet potato moth
-relationship: variable_of CO_331:00001026 ! rcspmth 5 pt. scale
-relationship: variable_of CO_331:0000367 ! reaction to sweet potato moth
-
-[Term]
-id: CO_331:0000732
-name: Reaction to Moth estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "MOTH" EXACT []
-synonym: "RnMth_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001027 ! visual estimation of the plant response to  moth
-relationship: variable_of CO_331:00001028 ! rcmth 5 pt. scale
-relationship: variable_of CO_331:0000368 ! reaction to moth
-
-[Term]
-id: CO_331:0000733
-name: Reaction to Sweet potato stem borer estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato stem borer. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPSB_Et_1to9" EXACT []
-synonym: "SPSB" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001029 ! visual estimation of the plant response to  sweet potato stem borer
-relationship: variable_of CO_331:00001030 ! rcspsb 5 pt. scale
-relationship: variable_of CO_331:0000369 ! reaction to sweet potato stem borer
-
-[Term]
-id: CO_331:0000734
-name: Reaction to Other insects estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Other insects. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "INSECTS" EXACT []
-synonym: "RnIns_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001031 ! visual estimation of the plant response to  other insects
-relationship: variable_of CO_331:00001032 ! rcins 5 pt. scale
-relationship: variable_of CO_331:0000370 ! reaction to other insects
-
-[Term]
-id: CO_331:0000735
-name: Reaction to Reniform nematode estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Reniform nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RENIN" EXACT []
-synonym: "RnRFN_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001033 ! visual estimation of the root response to  reniform nematode
-relationship: variable_of CO_331:00001034 ! rcrfn 5 pt. scale
-relationship: variable_of CO_331:0000371 ! reaction to reniform nematode
-
-[Term]
-id: CO_331:0000736
-name: Reaction to Sting nematode estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sting nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnStN_Et_1to9" EXACT []
-synonym: "STINGN" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001035 ! visual estimation of the root response to  sting nematode
-relationship: variable_of CO_331:00001036 ! rcstn 5 pt. scale
-relationship: variable_of CO_331:0000372 ! reaction to sting nematode
-
-[Term]
-id: CO_331:0000737
-name: Reaction to Brown ring rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Brown ring rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BRROT" EXACT []
-synonym: "RnBRR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001037 ! visual estimation of the root response to  brown ring rot
-relationship: variable_of CO_331:00001038 ! rcbrr 5 pt. scale
-relationship: variable_of CO_331:0000373 ! reaction to brown ring rot
-
-[Term]
-id: CO_331:0000738
-name: Reaction to Root lesion nematode estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Root lesion nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnRLN_Et_1to9" EXACT []
-synonym: "ROOTLN" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
-relationship: variable_of CO_331:00001040 ! rcrln 5 pt. scale
-relationship: variable_of CO_331:0000374 ! reaction to root lesion nematode
-
-[Term]
-id: CO_331:0000739
-name: Reaction to other nematodes estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to other nematodes. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "NEMATODS" EXACT []
-synonym: "RnON_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
-relationship: variable_of CO_331:00001041 ! rcon 5 pt. scale
-relationship: variable_of CO_331:0000375 ! reaction to other nematodes
-
-[Term]
-id: CO_331:0000740
-name: Reaction to Wilt rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Wilt rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnWR_Et_1to9" EXACT []
-synonym: "WILT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001042 ! visual estimation of the root response to  wilt rot
-relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
-relationship: variable_of CO_331:0000376 ! reaction to wilt rot
-
-[Term]
-id: CO_331:0000741
-name: Reaction to Fusarium surface rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium surface rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FUSSURF" EXACT []
-synonym: "RnFRS_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001044 ! visual estimation of the root response to  fusarium surface rot
-relationship: variable_of CO_331:00001045 ! rcfrs 5 pt. scale
-relationship: variable_of CO_331:0000377 ! reaction to fusarium surface rot
-
-[Term]
-id: CO_331:0000742
-name: Reaction to Fusarium root rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FUSROOT" EXACT []
-synonym: "RnFRR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001046 ! visual estimation of the root response to  fusarium root rot
-relationship: variable_of CO_331:00001047 ! rcfrr 5 pt. scale
-relationship: variable_of CO_331:0000378 ! reaction to fusarium root rot
-
-[Term]
-id: CO_331:0000743
-name: Reaction to Sclerotial blight and circular spot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sclerotial blight and circular spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSBC_Et_1to9" EXACT []
-synonym: "SCLBLT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001048 ! visual estimation of the root response to  sclerotial blight and circular spot
-relationship: variable_of CO_331:00001049 ! rcsbc 5 pt. scale
-relationship: variable_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
-
-[Term]
-id: CO_331:0000744
-name: Reaction to Black rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BLACKROT" EXACT []
-synonym: "RnBR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001050 ! visual estimation of the root response to  black rot
-relationship: variable_of CO_331:00001051 ! rcbr 5 pt. scale
-relationship: variable_of CO_331:0000380 ! reaction to black rot
-
-[Term]
-id: CO_331:0000745
-name: Reaction to Scurf estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Scurf. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnScrf_Et_1to9" EXACT []
-synonym: "SCURF" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001052 ! visual estimation of the root response to  scurf
-relationship: variable_of CO_331:00001053 ! rcscrf 5 pt. scale
-relationship: variable_of CO_331:0000381 ! reaction to scurf
-
-[Term]
-id: CO_331:0000746
-name: Reaction to Soft rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Soft rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSR_Et_1to9" EXACT []
-synonym: "SOFTROT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001054 ! appearance of roots in response soft rot
-relationship: variable_of CO_331:00001055 ! rcsr 5 pt. scale
-relationship: variable_of CO_331:0000382 ! reaction to soft rot
-
-[Term]
-id: CO_331:0000747
-name: Reaction to Java black rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Java black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "JAVABR" EXACT []
-synonym: "RnJBR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001056 ! appearance of roots in response java black rot
-relationship: variable_of CO_331:00001057 ! rcjbr 5 pt. scale
-relationship: variable_of CO_331:0000383 ! reaction to java black rot
-
-[Term]
-id: CO_331:0000748
-name: Reaction to Diaporthe dry rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Diaporthe dry rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "DIAPORTHE" EXACT []
-synonym: "RnDDR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
-relationship: variable_of CO_331:00001059 ! rcddr 5 pt. scale
-relationship: variable_of CO_331:0000384 ! reaction to diaporthe dry rot
-
-[Term]
-id: CO_331:0000749
-name: Reaction to Scab estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Scab. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnScb_Et_1to9" EXACT []
-synonym: "SCAB" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001060 ! visual estimation of the plant response to  scab
-relationship: variable_of CO_331:00001061 ! rcscb 5 pt. scale
-relationship: variable_of CO_331:0000385 ! reaction to scab
-
-[Term]
-id: CO_331:0000750
-name: Reaction to leaf spot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to leaf spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "LEAFSPOT" EXACT []
-synonym: "RnLS_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001062 ! visual estimation of the plant response to  leaf spot
-relationship: variable_of CO_331:00001063 ! rcls 5 pt. scale
-relationship: variable_of CO_331:0000386 ! reaction to leaf spot
-
-[Term]
-id: CO_331:0000751
-name: Reaction to White rust estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to White rust. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnWR_Et_1to9" EXACT []
-synonym: "WHITERUST" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
-relationship: variable_of CO_331:00001064 ! visual estimation of the plant response to  white rust
-relationship: variable_of CO_331:0000387 ! reaction to white rust
-
-[Term]
-id: CO_331:0000752
-name: Reaction to Foot rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Foot rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FOOTROT" EXACT []
-synonym: "RnFR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001065 ! visual estimation of the plant response to  foot rot
-relationship: variable_of CO_331:00001066 ! rcfr 5 pt. scale
-relationship: variable_of CO_331:0000388 ! reaction to foot rot
-
-[Term]
-id: CO_331:0000753
-name: Reaction to Charcoal rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Charcoal rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "CHARCROT" EXACT []
-synonym: "RnCR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001067 ! visual estimation of the plant response to  charcoal rot
-relationship: variable_of CO_331:00001068 ! rccr 5 pt. scale
-relationship: variable_of CO_331:0000389 ! reaction to charcoal rot
-
-[Term]
-id: CO_331:0000754
-name: Reaction to Other fungi estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Other fungi. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "FUNGI" EXACT []
-synonym: "RnOF_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001069 ! visual estimation of the plant response to  other fungi
-relationship: variable_of CO_331:00001070 ! rcof 5 pt. scale
-relationship: variable_of CO_331:0000390 ! reaction to other fungi
-
-[Term]
-id: CO_331:0000755
-name: Reaction to Pox or soil rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Pox or soil rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "POXROT" EXACT []
-synonym: "RnPSR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001071 ! visual estimation of the plant response to  pox or soil rot
-relationship: variable_of CO_331:00001072 ! rcpsr 5 pt. scale
-relationship: variable_of CO_331:0000391 ! reaction to pox or soil rot
-
-[Term]
-id: CO_331:0000756
-name: Reaction to Bacterial stem and root rot estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Bacterial stem and root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnBSRt_Et_1to9" EXACT []
-synonym: "STEMROT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001073 ! visual estimation of the plant response to  bacterial stem and root rot
-relationship: variable_of CO_331:00001074 ! rcbsrt 5 pt. scale
-relationship: variable_of CO_331:0000392 ! reaction to bacterial stem and root rot
-
-[Term]
-id: CO_331:0000757
-name: Reaction to Bacterial wilt estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Bacterial wilt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BACWILT" EXACT []
-synonym: "RnBW_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001075 ! visual estimation of the plant response to  bacterial wilt
-relationship: variable_of CO_331:00001076 ! rcbw 5 pt. scale
-relationship: variable_of CO_331:0000393 ! reaction to bacterial wilt
-
-[Term]
-id: CO_331:0000758
-name: Reaction to Other bacteria estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Other bacteria. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BACTERIA" EXACT []
-synonym: "RnOB_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001077 ! visual estimation of the plant response to  other bacteria
-relationship: variable_of CO_331:00001078 ! rcob 5 pt. scale
-relationship: variable_of CO_331:0000394 ! reaction to other bacteria
-
-[Term]
-id: CO_331:0000759
-name: Reaction to Sweet potato feathery mottle virus (SPMV)
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato feathery mottle virus (SPMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPMV_Et_1to9" EXACT []
-synonym: "SPMV" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001079 ! visual estimation of the plant response to  sweet potato feathery mottle virus
-relationship: variable_of CO_331:00001080 ! rcspmv 5 pt. scale
-relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus (spmv)
-
-[Term]
-id: CO_331:0000760
-name: Reaction to Sweet potato mild mottle virus (SPMMV) estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato mild mottle virus (SPMMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPMMV_Et_1to9" EXACT []
-synonym: "SPMMV" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001081 ! visual estimation of the plant response to  sweet potato mild mottle virus
-relationship: variable_of CO_331:00001082 ! rcspmmv 5 pt. scale
-relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle virus (spmmv)
-
-[Term]
-id: CO_331:0000761
-name: Reaction to Sweet potato vein mottle virus (SPVMV) estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato vein mottle virus (SPVMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPVMV_Et_1to9" EXACT []
-synonym: "SPVMV" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001083 ! visual estimation of the plant response to  sweet potato vein mottle virus
-relationship: variable_of CO_331:00001084 ! rcspvmv 5 pt. scale
-relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle virus (spvmv)
-
-[Term]
-id: CO_331:0000762
-name: Reaction to Sweet potato virus disease complex (SPVD complex) estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato virus disease complex (SPVD complex). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnSPVD_Et_1to9" EXACT []
-synonym: "SPVD" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001085 ! visual estimation of the plant response to  sweet potato virus disease complex
-relationship: variable_of CO_331:00001086 ! rcspvd 5 pt. scale
-relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus disease complex (spvd complex)
-
-[Term]
-id: CO_331:0000763
-name: Reaction to Other virus estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Other virus. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "RnOV_Et_1to9" EXACT []
-synonym: "VIRUS" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001087 ! visual estimation of the plant response to  other virus
-relationship: variable_of CO_331:00001088 ! rcov 5 pt. scale
-relationship: variable_of CO_331:0000399 ! reaction to other virus
-
-[Term]
-id: CO_331:0000764
-name: Reaction to Witches broom estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Witches broom. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "BROOM" EXACT []
-synonym: "RnWB_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001089 ! visual estimation of the plant response to  witches broom
-relationship: variable_of CO_331:00001090 ! rcwb 5 pt. scale
-relationship: variable_of CO_331:0000400 ! reaction to witches broom
-
-[Term]
-id: CO_331:0000765
-name: Reaction to Other mycoplasma estimating 1-9
-namespace: SweetpotatoTrait
-def: "Reaction to Other mycoplasma. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
-synonym: "MYCOPLASMA" EXACT []
-synonym: "RnOM_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001091 ! visual estimation of the plant response to  to other mycoplasma
-relationship: variable_of CO_331:00001092 ! rcom 5 pt. scale
-relationship: variable_of CO_331:0000401 ! reaction to other mycoplasma
-
-[Term]
-id: CO_331:0000766
-name: Total sugar content estimating 1-9
-namespace: SweetpotatoTrait
-def: "Total sugar content" []
-synonym: "RtTSgC_Et_1to9" EXACT []
-synonym: "TOTSUG" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001094 ! rttsgc
-relationship: variable_of CO_331:0000402 ! total sugar content
-
-[Term]
-id: CO_331:0000767
-name: Habitus measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of plant" []
-synonym: "FOTHAB" EXACT []
-synonym: "PtHbt_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001095 ! plant picture
-relationship: variable_of CO_331:0000403 ! appearance of plant
-
-[Term]
-id: CO_331:0000768
-name: Flower measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of flower" []
-synonym: "FOTFLW" EXACT []
-synonym: "FrCol_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001096 ! flower picture
-relationship: variable_of CO_331:0000404 ! appearance of flower
-
-[Term]
-id: CO_331:0000769
-name: Root measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of roots" []
-synonym: "FOTROT" EXACT []
-synonym: "RtCol_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001097 ! root picture
-relationship: variable_of CO_331:0000405 ! appearance of roots
-
-[Term]
-id: CO_331:0000770
-name: Seeds measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of seeds" []
-synonym: "FOTSDS" EXACT []
-synonym: "FrSds_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001098 ! seeds picture
-relationship: variable_of CO_331:0000406 ! appearance of seeds
-
-[Term]
-id: CO_331:0000771
-name: Leaf measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of leaves" []
-synonym: "FOTLEA" EXACT []
-synonym: "Lf_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001099 ! leaf picture
-relationship: variable_of CO_331:0000407 ! appearance of leaves
-
-[Term]
-id: CO_331:0000772
-name: Herbarium measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of hearbarium" []
-synonym: "FOTHRB" EXACT []
-synonym: "PtHrb_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001099 ! leaf picture
-relationship: variable_of CO_331:0000408 ! appearance of hearbarium
-
-[Term]
-id: CO_331:0000774
-name: Storage Root Shape primary estimating 1-8
-namespace: SweetpotatoTrait
-def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
-synonym: "RTSHP1" EXACT []
-synonym: "RtShpP_Et_1to8" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001100 ! observation of most frequennt storage root shape
-relationship: variable_of CO_331:00001101 ! rtshpp 8 pt. scale
-relationship: variable_of CO_331:0000069 ! storage root shape (primary)
-
-[Term]
-id: CO_331:0000775
-name: Storage Root Shape secondary estimating 1-8
-namespace: SweetpotatoTrait
-def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
-synonym: "RTSHP2" EXACT []
-synonym: "RtShpS_Et_1to8" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001102 ! observation of 2nd most frequent storage root shape
-relationship: variable_of CO_331:00001103 ! rtshps 8 pt. scale
-relationship: variable_of CO_331:0000441 ! storage root shape (secondary)
-
-[Term]
-id: CO_331:0000776
-name: Storage Root Shape Uniformity estimating 1-9
-namespace: SweetpotatoTrait
-def: "Storage Root Shape uniformity within a single plant or plot. 1 = Very Poor, 2 = Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
-synonym: "RTSHPU" EXACT []
-synonym: "RtShpU_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001104 ! observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
-relationship: variable_of CO_331:00001105 ! rtshpu 9 pt. scale
-relationship: variable_of CO_331:0000409 ! storage root shape uniformity
-
-[Term]
-id: CO_331:0000777
-name: Storage Root Stalk estimating 0-9
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
-synonym: "RTSTALK" EXACT []
-synonym: "RtStlk_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001107 ! rtstlk 6 pt. scale
-relationship: variable_of CO_331:0000410 ! storage root stalk
-
-[Term]
-id: CO_331:0000778
-name: Storage Root Attachement estimating 0-9
-namespace: SweetpotatoTrait
-def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off. 1 = Very tight, 3 = Tight, 5 = Moderate, 6.0, 7 = Light, 8.0, 9 = Very Light" []
-synonym: "RtAtt_Et_1to9" EXACT []
-synonym: "RTATTACH" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001108 ! rtatt 9 pt. scale
-relationship: variable_of CO_331:0000411 ! storage root attachement
-
-[Term]
-id: CO_331:0000779
-name: Length to Diameter Ratio computation
-namespace: SweetpotatoTrait
-def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
-synonym: "LDR" EXACT []
-synonym: "RtLDR_Cp_ratio" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
-relationship: variable_of CO_331:0000412 ! length to diameter ratio of roots
-
-[Term]
-id: CO_331:0000780
-name: Skin Color estimating 1-12
-namespace: SweetpotatoTrait
-def: "The most representative skin color observed is recorded. 1 = White, 2 = Cream, 3 = Yellow, 4 = Tan, 5 = Orange, 6 = Rose, 7 = Pink, 8 = Red, 9 = Light Purple, 10 = Purple, 11 = Dark Purple, 12 = Brown" []
-synonym: "RtSknCol_Et_1to12" EXACT []
-synonym: "SKINCOLOR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001110 ! rtskncol 12 pt. scale
-relationship: variable_of CO_331:0000413 ! skin color of roots
-
-[Term]
-id: CO_331:0000781
-name: Skin Texture estimating 1-9
-namespace: SweetpotatoTrait
-def: "Storage root skin feel, appearance, or consistency by visual observation and touch. 1 = Very Rough, 2.0, 3 = Moderately Rough, 4.0, 5 = Moderately Smooth, 6.0, 7 = Smooth, 8.0, 9 = Very Smooth" []
-synonym: "RTSKNTEX" EXACT []
-synonym: "RtSknTxt_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001111 ! rtskntxt 9 pt. scale
-relationship: variable_of CO_331:0000414 ! skin texture of roots
-
-[Term]
-id: CO_331:0000782
-name: Flesh Color Carotenoids estimating 0-4
-namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = White, 0.5, 1 = Cream, 2 = Yellow, 2.5 = Yellow with orange, 2.75 = Orange with yellow, 3 = Orange, 3.5 = Dark Orange, 4 = Very Dark Orange" []
-synonym: "RTFLESH1" EXACT []
-synonym: "RtFlsColC_Et_0to4" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001112 ! rtflscolc 9 pt. scale
-relationship: variable_of CO_331:0000415 ! flesh color (carotenoids)
-
-[Term]
-id: CO_331:0000783
-name: Flesh Color Anthocyanins estimating 0-4
-namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = No Anthocyanins, 0.5, 1 = Light Purple, 1.5, 2 = Moderate Purple, 2.5, 3 = Dark Purple, 3.5, 4 = Very Dark Purple" []
-synonym: "RTFLESH2" EXACT []
-synonym: "RtFlsColA_Et_0to4" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001113 ! rtflscola 9 pt. scale
-relationship: variable_of CO_331:0000416 ! flesh color (anthocyanins)
-
-[Term]
-id: CO_331:0000784
-name: Adventitious buds estimating 1-9
-namespace: SweetpotatoTrait
-def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface. 1 = Very Deep, 3 = Deep, 5 = Moderate, 7 = Shallow, 9 = Very Shallow" []
-synonym: "EYES" EXACT []
-synonym: "RtAdvB_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001114 ! rtadvb 5 pt. scale
-relationship: variable_of CO_331:0000417 ! deep of eyes of roots
-
-[Term]
-id: CO_331:0000785
-name: Lenticels estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall assessment of visible lenticels at the storage root interface. 1 = Very Prominent, 2.0, 3 = Prominent, 4.0, 5 = Moderate, 6.0, 7 = Few, 8.0, 9 = None" []
-synonym: "LENTS" EXACT []
-synonym: "RtLtcl_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001115 ! ses 9 pt. scale
-relationship: variable_of CO_331:0000418 ! number of lenticels
-
-[Term]
-id: CO_331:0000786
-name: Streptomyces Soil Rot estimating 0-5
-namespace: SweetpotatoTrait
-def: "Streptomyces ipomoeae symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
-synonym: "RnPSR_Et_0to5" EXACT []
-synonym: "SSR" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001116 ! observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
-relationship: variable_of CO_331:00001117 ! ses 6 pt. scale
-relationship: variable_of CO_331:0000419 ! reaction to streptomyces soil rot
-
-[Term]
-id: CO_331:0000787
-name: Root Knot Nematode  Meloidogyne estimating 0-5
-namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
-synonym: "RKN" EXACT []
-synonym: "RnMgRKN_Et_0to5" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
-relationship: variable_of CO_331:00001119 ! rcmgrkn  6 pt. scale
-relationship: variable_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
-
-[Term]
-id: CO_331:0000788
-name: Root Knot Nematode  Meloidogyne incognita estimating 0-7
-namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation. 1= highly resistant (HR), 2= Resistant (1-10%), 3 = Moderate resistant (MR)(11-25%), 4 = Susceptible (S) (26-75%), 5= (HS) Highly susceptible (>76%)" []
-synonym: "RKN, MELOI" EXACT []
-synonym: "RnMgIRKN_Et_0to7" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
-relationship: variable_of CO_331:00001120 ! rcmigrkn  5 pt. scale
-relationship: variable_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
-
-[Term]
-id: CO_331:0000789
-name: Reaction to Fusarium Wilt estimating 0-5
-namespace: SweetpotatoTrait
-def: "Reaction to Fusarium oxysporum batatas symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
-synonym: "FWILT" EXACT []
-synonym: "RnFR_Et_0to5" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001121 ! visual estimation of the roots response to  fusarium oxysporum
-relationship: variable_of CO_331:00001122 ! rnfr 6 pt. scale
-relationship: variable_of CO_331:0000422 ! reaction to fusarium oxysporum
-
-[Term]
-id: CO_331:0000790
-name: Storage Root Defects primary estimating 1-18
-def: "Type and/or name of primary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
-namespace: SweetpotatoTrait
-synonym: "RTDEF1" EXACT []
-synonym: "RtDefP_Et_1to18" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000423 ! storage root defects (primary)
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001123 ! rtdam 14 pt. scale
-
-
-[Term]
-id: CO_331:0000791
-name: Relative Storage Root Yield estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield. 1 = Very Poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = Excellent" []
-synonym: "RTRYIELD" EXACT []
-synonym: "RtYldR_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001124 ! rtyldr 5 pt. scale
-relationship: variable_of CO_331:0000424 ! relative storage root yield
-
-[Term]
-id: CO_331:0000792
-name: Yield as percent of check
-namespace: SweetpotatoTrait
-def: "Overall calculation of relative root yield" []
-synonym: "RtYldChk_Cp_pct" EXACT []
-synonym: "RTYLDPCT" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
-relationship: variable_of CO_331:0000425 ! storage root yield relative to check
-
-[Term]
-id: CO_331:0000793
-name: Storage Root Appearance estimating 1-9
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield appearance. 1 = Very Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
-synonym: "RTAPPEAR" EXACT []
-synonym: "RtApr_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
-relationship: variable_of CO_331:0000426 ! storage root appearance
-
-[Term]
-id: CO_331:0000794
-name: Season maturity estimating 0-4
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season. 0 = Late Season, 1 = Mid to Late Season, 2 = Mid Season, 3 = Early to Mid Season, 4 = Early Season" []
-synonym: "PtMtSs_Et_0to4" EXACT []
-synonym: "SEASON" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001125 ! ptmtss 5 pt. scale
-relationship: variable_of CO_331:0000427 ! growing season
-
-[Term]
-id: CO_331:0000795
-name: Amylose content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Amylose content in sweetpotato" []
-synonym: "AMY" EXACT []
-synonym: "RtFlsAmy_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001126 ! amylose - method
-relationship: variable_of CO_331:00001127 ! g/100 g fw
-relationship: variable_of CO_331:0000428 ! amylose content
-
-[Term]
-id: CO_331:0000796
-name: Asparagine content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "peonidin content of purple flesh sweetpotato" []
-synonym: "ASP" EXACT []
-synonym: "RtFlsAsp_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001128 ! asparagine - method
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:0000429 ! asparagine content
-
-[Term]
-id: CO_331:0000797
-name: Cyanidin content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
-synonym: "CYAN" EXACT []
-synonym: "RtFlsCya_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001130 ! cyanidin - method
-relationship: variable_of CO_331:0000430 ! cyanidin content
-
-[Term]
-id: CO_331:0000798
-name: Total Monomeric Anthocyanin content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
-synonym: "RtFlsAntM_Ms_mgpergDW" EXACT []
-synonym: "TMA" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001131 ! total monomeric anthocyanins - method
-relationship: variable_of CO_331:0000431 ! total monomeric anthocyanin content
-
-[Term]
-id: CO_331:0000799
-name: Peonidin content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Peonidin content of purple flesh sweetpotato" []
-synonym: "PEO" EXACT []
-synonym: "RtFlsPeo_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001132 ! peonidin - method
-relationship: variable_of CO_331:0000432 ! peonidin content
-
-[Term]
-id: CO_331:0000800
-name: Anthocyanin content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Anthocyanin content of purple flesh sweetpotato" []
-synonym: "ANTHO" EXACT []
-synonym: "RtFlsAnt_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001133 ! anthocyanin - method
-relationship: variable_of CO_331:0000433 ! anthocyanin content
-
-[Term]
-id: CO_331:0000801
-name: Phenol content measuring  mg per g DW
-namespace: SweetpotatoTrait
-def: "Phenol content of purple flesh sweetpotato" []
-synonym: "PHEN" EXACT []
-synonym: "RtFlsPhe_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001134 ! phenol - method
-relationship: variable_of CO_331:0000434 ! phenol content
-
-[Term]
-id: CO_331:0000802
-name: Node number counting nodes per vine
-namespace: SweetpotatoTrait
-def: "Nodes per vine" []
-synonym: "VINTND" EXACT []
-synonym: "VnNds_Ct_pervine" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001135 ! nodes per vine evaluation
-relationship: variable_of CO_331:00001136 ! nodes/plant
-relationship: variable_of CO_331:0000435 ! nodes per vine
-
-[Term]
-id: CO_331:0000803
-name: Total number of leaves counting per plant
-namespace: SweetpotatoTrait
-def: "Leaves per plant" []
-synonym: "LEFTPP" EXACT []
-synonym: "PtLvs_ct_perplant" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001137 ! leaves per plant evaluation
-relationship: variable_of CO_331:00001138 ! leaf/plant
-relationship: variable_of CO_331:0000436 ! leaves per plant
-
-[Term]
-id: CO_331:0000804
-name: Leaf color by picture measuring by picture using method
-namespace: SweetpotatoTrait
-def: "Color of leave" []
-synonym: "LEFCPC" EXACT []
-synonym: "LfCol_Ms_image" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001139 ! color of leave picture
-relationship: variable_of CO_331:00001140 ! picture
-relationship: variable_of CO_331:0000437 ! color of leave
-
-[Term]
-id: CO_331:0000805
-name: Millipede damage estimating 1-9
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by Millipede in roots. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
-synonym: "MILLDAM" EXACT []
-synonym: "RtsMillDam_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001141 ! rtsmilldam 5 pt. scale
-relationship: variable_of CO_331:0000438 ! millipede damage
-
-[Term]
-id: CO_331:0000806
-name: Alcidodes sp. damage estimating 1-9
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by Alcidodes sp, causes crown enlargement/galling or death by girdling. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
-synonym: "ALCDAM" EXACT []
-synonym: "RtAlcDam_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001142 ! rtalcdam 5 pt. scale
-relationship: variable_of CO_331:0000883 ! weevil damage evaluation
-relationship: variable_of CO_331:0000439 ! alcidodes sp. damage
-
-[Term]
-id: CO_331:0000807
-name: Soil insect damage estimating 1-9
-namespace: SweetpotatoTrait
-def: "Observation of damage caused by soil insect. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
-synonym: "INSDAM" EXACT []
-synonym: "RtSInsDam_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:00001143 ! soils insect evaluation
-relationship: variable_of CO_331:00001144 ! rtsinsdam  5 pt. scale
-relationship: variable_of CO_331:0000440 ! soil insect damage
-
-[Term]
-id: CO_331:0000811
-name: storage root defects (secondary)
-def: "Type and/or name of secondary visible storage root defect" []
-synonym: "RtDefS" EXACT []
-is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: C. Yencho
-creation_date: 2016-11-30T20:41:53Z
-
-[Term]
-id: CO_331:0000810
-name: Storage Root Defects secondary estimating 1-18
-def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
-synonym: "RTDEF2" EXACT []
-synonym: "RtDefS_Et_1to18" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
-created_by: C. Yencho
-creation_date: 2016-11-30T20:44:25Z
-
-[Term]
-id: CO_331:0000809
-name: Storage root total marketable yield weight computation tons per ha
-def: "Marketable root yield" []
-synonym: "RtCYld_Cp_tha" EXACT []
-synonym: "RYTHA" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000307 ! marketable root yield
-created_by: W. Grueneberg
-creation_date: 2016-11-30T21:23:23Z
-
-[Term]
-id: CO_331:0000808
-name: overall storage root disease symptoms
-def: "Overall storage root disease symptoms evaluation" []
-synonym: "RtDSm" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
-creation_date: 2016-12-01T02:33:40Z
-
-[Term]
-id: CO_331:0000600
-name: Overall storage root disease symptoms estimating 1-9
-def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
-synonym: "DISEASE" EXACT []
-synonym: "RtDSm_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variable
-relationship: variable_of CO_331:0000815   ! overall storage root disease symptoms
-created_by: C. Yencho
-creation_date: 2016-12-01T04:02:09Z
-
-[Term]
-id: CO_331:1000004
-name: Abiotic_stress_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
-[Term]
-id: CO_331:1000005
-name: Biotic_stress_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
-[Term]
-id: CO_331:1000007
-name: Quality_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
-[Term]
-id: CO_331:1000008
-name: Agronomic_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
-[Term]
-id: CO_331:1000009
-name: Biochemical_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
-[Term]
-id: CO_331:1000010
-name: Morphological_trait
-is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
-
 [Typedef]
 id: method_of
 name: method_of
-
 
 [Typedef]
 id: scale_of
@@ -6976,3 +6526,4 @@ name: scale_of
 [Typedef]
 id: variable_of
 name: variable_of
+

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -870,27 +870,6 @@ is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 
 [Term]
-id: CO_331:00001112:2.5
-name: Yellow with orange
-namespace: SweetpotatoScale
-synonym: "2.5" EXACT []
-is_a: CO_331:00001112 ! rtflscolc 9 pt. scale
-
-[Term]
-id: CO_331:00001112:2.75
-name: Orange with yellow
-namespace: SweetpotatoScale
-synonym: "2.75" EXACT []
-is_a: CO_331:00001112 ! rtflscolc 9 pt. scale
-
-[Term]
-id: CO_331:00001112:3.5
-name: Dark Orange
-namespace: SweetpotatoScale
-synonym: "3.5" EXACT []
-is_a: CO_331:00001112 ! rtflscolc 9 pt. scale
-
-[Term]
 id: CO_331:00001113
 name: rtflscola 9 pt. scale
 namespace: SweetpotatoScale
@@ -2155,27 +2134,6 @@ name: rtscb 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
-
-[Term]
-id: CO_331:0000942:DO
-name: Deep orange
-namespace: SweetpotatoScale
-synonym: "DO" EXACT []
-is_a: CO_331:0000942 ! rtscb 3 pt. scale
-
-[Term]
-id: CO_331:0000942:IO
-name: Intermediate orange
-namespace: SweetpotatoScale
-synonym: "IO" EXACT []
-is_a: CO_331:0000942 ! rtscb 3 pt. scale
-
-[Term]
-id: CO_331:0000942:O
-name: Orange
-namespace: SweetpotatoScale
-synonym: "O" EXACT []
-is_a: CO_331:0000942 ! rtscb 3 pt. scale
 
 [Term]
 id: CO_331:0000943
@@ -6918,7 +6876,7 @@ relationship: variable_of CO_331:00001144 ! rtsinsdam  5 pt. scale
 relationship: variable_of CO_331:0000440 ! soil insect damage
 
 [Term]
-id: CO_331:0000812
+id: CO_331:0000811
 name: storage root defects (secondary)
 def: "Type and/or name of secondary visible storage root defect" []
 synonym: "RtDefS" EXACT []
@@ -6927,17 +6885,17 @@ created_by: C. Yencho
 creation_date: 2016-11-30T20:41:53Z
 
 [Term]
-id: CO_331:0000813
+id: CO_331:0000810
 name: Storage Root Defects secondary estimating 1-18
 def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
 synonym: "RTDEF2" EXACT []
 synonym: "RtDefS_Et_1to18" EXACT []
-relationship: variable_of CO_331:0000812 ! storage root defects (secondary)
+relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
 created_by: C. Yencho
 creation_date: 2016-11-30T20:44:25Z
 
 [Term]
-id: CO_331:0000814
+id: CO_331:0000809
 name: Storage root total marketable yield weight computation tons per ha
 def: "Marketable root yield" []
 synonym: "RtCYld_Cp_tha" EXACT []
@@ -6947,7 +6905,7 @@ created_by: W. Grueneberg
 creation_date: 2016-11-30T21:23:23Z
 
 [Term]
-id: CO_331:0000815
+id: CO_331:0000808
 name: overall storage root disease symptoms
 def: "Overall storage root disease symptoms evaluation" []
 synonym: "RtDSm" EXACT []
@@ -6956,7 +6914,7 @@ created_by: C. Yencho
 creation_date: 2016-12-01T02:33:40Z
 
 [Term]
-id: CO_331:0000816
+id: CO_331:0000600
 name: Overall storage root disease symptoms estimating 1-9
 def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
 synonym: "DISEASE" EXACT []

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -1,18 +1,19 @@
 format-version: 1.2
-date: 01:12:2016 04:15
+date: 12:02:2018 19:35
 saved-by: vagrant
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: SweetpotatoTrait
-ontology: TEMP
 
 [Term]
 id: CO_331:0000000
 name: CGIAR sweetpotato trait ontology
+namespace: SweetpotatoTrait
 def: "A controlled vocabulary to describe each trait as a distinguishable, characteristic, quality or phenotypic feature of a developing or mature sweetpotato plant." []
 
 [Term]
 id: CO_331:0000001
 name: plant type
+namespace: SweetpotatoTrait
 def: "Length of the main vines" []
 synonym: "Main vine length" EXACT []
 synonym: "PtTyp" EXACT []
@@ -22,6 +23,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000004
 name: ground cover
+namespace: SweetpotatoTrait
 def: "Soil area covered by plant canopy" []
 synonym: "VnFolGRnv" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -30,6 +32,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000007
 name: twining
+namespace: SweetpotatoTrait
 def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics" []
 synonym: "PtTwg" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -38,6 +41,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000010
 name: predominant vine color
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color" []
 synonym: "VnColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -46,6 +50,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000013
 name: secondary vine color
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color" []
 synonym: "VnColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -54,6 +59,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000016
 name: vine tips pubescence
+namespace: SweetpotatoTrait
 def: "Degree of hairiness of immature leaves recorded at the apex of the vines" []
 synonym: "VnTipP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -62,6 +68,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000019
 name: general outline of the leaf
+namespace: SweetpotatoTrait
 def: "Outline i.e., shape of a leaf located in the middle section of the vine" []
 synonym: "LfOut" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -70,6 +77,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000022
 name: leaf lobe type
+namespace: SweetpotatoTrait
 def: "Type of the lobe of a leaf located in the middle section of the vine" []
 synonym: "LfLbT" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -78,6 +86,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000025
 name: leaf lobe number
+namespace: SweetpotatoTrait
 def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine" []
 synonym: "LfLbN" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -86,6 +95,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000028
 name: shape of central leaf lobe
+namespace: SweetpotatoTrait
 def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine" []
 synonym: "LfLCS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -94,6 +104,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000031
 name: mature leaf size
+namespace: SweetpotatoTrait
 def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave." []
 synonym: "LfLMS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -102,6 +113,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000034
 name: abaxial leaf vein pigmentation
+namespace: SweetpotatoTrait
 def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf" []
 synonym: "LfAVP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -110,6 +122,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000037
 name: mature leaf color
+namespace: SweetpotatoTrait
 def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants." []
 synonym: "LfCMt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -118,6 +131,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000040
 name: immature leaf color
+namespace: SweetpotatoTrait
 def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants." []
 synonym: "LfColI" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -126,6 +140,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000043
 name: petiole pigmentation
+namespace: SweetpotatoTrait
 def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first." []
 synonym: "FrPtP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -134,6 +149,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000046
 name: flower color
+namespace: SweetpotatoTrait
 def: "The most representative color in the flowers" []
 synonym: "FRnol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -142,6 +158,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000049
 name: predominant skin color
+namespace: SweetpotatoTrait
 def: "The most representative skin color  of the root" []
 synonym: "RtSknColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -150,6 +167,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000052
 name: intensity of predominant skin color
+namespace: SweetpotatoTrait
 def: "Intensity of Predominant Skin color of the root" []
 synonym: "RtSknColPI" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -158,6 +176,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000055
 name: secondary skin color
+namespace: SweetpotatoTrait
 def: "The less representative skin color of the root" []
 synonym: "RtSknColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -166,6 +185,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000058
 name: predominant flesh color
+namespace: SweetpotatoTrait
 def: "The most representative flesh color of the root" []
 synonym: "RtFlsColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -174,6 +194,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000061
 name: secondary flesh color
+namespace: SweetpotatoTrait
 def: "The less representative flesh color of the root" []
 synonym: "RtFlsColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -182,6 +203,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000064
 name: distribution of secondary flesh color
+namespace: SweetpotatoTrait
 def: "Distribution of Secondary Flesh color of the root" []
 synonym: "RtFlsColSD" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -190,6 +212,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000067
 name: storage root shape
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root shape" []
 synonym: "RtShp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -198,6 +221,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000069
 name: storage root shape (primary)
+namespace: SweetpotatoTrait
 def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots" []
 synonym: "RtShpP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -206,6 +230,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000070
 name: latex production in storage roots
+namespace: SweetpotatoTrait
 def: "Amount of latex observed after cross sectioning medium-sized storage roots" []
 synonym: "RtLxP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -214,6 +239,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000073
 name: oxidation in storage roots
+namespace: SweetpotatoTrait
 def: "Amount of browning due to oxidation" []
 synonym: "RtOxi" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -222,6 +248,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000076
 name: storage root size
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root size based on inspection of the harvested roots" []
 synonym: "RtSiz" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -230,6 +257,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000079
 name: total number of root
+namespace: SweetpotatoTrait
 def: "Total number of root after harvest" []
 synonym: "RtTtN" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -238,6 +266,7 @@ created_by: CloneSelector2015
 [Term]
 id: CO_331:0000082
 name: yield of total roots
+namespace: SweetpotatoTrait
 def: "Yield evaluated in the harvest" []
 synonym: "RtYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -246,6 +275,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000085
 name: harvest index
+namespace: SweetpotatoTrait
 def: "Harvest index" []
 synonym: "IxHrv" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -254,6 +284,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000088
 name: reaction to sweet potato weevil
+namespace: SweetpotatoTrait
 def: "Overall assessment of weevil damage based on inspection of the harvested roots; early." []
 synonym: "RnWvl" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -262,6 +293,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000091
 name: reaction to early blight: (alternaria spp)
+namespace: SweetpotatoTrait
 def: "Alternaria symptoms evaluation" []
 synonym: "RnAlt" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -270,6 +302,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000094
 name: virus symptoms
+namespace: SweetpotatoTrait
 def: "Virus symptoms evaluation" []
 synonym: "RnVir" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -278,6 +311,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000097
 name: storage root cracking
+namespace: SweetpotatoTrait
 def: "Storage root cracking" []
 synonym: "RtCrk" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -286,6 +320,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000100
 name: protein content
+namespace: SweetpotatoTrait
 def: "Protein content of the root" []
 synonym: "RtFlsPrt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -519,6 +554,7 @@ relationship: method_of CO_331:0000369 ! reaction to sweet potato stem borer
 [Term]
 id: CO_331:0000103
 name: iron content
+namespace: SweetpotatoTrait
 def: "Content of iron on dry weight basis of the root" []
 synonym: "RtFlsFe" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -753,6 +789,7 @@ relationship: scale_of CO_331:00001058 ! appearance of roots in response diaport
 [Term]
 id: CO_331:0000106
 name: zinc content
+namespace: SweetpotatoTrait
 def: "Content of zinc on dry weight basis of the root" []
 synonym: "RtFlsZn" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -987,6 +1024,7 @@ relationship: method_of CO_331:0000400 ! reaction to witches broom
 [Term]
 id: CO_331:0000109
 name: beta-carotene content
+namespace: SweetpotatoTrait
 def: "Beta carotene content of the root" []
 synonym: "RtFlsBC" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1032,42 +1070,42 @@ relationship: method_of CO_331:0000408 ! appearance of hearbarium
 id: CO_331:00001094
 name: rttsgc
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001095
 name: plant picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001096
 name: flower picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001097
 name: root picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001098
 name: seeds picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
 id: CO_331:00001099
 name: leaf picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001093 ! taking standardized photo
 
 [Term]
@@ -1075,7 +1113,7 @@ id: CO_331:00001100
 name: observation of most frequennt storage root shape
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000069 ! storage root shape (primary)
 
 [Term]
@@ -1090,7 +1128,7 @@ id: CO_331:00001102
 name: observation of 2nd most frequent storage root shape
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000441 ! storage root shape (secondary)
 
 [Term]
@@ -1105,7 +1143,7 @@ id: CO_331:00001104
 name: observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000409 ! storage root shape uniformity
 
 [Term]
@@ -1120,7 +1158,7 @@ id: CO_331:00001106
 name: observation of an average or all storage roots within a single plant or plot
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000410 ! storage root stalk length
 relationship: method_of CO_331:0000411 ! storage root attachment
 relationship: method_of CO_331:0000412 ! length to diameter ratio of roots
@@ -1154,7 +1192,7 @@ relationship: scale_of CO_331:00001106 ! observation of an average or all storag
 id: CO_331:00001109
 name: scale_of CO_331:00001106
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
 
@@ -1205,7 +1243,7 @@ id: CO_331:00001116
 name: observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
 namespace: SweetpotatoMethod
 def: "Visual estimation" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000419 ! reaction to streptomyces soil rot
 
 [Term]
@@ -1220,7 +1258,7 @@ id: CO_331:00001118
 name: visual estimation of the roots response to  root-knot nematode
 namespace: SweetpotatoMethod
 def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Root-knot nematode" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
 relationship: method_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
 
@@ -1234,6 +1272,7 @@ relationship: scale_of CO_331:00001118 ! visual estimation of the roots response
 [Term]
 id: CO_331:0000112
 name: total carotenoids
+namespace: SweetpotatoTrait
 def: "Total carotenoids content of the root" []
 synonym: "RtFlsTC" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1251,7 +1290,7 @@ id: CO_331:00001121
 name: visual estimation of the roots response to  fusarium oxysporum
 namespace: SweetpotatoMethod
 def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Fusarium oxysporum" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000422 ! reaction to fusarium oxysporum
 
 [Term]
@@ -1286,28 +1325,28 @@ relationship: scale_of CO_331:00001106 ! observation of an average or all storag
 id: CO_331:00001126
 name: amylose - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000428 ! amylose content
 
 [Term]
 id: CO_331:00001127
 name: g/100 g fw
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001126 ! amylose - method
 
 [Term]
 id: CO_331:00001128
 name: asparagine - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000429 ! asparagine content
 
 [Term]
 id: CO_331:00001129
 name: mg/g dw
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001128 ! asparagine - method
 relationship: scale_of CO_331:00001130 ! cyanidin - method
 relationship: scale_of CO_331:00001131 ! total monomeric anthocyanins - method
@@ -1319,35 +1358,35 @@ relationship: scale_of CO_331:00001134 ! phenol - method
 id: CO_331:00001130
 name: cyanidin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000430 ! cyanidin content
 
 [Term]
 id: CO_331:00001131
 name: total monomeric anthocyanins - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000431 ! total monomeric anthocyanin content
 
 [Term]
 id: CO_331:00001132
 name: peonidin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000432 ! peonidin content
 
 [Term]
 id: CO_331:00001133
 name: anthocyanin - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000433 ! anthocyanin content
 
 [Term]
 id: CO_331:00001134
 name: phenol - method
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000434 ! phenol content
 
 [Term]
@@ -1361,7 +1400,7 @@ relationship: method_of CO_331:0000435 ! nodes per vine
 id: CO_331:00001136
 name: nodes/plant
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001135 ! nodes per vine evaluation
 
 [Term]
@@ -1375,7 +1414,7 @@ relationship: method_of CO_331:0000436 ! leaves per plant
 id: CO_331:00001138
 name: leaf/plant
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001137 ! leaves per plant evaluation
 
 [Term]
@@ -1383,14 +1422,14 @@ id: CO_331:00001139
 name: color of leave picture
 namespace: SweetpotatoMethod
 def: "Taking picture" []
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 relationship: method_of CO_331:0000437 ! color of leave
 
 [Term]
 id: CO_331:00001140
 name: picture
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:00001139 ! color of leave picture
 
 [Term]
@@ -1425,6 +1464,7 @@ relationship: scale_of CO_331:00001143 ! soils insect evaluation
 [Term]
 id: CO_331:0000115
 name: storage root starch content
+namespace: SweetpotatoTrait
 def: "Storage root starch content evaluated in percentage dry weight" []
 synonym: "RtFlsSta" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1433,6 +1473,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000118
 name: fructose content
+namespace: SweetpotatoTrait
 def: "Fructose content of the root" []
 synonym: "RtFlsFru" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1441,6 +1482,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000121
 name: glucose content
+namespace: SweetpotatoTrait
 def: "Glucose content of the root" []
 synonym: "RtFlsGlu" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1449,6 +1491,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000124
 name: sucrose content
+namespace: SweetpotatoTrait
 def: "Sucrose content  of the root" []
 synonym: "RtFlsSuc" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1457,6 +1500,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000127
 name: maltose content
+namespace: SweetpotatoTrait
 def: "Maltose content  of the root" []
 synonym: "RtFlsMal" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1465,6 +1509,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000130
 name: fiber content
+namespace: SweetpotatoTrait
 def: "Fiber content in fresh samples" []
 synonym: "RtFlsFf" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1473,6 +1518,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000133
 name: color of boiled roots
+namespace: SweetpotatoTrait
 def: "Color of boiled roots" []
 synonym: "RtCb" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1481,6 +1527,7 @@ created_by: R.Kapinga
 [Term]
 id: CO_331:0000136
 name: texture of boiled storage root flesh
+namespace: SweetpotatoTrait
 def: "Storage root texture after boiled" []
 synonym: "RtFlsTxH" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -1489,6 +1536,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000139
 name: sweetness of boiled storage root flesh
+namespace: SweetpotatoTrait
 def: "Sweetness of boiled root" []
 synonym: "RtFlsSwt" EXACT []
 synonym: "Storage root sweetness" EXACT []
@@ -1498,6 +1546,7 @@ created_by: Z. Huaman,W. Grueneberg
 [Term]
 id: CO_331:0000142
 name: storage root dry matter content
+namespace: SweetpotatoTrait
 def: "Storage root dry matter content" []
 synonym: "RtDMC" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -1506,10 +1555,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000147
 name: Plant Type estimating 3-9
+namespace: SweetpotatoTrait
 def: "Length of the main vines. 3= Erect (<75 cm), 5= Semi-erect (75-150 cm), 7= Spreading (151-250 cm), 9= Extremely spreading (> 250 cm)" []
 synonym: "PLANT" EXACT []
 synonym: "PtTyp_Et_3to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000001 ! plant type
 relationship: variable_of CO_331:0000812 ! observation of plant type
 relationship: variable_of CO_331:0000813 ! plttyp 4 pt. scale
@@ -1517,10 +1567,11 @@ relationship: variable_of CO_331:0000813 ! plttyp 4 pt. scale
 [Term]
 id: CO_331:0000148
 name: Ground Cover estimating 3-9
+namespace: SweetpotatoTrait
 def: "Soil area covered by plant canopy. 3= Low (<50%), 5= Medium (<50-74%), 7= High (75-90%), 9= Total (> 90%)" []
 synonym: "GRNDCOVR" EXACT []
 synonym: "VnFolGRnv_Et_3to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000004 ! ground cover
 relationship: variable_of CO_331:0000814 ! observation of ground cover
 relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
@@ -1528,10 +1579,11 @@ relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
 [Term]
 id: CO_331:0000149
 name: Twining  estimating 0-9
+namespace: SweetpotatoTrait
 def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics. 0= Non-Twining, 3= Slightly twining, 5 = Moderately twining, 7= Twining, 9 = Very twining" []
 synonym: "PtTwg_Et_0to9" EXACT []
 synonym: "TWING" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000007 ! twining
 relationship: variable_of CO_331:0000816 ! observation of twining
 relationship: variable_of CO_331:0000817 ! plttwg 5 pt. scale
@@ -1539,10 +1591,11 @@ relationship: variable_of CO_331:0000817 ! plttwg 5 pt. scale
 [Term]
 id: CO_331:0000150
 name: Predominant Vine Color estimating 1-9
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color. 1= Green, 3= Green with few purple spots, 4= Green with many purple spots, 5= Green with many dark purple spots, 6 = Mostly purple, 7= Mostly dark purple, 8= Totally purple, 9= Totally dark purple" []
 synonym: "VINCO1" EXACT []
 synonym: "VnColP_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000010 ! predominant vine color
 relationship: variable_of CO_331:0000818 ! observation of predominant vine color
 relationship: variable_of CO_331:0000819 ! vinclp 9 pt. scale
@@ -1550,10 +1603,11 @@ relationship: variable_of CO_331:0000819 ! vinclp 9 pt. scale
 [Term]
 id: CO_331:0000151
 name: Secondary Vine Color estimating 0-7
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color. 0 = Absent, 1 = Green base, 2 = Green tip, 3 = Green nodes, 4 = Purple base, 5 = Purple tip, 6 = Purple nodes, 7 = Other" []
 synonym: "VINCO2" EXACT []
 synonym: "VnColS_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000013 ! secondary vine color
 relationship: variable_of CO_331:0000820 ! observation of secondary vine color
 relationship: variable_of CO_331:0000821 ! vincls 8 pt. scale
@@ -1561,10 +1615,11 @@ relationship: variable_of CO_331:0000821 ! vincls 8 pt. scale
 [Term]
 id: CO_331:0000152
 name: Vine Tips Pubescence estimating 0-7
+namespace: SweetpotatoTrait
 def: "Degree of hairiness of immature leaves recorded at the apex of the vines. 0= Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
 synonym: "VINPUBS" EXACT []
 synonym: "VnTipP_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000016 ! vine tips pubescence
 relationship: variable_of CO_331:0000822 ! observation of vine tips pubescence
 relationship: variable_of CO_331:0000823 ! vintpp 8 pt. scale
@@ -1572,6 +1627,7 @@ relationship: variable_of CO_331:0000823 ! vintpp 8 pt. scale
 [Term]
 id: CO_331:0000153
 name: vine internode length
+namespace: SweetpotatoTrait
 def: "Measurement of the vine internode length" []
 synonym: "VnInLg" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -1580,10 +1636,11 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000156
 name: Vine internode length estimating 1-9
+namespace: SweetpotatoTrait
 def: "Measurement of the vine internode length. 1= Very short (<3 cm), 3= Short (3-5 cm), 5=Intermediate (6-9 cm), 7=Long (10-12 cm), 9 =Very long (>12 cm)" []
 synonym: "VINLG" EXACT []
 synonym: "VnInLg_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000153 ! vine internode length
 relationship: variable_of CO_331:0000824 ! average length of at least three internodes located in the middle section of the vine
 relationship: variable_of CO_331:0000825 ! vininlg 5 pt. scale
@@ -1591,6 +1648,7 @@ relationship: variable_of CO_331:0000825 ! vininlg 5 pt. scale
 [Term]
 id: CO_331:0000157
 name: vine internode diameter
+namespace: SweetpotatoTrait
 def: "Measurement of the vine internode diameter" []
 synonym: "VnInD" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -1599,10 +1657,11 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000160
 name: Vine internode diameter estimating 1-9
+namespace: SweetpotatoTrait
 def: "Measurement of the vine internode diameter. 1= Very thin (<4 mm), 3= Thin (4-6 mm), 5=Intermediate (7-9 mm), 7=Thick (10-12 mm), 9=Very thick (>12 mm)" []
 synonym: "VINDIA" EXACT []
 synonym: "VnInD_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000157 ! vine internode diameter
 relationship: variable_of CO_331:0000826 ! average diameter of at least three internodes located in the middle section of the vine
 relationship: variable_of CO_331:0000827 ! vinind 5 pt. scale
@@ -1610,10 +1669,11 @@ relationship: variable_of CO_331:0000827 ! vinind 5 pt. scale
 [Term]
 id: CO_331:0000161
 name: General Outline of the Leaf estimating 1-7
+namespace: SweetpotatoTrait
 def: "Outline i.e., shape of a leaf located in the middle section of the vine. 1= Rounded, 2= Reniform (kidney-shaped), 3 = Chordate (heart-shaped), 4 = Triangular, 5= Hastate, 6 = Lobed, 7 = Almost divided" []
 synonym: "LEAFSHAP1" EXACT []
 synonym: "LfOut_Et_1to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000019 ! general outline of the leaf
 relationship: variable_of CO_331:0000828 ! observation of general outline of the leaf
 relationship: variable_of CO_331:0000829 ! lefout 7 pt. scale
@@ -1621,10 +1681,11 @@ relationship: variable_of CO_331:0000829 ! lefout 7 pt. scale
 [Term]
 id: CO_331:0000162
 name: Leaf Lobes Type estimating 0-9
+namespace: SweetpotatoTrait
 def: "Type of the lobe of a leaf located in the middle section of the vine. 0 = No lateral lobes (entire), 1 = Very slight (teeth), 3 = Slight, 5 = Moderate, 7 = Deep, 9= Very deep" []
 synonym: "LEAFSHAP2" EXACT []
 synonym: "LfLbT_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000022 ! leaf lobe type
 relationship: variable_of CO_331:0000830 ! observation of leaf lobes type
 relationship: variable_of CO_331:0000831 ! leflbt  6 pt. scale
@@ -1632,10 +1693,11 @@ relationship: variable_of CO_331:0000831 ! leflbt  6 pt. scale
 [Term]
 id: CO_331:0000163
 name: Leaf Lobe Number estimating 1-9
+namespace: SweetpotatoTrait
 def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine. 1= 1 Lobe, 3 = 3 Lobe, 5 = 5 Lobe, 7 = 7 Lobe, 9 = 9 Lobe" []
 synonym: "LEAFSHAP3" EXACT []
 synonym: "LfLbN_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000025 ! leaf lobe number
 relationship: variable_of CO_331:0000832 ! observation of leaf lobe number
 relationship: variable_of CO_331:0000833 ! leflbn 5 pt. scale
@@ -1643,10 +1705,11 @@ relationship: variable_of CO_331:0000833 ! leflbn 5 pt. scale
 [Term]
 id: CO_331:0000164
 name: Shape of Central Leaf Lobe estimating 0-9
+namespace: SweetpotatoTrait
 def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine. 0 = Absent, 1 = Toothed, 2 = Triangular, 3 = Semi-circular, 4 = Semi-elliptic, 5 = Elliptic, 6 = Lanceolate, 7 = Oblanceolate, 8 = Linear (broad), 9 = Linear (narrow)" []
 synonym: "LEAFSHAP4" EXACT []
 synonym: "LfLCS_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000028 ! shape of central leaf lobe
 relationship: variable_of CO_331:0000834 ! observation of shape of central leaf lobe
 relationship: variable_of CO_331:0000835 ! leflcs 10 pt. scale
@@ -1654,10 +1717,11 @@ relationship: variable_of CO_331:0000835 ! leflcs 10 pt. scale
 [Term]
 id: CO_331:0000165
 name: Mature Leaf Size estimating 3-9
+namespace: SweetpotatoTrait
 def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave.. 3 = Small (<8 cm), 5 = Medium (8-15 cm), 7 = Large (16-25 cm), 9 = Very large (> 25 cm)" []
 synonym: "LfLMS_Et_3to9" EXACT []
 synonym: "LFSIZE" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000031 ! mature leaf size
 relationship: variable_of CO_331:0000836 ! observation of mature leaf size
 relationship: variable_of CO_331:0000837 ! leflms 9 pt. scale
@@ -1665,10 +1729,11 @@ relationship: variable_of CO_331:0000837 ! leflms 9 pt. scale
 [Term]
 id: CO_331:0000166
 name: Abaxial Leaf Vein Pigmentation estimating 1-9
+namespace: SweetpotatoTrait
 def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf. 1 = Yellow, 2 = Green, 3 = Purple spot in the base of main rib, 4 = Purple spot in several veins, 5 = Main rib partially purple, 6 = Main rib mostly or totally purple, 7 = All veins partial purple, 8 = All veins mostly or totally purple, 9 = Lower surface and veins totally purple" []
 synonym: "LfAVP_Et_1to9" EXACT []
 synonym: "LFVEIN" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000034 ! abaxial leaf vein pigmentation
 relationship: variable_of CO_331:0000838 ! observation of abaxial leaf vein pigmentation
 relationship: variable_of CO_331:0000839 ! lefavp 9 pt. scale
@@ -1676,10 +1741,11 @@ relationship: variable_of CO_331:0000839 ! lefavp 9 pt. scale
 [Term]
 id: CO_331:0000167
 name: Mature Leaf Color estimating 1-9
+namespace: SweetpotatoTrait
 def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
 synonym: "LfCMt_Et_1to9" EXACT []
 synonym: "LFMATCO" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000037 ! mature leaf color
 relationship: variable_of CO_331:0000840 ! observation of mature leaf color
 relationship: variable_of CO_331:0000841 ! lefcmt 9 pt. scale
@@ -1687,10 +1753,11 @@ relationship: variable_of CO_331:0000841 ! lefcmt 9 pt. scale
 [Term]
 id: CO_331:0000168
 name: Immature Leaf Color estimating 1-9
+namespace: SweetpotatoTrait
 def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
 synonym: "LfColI_Et_1to9" EXACT []
 synonym: "LFINMCO" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000040 ! immature leaf color
 relationship: variable_of CO_331:0000842 ! observation of immature leaf color
 relationship: variable_of CO_331:0000843 ! lefcim 9 pt. scale
@@ -1698,10 +1765,11 @@ relationship: variable_of CO_331:0000843 ! lefcim 9 pt. scale
 [Term]
 id: CO_331:0000169
 name: Petiole Pigmentation estimating 1-9
+namespace: SweetpotatoTrait
 def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first.. 1 = Green, 2 = Green with purple near steam, 3 = Green width purple near leaf, 4 = Green with purple both ends, 5 = Green with purple spots throughout petiole, 6 = Green with multiple stripes, 7 = Purple with green near leaf, 8 = Some petioles purple others green, 9 = Totally or mostly purple" []
 synonym: "FrPtP_Et_1to9" EXACT []
 synonym: "PTIOPG" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000043 ! petiole pigmentation
 relationship: variable_of CO_331:0000844 ! observation of petiole pigmentation
 relationship: variable_of CO_331:0000845 ! flrptp 9 pt. scale
@@ -1709,6 +1777,7 @@ relationship: variable_of CO_331:0000845 ! flrptp 9 pt. scale
 [Term]
 id: CO_331:0000170
 name: petiole length
+namespace: SweetpotatoTrait
 def: "Petiole length from the base to the insertion with the blade" []
 synonym: "FrPtL" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -1717,10 +1786,11 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000173
 name: Petiole length estimating 1-9
+namespace: SweetpotatoTrait
 def: "Petiole length from the base to the insertion with the blade. 1=Very short (<10 cm), 3=Short (10-20 cm), 5=Intermediate (21-30 cm), 7=Long (31-40 cm), 9=Very long (>40 cm)" []
 synonym: "FrPtL_Et_1to9" EXACT []
 synonym: "PETIOL" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000170 ! petiole length
 relationship: variable_of CO_331:0000846 ! average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
 relationship: variable_of CO_331:0000847 ! flrptl 5 pt. scale
@@ -1728,10 +1798,11 @@ relationship: variable_of CO_331:0000847 ! flrptl 5 pt. scale
 [Term]
 id: CO_331:0000174
 name: Flower color estimating 1-6
+namespace: SweetpotatoTrait
 def: "The most representative color in the flowers. 1= White, 2 = White limb with purple throat, 3 = White limb with pale purple ring and purple throat, 4 = Pale purple limb with purple throat, 5 = Purple, 6 = Other" []
 synonym: "FLORCOL" EXACT []
 synonym: "FRnol_Et_1to6" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000046 ! flower color
 relationship: variable_of CO_331:0000848 ! observation of newly opened flowers
 relationship: variable_of CO_331:0000849 ! flrcol  6 pt. scale
@@ -1739,10 +1810,11 @@ relationship: variable_of CO_331:0000849 ! flrcol  6 pt. scale
 [Term]
 id: CO_331:0000175
 name: Predominant Skin color estimating 1-9
+namespace: SweetpotatoTrait
 def: "The most representative skin color of the root. 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
 synonym: "RTSKN1, SCOL" EXACT []
 synonym: "RtSknColP_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000049 ! predominant skin color
 relationship: variable_of CO_331:0000850 ! observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
 relationship: variable_of CO_331:0000851 ! prdskncol 9 pt. scale
@@ -1750,10 +1822,11 @@ relationship: variable_of CO_331:0000851 ! prdskncol 9 pt. scale
 [Term]
 id: CO_331:0000176
 name: Intensity of Predominant Skin color estimating 1-3
+namespace: SweetpotatoTrait
 def: "Intensity of Predominant Skin color of the root. 1= Pale, 2 = Intermediate, 3 = Dark" []
 synonym: "RTSKN2" EXACT []
 synonym: "RtSknColPI_Et_1to3" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000052 ! intensity of predominant skin color
 relationship: variable_of CO_331:0000852 ! observation of intensity of predominant skin color
 relationship: variable_of CO_331:0000853 ! skncpi  3 pt. scale
@@ -1761,10 +1834,11 @@ relationship: variable_of CO_331:0000853 ! skncpi  3 pt. scale
 [Term]
 id: CO_331:0000177
 name: Secondary Skin color estimating 1-10
+namespace: SweetpotatoTrait
 def: "The less representative skin color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
 synonym: "RTSKN3" EXACT []
 synonym: "RtSknColS_Et_1to10" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000055 ! secondary skin color
 relationship: variable_of CO_331:0000854 ! observation of secondary skin color
 relationship: variable_of CO_331:0000855 ! skncsc  10 pt. scale
@@ -1772,10 +1846,11 @@ relationship: variable_of CO_331:0000855 ! skncsc  10 pt. scale
 [Term]
 id: CO_331:0000178
 name: Predominant Flesh color estimating 1-9
+namespace: SweetpotatoTrait
 def: "The most representative flesh color of the root. 1 = White, 2 = Cream, 3 = Dark cream, 4 = Pale yellow, 5 = Dark yellow, 6 = Pale orange, 7 = Intermediate orange, 8 = Dark orange, 9 = Strongly pigmented with anthocyanins" []
 synonym: "RtFlsColP_Et_1to9" EXACT []
 synonym: "RTFSH1, FCOL" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000058 ! predominant flesh color
 relationship: variable_of CO_331:0000856 ! observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
 relationship: variable_of CO_331:0000857 ! prdflshcol 9 pt. scale
@@ -1783,10 +1858,11 @@ relationship: variable_of CO_331:0000857 ! prdflshcol 9 pt. scale
 [Term]
 id: CO_331:0000179
 name: Secondary Flesh color estimating 0-9
+namespace: SweetpotatoTrait
 def: "The less representative flesh color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Pink, 6 = Red, 7 = Purple-red, 8 = Purple, 9 = Dark purple" []
 synonym: "RtFlsColS_Et_0to9" EXACT []
 synonym: "RTFSH2" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000061 ! secondary flesh color
 relationship: variable_of CO_331:0000858 ! observation of secondary flesh color
 relationship: variable_of CO_331:0000859 ! flscsc 10 pt. scale
@@ -1794,10 +1870,11 @@ relationship: variable_of CO_331:0000859 ! flscsc 10 pt. scale
 [Term]
 id: CO_331:0000180
 name: Distribution of Secondary Flesh color estimating 0-9
+namespace: SweetpotatoTrait
 def: "Distribution of Secondary Flesh color of the root. 0 = Absent, 1 = Narrow ring in cortex, 2 = Broad ring in cortex, 3 = Scattered spots in flesh, 4 = Narrow ring in flesh, 5 = Broad ring in flesh, 6 = Ring and other areas in flesh, 7 = In longitudinal sections, 8 = Covering most of the flesh, 9 = Covering all flesh" []
 synonym: "RtFlsColSD_Et_1to9" EXACT []
 synonym: "RTFSH3" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000064 ! distribution of secondary flesh color
 relationship: variable_of CO_331:0000860 ! observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
 relationship: variable_of CO_331:0000861 ! flscsd 10 pt. scale
@@ -1805,10 +1882,11 @@ relationship: variable_of CO_331:0000861 ! flscsd 10 pt. scale
 [Term]
 id: CO_331:0000181
 name: Storage Root Shape estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root shape. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Ovate, 5 = Obovate, 6 = Oblong, 7 = Long oblong, 8 = Long elliptic, 9 = Long irregular or curved" []
 synonym: "RTSHP" EXACT []
 synonym: "RtShp_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000067 ! storage root shape
 relationship: variable_of CO_331:0000862 ! observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
 relationship: variable_of CO_331:0000863 ! rtshp 9 pt. scale
@@ -1816,10 +1894,11 @@ relationship: variable_of CO_331:0000863 ! rtshp 9 pt. scale
 [Term]
 id: CO_331:0000182
 name: Latex Production in Storage Roots estimating 3-7
+namespace: SweetpotatoTrait
 def: "Amount of latex observed after cross sectioning medium-sized storage roots. 3 = Little, 5 = Some, 7 = Abundant" []
 synonym: "RTLATX" EXACT []
 synonym: "RtLxP_Et_3to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000070 ! latex production in storage roots
 relationship: variable_of CO_331:0000864 ! observation of latex production in storage roots
 relationship: variable_of CO_331:0000865 ! rtlat 3 pt. scale
@@ -1827,10 +1906,11 @@ relationship: variable_of CO_331:0000865 ! rtlat 3 pt. scale
 [Term]
 id: CO_331:0000183
 name: Oxidation in Storage Roots estimating 3-7
+namespace: SweetpotatoTrait
 def: "Amount of browning due to oxidation. 3 = Little, 5 = Some, 7 = Abundant" []
 synonym: "RtOxi_Et_3to7" EXACT []
 synonym: "RTOXID" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000073 ! oxidation in storage roots
 relationship: variable_of CO_331:0000866 ! observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
 relationship: variable_of CO_331:0000867 ! rtoxi 3 pt. scale
@@ -1838,10 +1918,11 @@ relationship: variable_of CO_331:0000867 ! rtoxi 3 pt. scale
 [Term]
 id: CO_331:0000184
 name: Storage root size estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root size based on inspection of the harvested roots. 1 = Excellent, 3 = Good, 5 = Fair, 7 = Poor, 9 = terrible" []
 synonym: "RS" EXACT []
 synonym: "RtSiz_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000076 ! storage root size
 relationship: variable_of CO_331:0000868 ! storage root size - method
 relationship: variable_of CO_331:0000869 ! rtsize 5 pt. scale
@@ -1849,6 +1930,7 @@ relationship: variable_of CO_331:0000869 ! rtsize 5 pt. scale
 [Term]
 id: CO_331:0000189
 name: number of plants established
+namespace: SweetpotatoTrait
 def: "Number of plants established" []
 synonym: "PltEst" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -1857,10 +1939,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000192
 name: Plants established counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of plants established" []
 synonym: "NOPE" EXACT []
 synonym: "PltEst_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000189 ! number of plants established
 relationship: variable_of CO_331:0000870 ! evaluation of plant vine establishment
 relationship: variable_of CO_331:0000871 ! plants/plot
@@ -1868,10 +1951,11 @@ relationship: variable_of CO_331:0000871 ! plants/plot
 [Term]
 id: CO_331:0000193
 name: Virus symptoms 1 estimating 1-9
+namespace: SweetpotatoTrait
 def: "Virus symptoms evaluation. 1= No virus symptoms, 2= Unclear virus symptoms, 3= Clear virus symptoms < 5% of plants per plot, 4= Clear virus symptoms at 6 to 15% of plants per plot, 5= Clear virus symptoms at 16 to 33% of plants per plot, 6= Clear virus symptoms at 34 to 66% of plants per plot (more than 1/3 less than 2/3), 7= Clear virus symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8= Clear virus symptoms at all plants per plot (not stunted), 9= Severe virus symptoms in all plants per plot (stunted)." []
 synonym: "VIR1" EXACT []
 synonym: "VirSm1_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000094 ! virus symptoms
 relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
 relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
@@ -1879,6 +1963,7 @@ relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
 [Term]
 id: CO_331:0000194
 name: vine vigor
+namespace: SweetpotatoTrait
 def: "Vine vigor evaluation" []
 synonym: "VnVg" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -1887,10 +1972,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000197
 name: Vine vigor  estimating 1-9
+namespace: SweetpotatoTrait
 def: "Vine vigor evaluation. 1= Nearly no vines, 2= Weak vines, 3= Weak to medium strong vines, medium thick stems, and long internode distances, 4= Medium strong vines, medium thick stems, and medium internode distances, 5= Medium strong vines, thick vines, and long internode distances, 6= Medium strong vines, thick stems, and medium internode distances, 7= Strong vines, thick stems, short internode distances, and medium-long vines, 8= Strong vines, thick stems, short internode distances, and long vines,, 9= Very strong vine strength, thick stems, short internode distances, and very long vines" []
 synonym: "VnVg_Et_1to9" EXACT []
 synonym: "VV1" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000194 ! vine vigor
 relationship: variable_of CO_331:0000875 ! observation of plant vigour
 relationship: variable_of CO_331:0000876 ! vinvgr 9 pt. scale
@@ -1898,10 +1984,11 @@ relationship: variable_of CO_331:0000876 ! vinvgr 9 pt. scale
 [Term]
 id: CO_331:0000198
 name: Reaction to Alternaria symptom estimating 1-9
+namespace: SweetpotatoTrait
 def: "Alternaria symptoms evaluation. 1 = No symptoms, 2 = Unclear symptoms, 3 = Clear symptoms at <5% per plot, 4 = Clear symptoms at 6 to 15% of plants per plot, 5 = Clear symptoms at 16 to 33% of plants per plot (less than 1/3), 6 = Clear symptoms at 34 to 66% of plants per plot (more than 1/3, 7 = Clear symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8 = Clear symptoms at all plants (not fully defoliated), 9 = Severe symptoms at all plants per plot (fully defoliated)" []
 synonym: "ALT1, AS1" EXACT []
 synonym: "RnAlt_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000091 ! reaction to early blight: (alternaria spp)
 relationship: variable_of CO_331:0000877 ! early blight evaluation: (alternaria)
 relationship: variable_of CO_331:0000878 ! altsm 9 pt. scale
@@ -1909,6 +1996,7 @@ relationship: variable_of CO_331:0000878 ! altsm 9 pt. scale
 [Term]
 id: CO_331:0000199
 name: storage root form
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root form" []
 synonym: "RtFrm" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -1917,10 +2005,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000202
 name: Storage root form estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall assessment of storage root form. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
 synonym: "RF" EXACT []
 synonym: "RtFrm_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000199 ! storage root form
 relationship: variable_of CO_331:0000879 ! storage root form - method
 relationship: variable_of CO_331:0000880 ! rtform 9 pt. scale
@@ -1928,6 +2017,7 @@ relationship: variable_of CO_331:0000880 ! rtform 9 pt. scale
 [Term]
 id: CO_331:0000203
 name: number of storage root damages
+namespace: SweetpotatoTrait
 def: "Root with structural damages" []
 synonym: "RtDam" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -1936,10 +2026,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000206
 name: Storage root damages estimating 1-9
+namespace: SweetpotatoTrait
 def: "Root with structural damages. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
 synonym: "DAMR" EXACT []
 synonym: "RtDam_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000203 ! number of storage root damages
 relationship: variable_of CO_331:0000881 ! storage root damage
 relationship: variable_of CO_331:0000882 ! rtsdam 9 pt. scale
@@ -1947,10 +2038,11 @@ relationship: variable_of CO_331:0000882 ! rtsdam 9 pt. scale
 [Term]
 id: CO_331:0000207
 name: Reaction to Sweet potato weevil symptoms estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall assessment of weevil damage based on inspection of the harvested roots; early.. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
 synonym: "RnWvl_Et_1to9" EXACT []
 synonym: "WED1, WED" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000088 ! reaction to sweet potato weevil
 relationship: variable_of CO_331:0000883 ! weevil damage evaluation
 relationship: variable_of CO_331:0000884 ! rtdam 9 pt. scale
@@ -1958,6 +2050,7 @@ relationship: variable_of CO_331:0000884 ! rtdam 9 pt. scale
 [Term]
 id: CO_331:0000208
 name: number of plants with storage roots
+namespace: SweetpotatoTrait
 def: "Number of plants with storage roots" []
 synonym: "PtRt" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -1966,10 +2059,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000211
 name: Plants with storage roots counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of plants with storage roots" []
 synonym: "NOPR" EXACT []
 synonym: "PtRt_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000208 ! number of plants with storage roots
 relationship: variable_of CO_331:0000871 ! plants/plot
 relationship: variable_of CO_331:0000885 ! evaluation of plants
@@ -1977,6 +2071,7 @@ relationship: variable_of CO_331:0000885 ! evaluation of plants
 [Term]
 id: CO_331:0000212
 name: number of commercial storage roots
+namespace: SweetpotatoTrait
 def: "Roots 12-20 cm long and 10 cm in diameter" []
 synonym: "RtCmN" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -1985,10 +2080,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000214
 name: Number of commercial storage roots counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of root that are 12 to 20 cm long and at least 10 cm in diameter" []
 synonym: "NOCR" EXACT []
 synonym: "RtCmN_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000212 ! number of commercial storage roots
 relationship: variable_of CO_331:0000886 ! evaluation of roots
 relationship: variable_of CO_331:0000887 ! roots/plot
@@ -1996,6 +2092,7 @@ relationship: variable_of CO_331:0000887 ! roots/plot
 [Term]
 id: CO_331:0000215
 name: number of non-commercial storage roots
+namespace: SweetpotatoTrait
 def: "Number of small and large roots (10 > x < 20 cm long)" []
 synonym: "RtNCmN" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2004,10 +2101,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000217
 name: Number of non-commercial storage roots counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of root shorter than 10 cm long and greater than 20 cm long." []
 synonym: "NONC" EXACT []
 synonym: "RtNCmN_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000215 ! number of non-commercial storage roots
 relationship: variable_of CO_331:0000886 ! evaluation of roots
 relationship: variable_of CO_331:0000887 ! roots/plot
@@ -2015,6 +2113,7 @@ relationship: variable_of CO_331:0000887 ! roots/plot
 [Term]
 id: CO_331:0000218
 name: weight of commercial storage roots
+namespace: SweetpotatoTrait
 def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
 synonym: "RtCmW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2023,10 +2122,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000220
 name: Weight of commercial storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
 synonym: "CRW" EXACT []
 synonym: "RtCmW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000218 ! weight of commercial storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -2034,6 +2134,7 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000221
 name: weight of non-commercial storage roots
+namespace: SweetpotatoTrait
 def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
 synonym: "RtNCmW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2042,10 +2143,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000223
 name: Weight of non-commercial storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
 synonym: "NCRW" EXACT []
 synonym: "RtNCmW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000221 ! weight of non-commercial storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -2053,6 +2155,7 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000224
 name: weight of vines
+namespace: SweetpotatoTrait
 def: "Weight of vines" []
 synonym: "VnW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2061,10 +2164,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000227
 name: Weight of vines measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Weight of vines" []
 synonym: "VnW_Ms_kgplot" EXACT []
 synonym: "VW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000224 ! weight of vines
 relationship: variable_of CO_331:0000893 ! kg/plot
 relationship: variable_of CO_331:0000894 ! measurements of vine mass
@@ -2072,10 +2176,11 @@ relationship: variable_of CO_331:0000894 ! measurements of vine mass
 [Term]
 id: CO_331:0000230
 name: Total number of roots computation per plant
+namespace: SweetpotatoTrait
 def: "Total number of root after harvest" []
 synonym: "RtTtN_Ct_rtplant" EXACT []
 synonym: "TNROOT,NRPP" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000079 ! total number of root
 relationship: variable_of CO_331:0000890 ! estimated number per plant - method
 relationship: variable_of CO_331:0000891 ! roots/ plant
@@ -2083,10 +2188,11 @@ relationship: variable_of CO_331:0000891 ! roots/ plant
 [Term]
 id: CO_331:0000233
 name: Total number of root counting per plot
+namespace: SweetpotatoTrait
 def: "Total number of root after harvest" []
 synonym: "RtTtN_Ct_rtplot" EXACT []
 synonym: "TNRPLOT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000079 ! total number of root
 relationship: variable_of CO_331:0000888 ! estimated number per plot - method
 relationship: variable_of CO_331:0000889 ! roots/ plot
@@ -2094,6 +2200,7 @@ relationship: variable_of CO_331:0000889 ! roots/ plot
 [Term]
 id: CO_331:0000234
 name: total root weight
+namespace: SweetpotatoTrait
 def: "Total weight of root  after harvest" []
 synonym: "RtTWt" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2102,10 +2209,11 @@ created_by: CloneSelector2015
 [Term]
 id: CO_331:0000237
 name: Total root weight computation per plot
+namespace: SweetpotatoTrait
 def: "Total weight of root after harvest" []
 synonym: "RtTWt_Cp_plot" EXACT []
 synonym: "TRW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000234 ! total root weight
 relationship: variable_of CO_331:0000893 ! kg/plot
 relationship: variable_of CO_331:0000895 ! estimated weight per plot - method
@@ -2113,10 +2221,11 @@ relationship: variable_of CO_331:0000895 ! estimated weight per plot - method
 [Term]
 id: CO_331:0000239
 name: Storage root cracking estimating 0-7
+namespace: SweetpotatoTrait
 def: "Storage root cracking. 0 = Absent, 3 = Few cracks, 5 = Medium number of cracks, 7 = Many cracks" []
 synonym: "RtCrk_Et_0to7" EXACT []
 synonym: "SGROOT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000097 ! storage root cracking
 relationship: variable_of CO_331:0000902 ! estimation of cracking roots
 relationship: variable_of CO_331:0000903 ! rtscr 4 pt. scale
@@ -2124,6 +2233,7 @@ relationship: variable_of CO_331:0000903 ! rtscr 4 pt. scale
 [Term]
 id: CO_331:0000240
 name: Fresh weight of storage root
+namespace: SweetpotatoTrait
 def: "Weight of storage root samples" []
 synonym: "RtFWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2132,10 +2242,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000243
 name: Fresh weight of storage root samples measuring g of sample
+namespace: SweetpotatoTrait
 def: "Weight of storage root samples" []
 synonym: "DMF" EXACT []
 synonym: "RtFWt_Ms_g" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000240 ! Fresh weight of storage root
 relationship: variable_of CO_331:0000904 ! measurements of fresh root mass
 relationship: variable_of CO_331:0000905 ! g
@@ -2143,6 +2254,7 @@ relationship: variable_of CO_331:0000905 ! g
 [Term]
 id: CO_331:0000244
 name: Dry weight of storage root
+namespace: SweetpotatoTrait
 def: "Weight of storage root samples" []
 synonym: "RtDWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2151,10 +2263,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000247
 name: Dry weight of storage root samples measuring g of sample
+namespace: SweetpotatoTrait
 def: "Weight of storage root samples" []
 synonym: "DMD" EXACT []
 synonym: "RtDWt_Ms_g" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000244 ! Dry weight of storage root
 relationship: variable_of CO_331:0000905 ! g
 relationship: variable_of CO_331:0000906 ! measurements of dry root mass
@@ -2162,6 +2275,7 @@ relationship: variable_of CO_331:0000906 ! measurements of dry root mass
 [Term]
 id: CO_331:0000248
 name: Fresh weight of vines
+namespace: SweetpotatoTrait
 def: "Weight of vines samples" []
 synonym: "VnFWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2170,10 +2284,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000251
 name: Fresh weight of vines measuring g of sample
+namespace: SweetpotatoTrait
 def: "Weight of vines samples" []
 synonym: "DMFV" EXACT []
 synonym: "VnFWt_Et_g" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000248 ! Fresh weight of vines
 relationship: variable_of CO_331:0000905 ! g
 relationship: variable_of CO_331:0000907 ! measurements of fresh vine mass
@@ -2181,6 +2296,7 @@ relationship: variable_of CO_331:0000907 ! measurements of fresh vine mass
 [Term]
 id: CO_331:0000252
 name: Dry weight of vines
+namespace: SweetpotatoTrait
 def: "Weight of vines samples" []
 synonym: "VnDWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2189,10 +2305,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000255
 name: Dry weight of vines measuring g of sample
+namespace: SweetpotatoTrait
 def: "Weight of vines samples" []
 synonym: "DMDV" EXACT []
 synonym: "VnDWt_Ms_g" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000252 ! Dry weight of vines
 relationship: variable_of CO_331:0000905 ! g
 relationship: variable_of CO_331:0000908 ! measurements of dry vine mass
@@ -2200,6 +2317,7 @@ relationship: variable_of CO_331:0000908 ! measurements of dry vine mass
 [Term]
 id: CO_331:0000256
 name: fiber cooked
+namespace: SweetpotatoTrait
 def: "Fiber content in cooked samples" []
 synonym: "RtFlsFbC" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2208,10 +2326,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000259
 name: Fibers in cooked samples estimating 1-9
+namespace: SweetpotatoTrait
 def: "Fiber content in cooked samples. 1= Non-fibrous, 2= Non-fibrous to slightly fibrous, 3= Slightly fibrous, 4= Slightly to moderately fibrous, 5= Moderately fibrous, 6= Moderately fibrous to fibrous, 7= Fibrous, 8= Fibrous to very fibrous, 9= Very fibrous" []
 synonym: "COOF" EXACT []
 synonym: "RtFlsFbC_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000256 ! fiber cooked
 relationship: variable_of CO_331:0000909 ! evaluation of cooked samples for fibers
 relationship: variable_of CO_331:0000910 ! rtfbr 9 pt. scale
@@ -2219,10 +2338,11 @@ relationship: variable_of CO_331:0000910 ! rtfbr 9 pt. scale
 [Term]
 id: CO_331:0000260
 name: Fibers content in fresh samples measuring percent
+namespace: SweetpotatoTrait
 def: "Fiber content in fresh samples" []
 synonym: "FIBER" EXACT []
 synonym: "RtFlsFf_Ms_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000130 ! fiber content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
@@ -2230,10 +2350,11 @@ relationship: variable_of CO_331:0000911 ! storage root fibers content  evaluate
 [Term]
 id: CO_331:0000261
 name: Storage root sweetness estimating 1-9
+namespace: SweetpotatoTrait
 def: "Sweetness of boiled root. 1 = Not at all sweet, 2= Non-sweet to slightly sweet, 3 = Slightly sweet, 4= Slightly to moderately sweet, 5 = Moderately sweet, 6= Moderately sweet to sweet, 7 = Sweet, 8= Sweet to very sweet, 9= Very sweet" []
 synonym: "RtFlsSwt_Et_1to9" EXACT []
 synonym: "TASTE, COOSU" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000139 ! sweetness of boiled storage root flesh
 relationship: variable_of CO_331:0000912 ! evaluation of cooked samples for sweetness
 relationship: variable_of CO_331:0000913 ! rtswt 9 pt. scale
@@ -2241,10 +2362,11 @@ relationship: variable_of CO_331:0000913 ! rtswt 9 pt. scale
 [Term]
 id: CO_331:0000263
 name: Storage root texture estimating 1-9 by Huaman
+namespace: SweetpotatoTrait
 def: "Storage root texture after boiled. 1 = Dry, 3 = Somewhat dry, 5 = Intermediate, 7 = Moist, 9 = Very moist" []
 synonym: "RtFlsTxH_Et_1to9" EXACT []
 synonym: "RTTEXT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
 relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
 relationship: variable_of CO_331:0000915 ! flstxch 5 pt. scale
@@ -2252,10 +2374,11 @@ relationship: variable_of CO_331:0000915 ! flstxch 5 pt. scale
 [Term]
 id: CO_331:0000265
 name: Storage root texture estimating 1-9 by Grueneberg
+namespace: SweetpotatoTrait
 def: "Storage root texture after boiled. 1= very moist, 2= Very moist to moist, 3= Moist, 4= Moist to moderately dry, 5= Moderately dry, 6= Moderately dry to dry, 7= Dry, 8= Dry to very dry, 9= Very dry" []
 synonym: "RtFlsTxG_Et_1to9" EXACT []
 synonym: "TEXTBR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
 relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
 relationship: variable_of CO_331:0000916 ! flstxcg 9 pt. scale
@@ -2263,6 +2386,7 @@ relationship: variable_of CO_331:0000916 ! flstxcg 9 pt. scale
 [Term]
 id: CO_331:0000266
 name: overall taste of cooked sample
+namespace: SweetpotatoTrait
 def: "Overall taste of cooked sample" []
 synonym: "RtFlsTs" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2271,10 +2395,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000269
 name: Overall taste of cooked sample estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall taste of cooked sample. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
 synonym: "COOT" EXACT []
 synonym: "RtFlsTs_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000266 ! overall taste of cooked sample
 relationship: variable_of CO_331:0000917 ! evaluation of cooked samples for taste
 relationship: variable_of CO_331:0000918 ! rttst 9 pt. scale
@@ -2282,6 +2407,7 @@ relationship: variable_of CO_331:0000918 ! rttst 9 pt. scale
 [Term]
 id: CO_331:0000270
 name: overall appearance of cooked sample
+namespace: SweetpotatoTrait
 def: "Appearance of cooked sample" []
 synonym: "RtFlsAp" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2290,10 +2416,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000273
 name: Overall appearance of cooked sample estimating 1-9
+namespace: SweetpotatoTrait
 def: "Appearance of cooked sample. 1= Very appealing, 2= Very appealing to appealing, 3= Appealing, 4= Appealing to somewhat appealing, 5= Somewhat appealing, 6= Somewhat appealing to unappealing, 7= Unappealing, 8= Unappealing to very unappealing, 9= Very unappealing" []
 synonym: "COOAP" EXACT []
 synonym: "RtFlsAp_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000270 ! overall appearance of cooked sample
 relationship: variable_of CO_331:0000919 ! evaluation of cooked samples for appearance
 relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
@@ -2301,6 +2428,7 @@ relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
 [Term]
 id: CO_331:0000274
 name: sprouting ability
+namespace: SweetpotatoTrait
 def: "ability to produce new sprout" []
 synonym: "RtSpA" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2309,10 +2437,11 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000277
 name: Sprouting ability estimating 1-9
+namespace: SweetpotatoTrait
 def: "ability to produce new sprout. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
 synonym: "RSPR" EXACT []
 synonym: "RtSpA_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000274 ! sprouting ability
 relationship: variable_of CO_331:0000921 ! evaluation of roots for sprouting ability
 relationship: variable_of CO_331:0000922 ! rtsprt 9 pt. scale
@@ -2320,10 +2449,11 @@ relationship: variable_of CO_331:0000922 ! rtsprt 9 pt. scale
 [Term]
 id: CO_331:0000278
 name: Protein content measuring percent
+namespace: SweetpotatoTrait
 def: "Protein content of the root" []
 synonym: "PRO, PROTEIN" EXACT []
 synonym: "RtFlsPrt_Ms_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000100 ! protein content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000923 ! protein content - method
@@ -2331,10 +2461,11 @@ relationship: variable_of CO_331:0000923 ! protein content - method
 [Term]
 id: CO_331:0000279
 name: Content of iron on dry weight basis measuring mg per 100g
+namespace: SweetpotatoTrait
 def: "Content of iron on dry weight basis of the root" []
 synonym: "FeDW" EXACT []
 synonym: "RtFlsFe_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000103 ! iron content
 relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: variable_of CO_331:0000925 ! mg/100g
@@ -2342,10 +2473,11 @@ relationship: variable_of CO_331:0000925 ! mg/100g
 [Term]
 id: CO_331:0000280
 name: Content of zinc on dry weight basis measuring mg per 100g
+namespace: SweetpotatoTrait
 def: "Content of zinc on dry weight basis of the root" []
 synonym: "RtFlsZn_Ms_mg100gDW" EXACT []
 synonym: "ZnDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000106 ! zinc content
 relationship: variable_of CO_331:0000925 ! mg/100g
 relationship: variable_of CO_331:0000927 ! content of zinc in dry weight basis - method
@@ -2353,6 +2485,7 @@ relationship: variable_of CO_331:0000927 ! content of zinc in dry weight basis -
 [Term]
 id: CO_331:0000281
 name: calcium content
+namespace: SweetpotatoTrait
 def: "Content of calcium on dry weight basis of the root" []
 synonym: "RtFlsCa" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2361,10 +2494,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000284
 name: Content of calcium on dry weight basis measuringm g per 100g
+namespace: SweetpotatoTrait
 def: "Content of calcium on dry weight basis of the root" []
 synonym: "CaDW" EXACT []
 synonym: "RtFlsCa_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000281 ! calcium content
 relationship: variable_of CO_331:0000925 ! mg/100g
 relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
@@ -2372,6 +2506,7 @@ relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basi
 [Term]
 id: CO_331:0000285
 name: magnesium content
+namespace: SweetpotatoTrait
 def: "Content of magnesium on dry weight basis of the root" []
 synonym: "RtFlsMg" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -2380,10 +2515,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000288
 name: Content of magnesium on dry weight basis measuring mg per 100g
+namespace: SweetpotatoTrait
 def: "Content of magnesium on dry weight basis of the root" []
 synonym: "MgDW" EXACT []
 synonym: "RtFlsMg_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000285 ! magnesium content
 relationship: variable_of CO_331:0000925 ! mg/100g
 relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
@@ -2391,10 +2527,11 @@ relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight ba
 [Term]
 id: CO_331:0000289
 name: Beta carotene content measuring mg per 100g
+namespace: SweetpotatoTrait
 def: "Beta carotene content of the root" []
 synonym: "BCDW" EXACT []
 synonym: "RtFlsBC_Ms_mg100gDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000109 ! beta-carotene content
 relationship: variable_of CO_331:0000925 ! mg/100g
 relationship: variable_of CO_331:0000930 ! beta carotene content - method
@@ -2402,10 +2539,11 @@ relationship: variable_of CO_331:0000930 ! beta carotene content - method
 [Term]
 id: CO_331:0000290
 name: Total carotenoids measuring mg per 100g
+namespace: SweetpotatoTrait
 def: "Total carotenoids content of the root" []
 synonym: "RtFlsTC_Ms_mg100gDW" EXACT []
 synonym: "TCDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000112 ! total carotenoids
 relationship: variable_of CO_331:0000925 ! mg/100g
 relationship: variable_of CO_331:0000931 ! total carotenoids - method
@@ -2413,10 +2551,11 @@ relationship: variable_of CO_331:0000931 ! total carotenoids - method
 [Term]
 id: CO_331:0000291
 name: Storage root starch content measuring percent
+namespace: SweetpotatoTrait
 def: "Storage root starch content evaluated in percentage dry weight" []
 synonym: "RtFlsSta_Ms_pct" EXACT []
 synonym: "STAR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000115 ! storage root starch content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000932 ! storage root starch content - method
@@ -2424,10 +2563,11 @@ relationship: variable_of CO_331:0000932 ! storage root starch content - method
 [Term]
 id: CO_331:0000292
 name: Fructose content measuring percent
+namespace: SweetpotatoTrait
 def: "Fructose content of the root" []
 synonym: "FRUC" EXACT []
 synonym: "RtFlsFru_Ms_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000118 ! fructose content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000933 ! fructose content - method
@@ -2435,10 +2575,11 @@ relationship: variable_of CO_331:0000933 ! fructose content - method
 [Term]
 id: CO_331:0000293
 name: Glucose content measuring percent
+namespace: SweetpotatoTrait
 def: "Glucose content of the root" []
 synonym: "GLUC" EXACT []
 synonym: "RtFlsGlu_Ms_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000121 ! glucose content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000934 ! glucose content - method
@@ -2446,10 +2587,11 @@ relationship: variable_of CO_331:0000934 ! glucose content - method
 [Term]
 id: CO_331:0000294
 name: Sucrose content measuring percent
+namespace: SweetpotatoTrait
 def: "Sucrose content of the root" []
 synonym: "RtFlsSuc_Ms_pct" EXACT []
 synonym: "SUCR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000124 ! sucrose content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000935 ! sucrose content - method
@@ -2457,10 +2599,11 @@ relationship: variable_of CO_331:0000935 ! sucrose content - method
 [Term]
 id: CO_331:0000295
 name: Maltose content measuring percent
+namespace: SweetpotatoTrait
 def: "Maltose content of the root" []
 synonym: "MALT" EXACT []
 synonym: "RtFlsMal_Ms_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000127 ! maltose content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000936 ! maltose content - method
@@ -2468,10 +2611,11 @@ relationship: variable_of CO_331:0000936 ! maltose content - method
 [Term]
 id: CO_331:0000296
 name: Yield of total roots per hectar computing tons per ha
+namespace: SweetpotatoTrait
 def: "Yield evaluated in the harvest" []
 synonym: "RtYld_Cp_tha" EXACT []
 synonym: "RYTHA" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000082 ! yield of total roots
 relationship: variable_of CO_331:0000897 ! t/ha
 relationship: variable_of CO_331:0000937 ! estimated yield per hectare - method
@@ -2479,10 +2623,11 @@ relationship: variable_of CO_331:0000937 ! estimated yield per hectare - method
 [Term]
 id: CO_331:0000297
 name: Storage root dry matter content computing percent
+namespace: SweetpotatoTrait
 def: "Storage root dry matter content" []
 synonym: "DM" EXACT []
 synonym: "RtDMC_Cp_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000142 ! storage root dry matter content
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000938 ! storage root dry matter content - method
@@ -2490,6 +2635,7 @@ relationship: variable_of CO_331:0000938 ! storage root dry matter content - met
 [Term]
 id: CO_331:0000298
 name: survival index
+namespace: SweetpotatoTrait
 def: "Survival index" []
 synonym: "IxSrv" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2498,10 +2644,11 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000301
 name: Survival index computing percent
+namespace: SweetpotatoTrait
 def: "Survival index" []
 synonym: "IxSrv_Cp_pct" EXACT []
 synonym: "SHI" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000298 ! survival index
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000939 ! survival index - method
@@ -2509,10 +2656,11 @@ relationship: variable_of CO_331:0000939 ! survival index - method
 [Term]
 id: CO_331:0000302
 name: Harvest index computing percent
+namespace: SweetpotatoTrait
 def: "Harvest index" []
 synonym: "HI" EXACT []
 synonym: "IxHrv_Cp_pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000085 ! harvest index
 relationship: variable_of CO_331:0000900 ! %
 relationship: variable_of CO_331:0000940 ! harvest index evaluation  - method
@@ -2520,6 +2668,7 @@ relationship: variable_of CO_331:0000940 ! harvest index evaluation  - method
 [Term]
 id: CO_331:0000303
 name: number of plants planted
+namespace: SweetpotatoTrait
 def: "Number of plants planted" []
 synonym: "PltPld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2528,6 +2677,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000304
 name: number of plants harvested
+namespace: SweetpotatoTrait
 def: "Number of plants harvested" []
 synonym: "PtHrv" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2536,6 +2686,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000307
 name: marketable root yield
+namespace: SweetpotatoTrait
 def: "Marketable root yield" []
 synonym: "RtCYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2544,6 +2695,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000308
 name: average commercial root weight
+namespace: SweetpotatoTrait
 def: "Average commercial root weight evaluated in the harvest" []
 synonym: "RtACRW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2552,6 +2704,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000309
 name: yield of total roots 2
+namespace: SweetpotatoTrait
 def: "Yield of total roots calculated after harvest" []
 synonym: "RtYPP" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2560,6 +2713,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000310
 name: percentage of marketable roots
+namespace: SweetpotatoTrait
 def: "Percentage of marketable roots after harvest" []
 synonym: "RtCI" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2568,6 +2722,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000311
 name: biomass yield
+namespace: SweetpotatoTrait
 def: "Biomass yield" []
 synonym: "BioYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2576,6 +2731,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000312
 name: foliage total yield
+namespace: SweetpotatoTrait
 def: "Foliage total yield" []
 synonym: "VnFolYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -2584,6 +2740,7 @@ created_by: W. Grueneberg
 [Term]
 id: CO_331:0000326
 name: storage root surface defects
+namespace: SweetpotatoTrait
 def: "Storage Root Surface Defects" []
 synonym: "RtSDef" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2592,6 +2749,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000327
 name: storage root cortex thickness
+namespace: SweetpotatoTrait
 def: "Storage Root Cortex Thickness" []
 synonym: "RtCThk" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2600,6 +2758,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000328
 name: flowering habit
+namespace: SweetpotatoTrait
 def: "An behavior pattern of the plant to produce flowers" []
 synonym: "FrHab" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2608,6 +2767,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000329
 name: flower size
+namespace: SweetpotatoTrait
 def: "Flower size" []
 synonym: "FrSiz" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2616,6 +2776,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000330
 name: shape of limb
+namespace: SweetpotatoTrait
 def: "Shape of limb" []
 synonym: "FrShL" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2624,6 +2785,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000331
 name: equality of sepal length
+namespace: SweetpotatoTrait
 def: "Equality of sepal length" []
 synonym: "FrSepEql" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2632,6 +2794,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000332
 name: number of sepal veins
+namespace: SweetpotatoTrait
 def: "Number of veins observed in the sepals" []
 synonym: "FrSepNVn" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2640,6 +2803,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000333
 name: sepal shape
+namespace: SweetpotatoTrait
 def: "Sepal shape" []
 synonym: "FrSepShp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2648,6 +2812,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000334
 name: sepal apex
+namespace: SweetpotatoTrait
 def: "Sepal apex" []
 synonym: "FrSepApx" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2656,6 +2821,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000335
 name: sepal pubescence
+namespace: SweetpotatoTrait
 def: "Degree of hairiness registered in the sepals" []
 synonym: "FrSepPub" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2664,6 +2830,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000336
 name: sepal color
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the sepal" []
 synonym: "FrSepCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2672,6 +2839,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000337
 name: color of stigma
+namespace: SweetpotatoTrait
 def: "Color of stigma" []
 synonym: "FrStgCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2680,6 +2848,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000338
 name: color of style
+namespace: SweetpotatoTrait
 def: "Color of style" []
 synonym: "FrStyCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2688,6 +2857,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000339
 name: stigma exertion
+namespace: SweetpotatoTrait
 def: "The relative position of the stigma as compared to the highest anther." []
 synonym: "FrStgExt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2696,6 +2866,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000340
 name: seed capsule set
+namespace: SweetpotatoTrait
 def: "Seed capsule set" []
 synonym: "FrSdCp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2704,6 +2875,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000341
 name: storage root formation
+namespace: SweetpotatoTrait
 def: "Arrangement of the storage roots on the underground stems." []
 synonym: "RtFrm" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2712,6 +2884,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000342
 name: storage root stalk
+namespace: SweetpotatoTrait
 def: "Length of stalk joining the storage roots to the stems" []
 synonym: "RtStk" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2720,6 +2893,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000343
 name: variability of storage root shape
+namespace: SweetpotatoTrait
 def: "Variability of storage root shape" []
 synonym: "RtShV" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2728,6 +2902,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000344
 name: variability of storage root size
+namespace: SweetpotatoTrait
 def: "Variability of storage root size" []
 synonym: "RtSzV" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2736,6 +2911,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000345
 name: keeping quality of storage roots
+namespace: SweetpotatoTrait
 def: "Keeping quality of storage roots" []
 synonym: "RtKQl" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2744,6 +2920,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000346
 name: consistency of boiled storage root
+namespace: SweetpotatoTrait
 def: "Consistency of boiled storage root" []
 synonym: "RtBlCu" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2752,6 +2929,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000347
 name: undesirable color of boiled storage root
+namespace: SweetpotatoTrait
 def: "Undesirable color of boiled storage root" []
 synonym: "RtBlCd" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -2760,6 +2938,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000348
 name: reaction to drought
+namespace: SweetpotatoTrait
 def: "Response to damage by water restriction." []
 synonym: "RnDrt" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2768,6 +2947,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000349
 name: reaction to flooding
+namespace: SweetpotatoTrait
 def: "Response of plant to inundation by water of all or part of the plant" []
 synonym: "RnFld" EXACT []
 synonym: "waterlogging response" EXACT []
@@ -2777,6 +2957,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000350
 name: reaction to heat
+namespace: SweetpotatoTrait
 def: "Response of a plant or plant part to damage by higher than normal temperatures" []
 synonym: "RnHeat" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2785,6 +2966,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000351
 name: reaction to salinity
+namespace: SweetpotatoTrait
 def: "Response of a plant to damage by high concentration salt" []
 synonym: "RnSlt" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2793,6 +2975,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000352
 name: reaction to shade
+namespace: SweetpotatoTrait
 def: "Response of plant to damage by shade" []
 synonym: "RnShd" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2801,6 +2984,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000353
 name: reaction to soil
+namespace: SweetpotatoTrait
 def: "Response of plant to damage by ph soil" []
 synonym: "RnSph" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2809,6 +2993,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000354
 name: reaction to high soil temperature
+namespace: SweetpotatoTrait
 def: "Response of a plant to damage by high concentration salt" []
 synonym: "RnSTp" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -2817,6 +3002,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000355
 name: reaction to west indian sweet potato weevil
+namespace: SweetpotatoTrait
 def: "Reaction to West Indian sweet potato weevil" []
 synonym: "RnWISPW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2825,6 +3011,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000356
 name: reaction to striped sweet potato weevil
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil" []
 synonym: "RnSSPW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2833,6 +3020,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000357
 name: reaction to sweet potato wire worms
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato wire worms" []
 synonym: "RnSPWW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2841,6 +3029,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000358
 name: reaction to wire worms
+namespace: SweetpotatoTrait
 def: "Reaction to Wire worms" []
 synonym: "RnWW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2849,6 +3038,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000359
 name: reaction to sweet potato flea beetles
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato flea beetles" []
 synonym: "RnSPFB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2857,6 +3047,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000360
 name: reaction to flea beetles
+namespace: SweetpotatoTrait
 def: "Reaction to flea beetles" []
 synonym: "RnFB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2865,6 +3056,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000361
 name: reaction to sweet potato leaf beetles
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato leaf beetles" []
 synonym: "RnSPLB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2873,6 +3065,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000362
 name: reaction to beetles
+namespace: SweetpotatoTrait
 def: "Reaction to Beetles" []
 synonym: "RnBTL" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2881,6 +3074,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000363
 name: reaction to grubworm
+namespace: SweetpotatoTrait
 def: "The reaction of the root to damage caused by Grub worm" []
 synonym: "RnGrbW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2889,6 +3083,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000364
 name: reaction to hornworm
+namespace: SweetpotatoTrait
 def: "The reaction of the root to damage caused by Hornworm" []
 synonym: "RnHrnw" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2897,6 +3092,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000365
 name: reaction to aphids
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Aphis" []
 synonym: "RnAph" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2905,6 +3101,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000366
 name: reaction to sweet potato white fly
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly" []
 synonym: "RnSPWF" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2913,6 +3110,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000367
 name: reaction to sweet potato moth
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato moth" []
 synonym: "RnSPMth" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2921,6 +3119,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000368
 name: reaction to moth
+namespace: SweetpotatoTrait
 def: "Reaction to Moth" []
 synonym: "RnMth" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2929,6 +3128,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000369
 name: reaction to sweet potato stem borer
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato stem borer" []
 synonym: "RnSPSB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2937,6 +3137,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000370
 name: reaction to other insects
+namespace: SweetpotatoTrait
 def: "Reaction to Other insects" []
 synonym: "RnIns" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2945,6 +3146,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000371
 name: reaction to reniform nematode
+namespace: SweetpotatoTrait
 def: "Reaction to Reniform nematode" []
 synonym: "RnRFN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2953,6 +3155,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000372
 name: reaction to sting nematode
+namespace: SweetpotatoTrait
 def: "Reaction to Sting nematode" []
 synonym: "RnStN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2961,6 +3164,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000373
 name: reaction to brown ring rot
+namespace: SweetpotatoTrait
 def: "Reaction to Brown ring rot" []
 synonym: "RnBRR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2969,6 +3173,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000374
 name: reaction to root lesion nematode
+namespace: SweetpotatoTrait
 def: "Reaction to Root lesion nematode" []
 synonym: "RnRLN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2977,6 +3182,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000375
 name: reaction to other nematodes
+namespace: SweetpotatoTrait
 def: "Reaction to other nematodes" []
 synonym: "RnON" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2985,6 +3191,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000376
 name: reaction to wilt rot
+namespace: SweetpotatoTrait
 def: "Reaction to Wilt rot" []
 synonym: "RnWR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -2993,6 +3200,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000377
 name: reaction to fusarium surface rot
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium surface rot" []
 synonym: "RnFRS" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3001,6 +3209,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000378
 name: reaction to fusarium root rot
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium root rot" []
 synonym: "RnFRR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3009,6 +3218,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000379
 name: reaction to sclerotial blight and circular spot
+namespace: SweetpotatoTrait
 def: "Reaction to Sclerotial blight and circular spot" []
 synonym: "RnSBC" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3017,6 +3227,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000380
 name: reaction to black rot
+namespace: SweetpotatoTrait
 def: "Reaction to Black rot" []
 synonym: "RnBR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3025,6 +3236,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000381
 name: reaction to scurf
+namespace: SweetpotatoTrait
 def: "Reaction to Scurf" []
 synonym: "RnScrf" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3033,6 +3245,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000382
 name: reaction to soft rot
+namespace: SweetpotatoTrait
 def: "Reaction to Soft rot" []
 synonym: "RnSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3041,6 +3254,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000383
 name: reaction to java black rot
+namespace: SweetpotatoTrait
 def: "Reaction to Java black rot" []
 synonym: "RnJBR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3049,6 +3263,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000384
 name: reaction to diaporthe dry rot
+namespace: SweetpotatoTrait
 def: "Reaction to Diaporthe dry rot" []
 synonym: "RnDDR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3057,6 +3272,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000385
 name: reaction to scab
+namespace: SweetpotatoTrait
 def: "Reaction to Scab" []
 synonym: "RnScb" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3065,6 +3281,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000386
 name: reaction to leaf spot
+namespace: SweetpotatoTrait
 def: "Reaction to leaf spot" []
 synonym: "RnLS" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3073,6 +3290,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000387
 name: reaction to white rust
+namespace: SweetpotatoTrait
 def: "Reaction to White rust" []
 synonym: "RnWR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3081,6 +3299,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000388
 name: reaction to foot rot
+namespace: SweetpotatoTrait
 def: "Reaction to Foot rot" []
 synonym: "RnFR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3089,6 +3308,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000389
 name: reaction to charcoal rot
+namespace: SweetpotatoTrait
 def: "Reaction to Charcoal rot" []
 synonym: "RnCR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3097,6 +3317,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000390
 name: reaction to other fungi
+namespace: SweetpotatoTrait
 def: "Reaction to Other fungi" []
 synonym: "RnOF" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3105,6 +3326,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000391
 name: reaction to pox or soil rot
+namespace: SweetpotatoTrait
 def: "Reaction to Pox or soil rot" []
 synonym: "RnPSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3113,6 +3335,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000392
 name: reaction to bacterial stem and root rot
+namespace: SweetpotatoTrait
 def: "Reaction to Bacterial stem and root rot" []
 synonym: "RnBSRt" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3121,6 +3344,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000393
 name: reaction to bacterial wilt
+namespace: SweetpotatoTrait
 def: "Reaction to Bacterial wilt" []
 synonym: "RnBW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3129,6 +3353,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000394
 name: reaction to other bacteria
+namespace: SweetpotatoTrait
 def: "Reaction to Other bacteria" []
 synonym: "RnOB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3137,6 +3362,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000395
 name: reaction to sweet potato feathery mottle virus (spmv)
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato feathery mottle virus (SPMV)" []
 synonym: "RnSPMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3145,6 +3371,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000396
 name: reaction to sweet potato mild mottle virus (spmmv)
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato mild mottle virus (SPMMV)" []
 synonym: "RnSPMMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3153,6 +3380,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000397
 name: reaction to sweet potato vein mottle virus (spvmv)
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato vein mottle virus (SPVMV)" []
 synonym: "RnSPVMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3161,6 +3389,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000398
 name: reaction to sweet potato virus disease complex (spvd complex)
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato virus disease complex (SPVD complex)" []
 synonym: "RnSPVD" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3169,6 +3398,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000399
 name: reaction to other virus
+namespace: SweetpotatoTrait
 def: "Reaction to Other virus" []
 synonym: "RnOV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3177,6 +3407,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000400
 name: reaction to witches broom
+namespace: SweetpotatoTrait
 def: "Reaction to Witches broom" []
 synonym: "RnWB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3185,6 +3416,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000401
 name: reaction to other mycoplasma
+namespace: SweetpotatoTrait
 def: "Reaction to Other mycoplasma" []
 synonym: "RnOM" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3193,6 +3425,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000402
 name: total sugar content
+namespace: SweetpotatoTrait
 def: "Total sugar content" []
 synonym: "RtTSgC" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
@@ -3201,6 +3434,7 @@ created_by: Z. Huaman
 [Term]
 id: CO_331:0000403
 name: appearance of plant
+namespace: SweetpotatoTrait
 def: "Appearance of plant" []
 synonym: "PtHbt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3209,6 +3443,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000404
 name: appearance of flower
+namespace: SweetpotatoTrait
 def: "Appearance of flower" []
 synonym: "FrCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3217,6 +3452,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000405
 name: appearance of roots
+namespace: SweetpotatoTrait
 def: "Appearance of roots" []
 synonym: "RtCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3225,6 +3461,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000406
 name: appearance of seeds
+namespace: SweetpotatoTrait
 def: "Appearance of seeds" []
 synonym: "FrSds" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3233,6 +3470,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000407
 name: appearance of leaves
+namespace: SweetpotatoTrait
 def: "Appearance of leaves" []
 synonym: "Lf" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3241,6 +3479,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000408
 name: appearance of hearbarium
+namespace: SweetpotatoTrait
 def: "Appearance of hearbarium" []
 synonym: "PtHrb" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3249,6 +3488,7 @@ created_by: G. Rossel
 [Term]
 id: CO_331:0000409
 name: storage root shape uniformity
+namespace: SweetpotatoTrait
 def: "Storage Root Shape uniformity within a single plant or plot" []
 synonym: "RtShpU" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3257,6 +3497,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000410
 name: storage root stalk length
+namespace: SweetpotatoTrait
 def: "Length of stalk joining the storage roots to the stems" []
 synonym: "RtStlk" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3265,6 +3506,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000411
 name: storage root attachment
+namespace: SweetpotatoTrait
 def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off" []
 synonym: "RtAtt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3273,6 +3515,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000412
 name: length to diameter ratio of roots
+namespace: SweetpotatoTrait
 def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
 synonym: "RtLDR" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3281,6 +3524,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000413
 name: skin color of roots
+namespace: SweetpotatoTrait
 def: "The most representative skin color observed is recorded" []
 synonym: "RtSknCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3289,6 +3533,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000414
 name: skin texture of roots
+namespace: SweetpotatoTrait
 def: "Storage root skin feel, appearance, or consistency by visual observation and touch" []
 synonym: "RtSknTxt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3297,6 +3542,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000415
 name: flesh color (carotenoids)
+namespace: SweetpotatoTrait
 def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
 synonym: "RtFlsColC" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3305,6 +3551,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000416
 name: flesh color (anthocyanins)
+namespace: SweetpotatoTrait
 def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
 synonym: "RtFlsColA" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3313,6 +3560,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000417
 name: deep of eyes of roots
+namespace: SweetpotatoTrait
 def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface" []
 synonym: "RtAdvB" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3321,6 +3569,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000418
 name: number of lenticels
+namespace: SweetpotatoTrait
 def: "Overall assessment of visible lenticels at the storage root interface" []
 synonym: "RtLtcl" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3329,6 +3578,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000419
 name: reaction to streptomyces soil rot
+namespace: SweetpotatoTrait
 def: "Streptomyces ipomoeae symptom evaluation" []
 synonym: "RnPSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3337,6 +3587,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000420
 name: reaction to root knot nematode meloidogyne spp
+namespace: SweetpotatoTrait
 def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation" []
 synonym: "RnMgRKN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3345,6 +3596,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000421
 name: reaction to root knot nematode meloidogyne incognita
+namespace: SweetpotatoTrait
 def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation" []
 synonym: "RnMgIRKN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3353,6 +3605,7 @@ created_by: A.Gonzales
 [Term]
 id: CO_331:0000422
 name: reaction to fusarium oxysporum
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium oxysporum batatas symptom evaluation" []
 synonym: "RnFR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3361,6 +3614,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000423
 name: storage root defects (primary)
+namespace: SweetpotatoTrait
 def: "Type and/or name of primary visible storage root defect" []
 synonym: "RtDam" EXACT []
 synonym: "RtDefP" EXACT []
@@ -3370,6 +3624,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000424
 name: relative storage root yield
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root yield" []
 synonym: "RtYldR" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3378,6 +3633,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000425
 name: storage root yield relative to check
+namespace: SweetpotatoTrait
 def: "Overall calculation of relative root yield" []
 synonym: "RtYldChk" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3386,6 +3642,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000426
 name: storage root appearance
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root yield appearance" []
 synonym: "RtApr" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3394,6 +3651,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000427
 name: growing season
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season" []
 synonym: "PtMtSs" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3402,6 +3660,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000428
 name: amylose content
+namespace: SweetpotatoTrait
 def: "Amylose content in sweetpotato" []
 synonym: "RtFlsAmy" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3410,6 +3669,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000429
 name: asparagine content
+namespace: SweetpotatoTrait
 def: "peonidin content of purple flesh sweetpotato" []
 synonym: "RtFlsAsp" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3418,6 +3678,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000430
 name: cyanidin content
+namespace: SweetpotatoTrait
 def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
 synonym: "RtFlsCya" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3426,6 +3687,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000431
 name: total monomeric anthocyanin content
+namespace: SweetpotatoTrait
 def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
 synonym: "RtFlsAntM" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3434,6 +3696,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000432
 name: peonidin content
+namespace: SweetpotatoTrait
 def: "Peonidin content of purple flesh sweetpotato" []
 synonym: "RtFlsPeo" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3442,6 +3705,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000433
 name: anthocyanin content
+namespace: SweetpotatoTrait
 def: "Anthocyanin content of purple flesh sweetpotato" []
 synonym: "RtFlsAnt" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3450,6 +3714,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000434
 name: phenol content
+namespace: SweetpotatoTrait
 def: "Phenol content of purple flesh sweetpotato" []
 synonym: "RtFlsPhe" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
@@ -3458,6 +3723,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000435
 name: nodes per vine
+namespace: SweetpotatoTrait
 def: "Nodes per vine" []
 synonym: "VnNds" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3466,6 +3732,7 @@ created_by: D. Gemenet
 [Term]
 id: CO_331:0000436
 name: leaves per plant
+namespace: SweetpotatoTrait
 def: "Leaves per plant" []
 synonym: "PtLvs" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3474,6 +3741,7 @@ created_by: D. Gemenet
 [Term]
 id: CO_331:0000437
 name: color of leave
+namespace: SweetpotatoTrait
 def: "Color of leave" []
 synonym: "LfCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3482,6 +3750,7 @@ created_by: D. Gemenet
 [Term]
 id: CO_331:0000438
 name: millipede damage
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by Millipede in roots" []
 synonym: "RtMillDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3490,6 +3759,7 @@ created_by: T.Carey
 [Term]
 id: CO_331:0000439
 name: alcidodes sp. damage
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by Alcidodes sp,  causes crown enlargement/galling or death by girdling" []
 synonym: "RtAlcDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3498,6 +3768,7 @@ created_by: T.Carey
 [Term]
 id: CO_331:0000440
 name: soil insect damage
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by soil insect" []
 synonym: "RtSInsDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -3506,6 +3777,7 @@ created_by: T.Carey
 [Term]
 id: CO_331:0000441
 name: storage root shape (secondary)
+namespace: SweetpotatoTrait
 def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots" []
 synonym: "RtShpS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
@@ -3514,10 +3786,11 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000600
 name: Overall storage root disease symptoms estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
 synonym: "DISEASE" EXACT []
 synonym: "RtDSm_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
 created_by: C. Yencho
 creation_date: 2016-12-01T04:02:09Z
@@ -3525,6 +3798,7 @@ creation_date: 2016-12-01T04:02:09Z
 [Term]
 id: CO_331:0000601
 name: weight of total US no. 1 storage roots
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects." []
 synonym: "RtUS1W" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3533,6 +3807,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000602
 name: weight of canner storage roots
+namespace: SweetpotatoTrait
 def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length." []
 synonym: "RtCanW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3541,6 +3816,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000603
 name: weight of jumbo storage roots
+namespace: SweetpotatoTrait
 def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality." []
 synonym: "RtJumW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3549,6 +3825,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000604
 name: weight of cull storage roots
+namespace: SweetpotatoTrait
 def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades" []
 synonym: "RtCulW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3557,6 +3834,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000605
 name: weight of 90 count US no. 1 storage roots
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box." []
 synonym: "Rt90ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3565,6 +3843,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000606
 name: weight of 55 count US no. 1 storage roots
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box." []
 synonym: "Rt55ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3573,6 +3852,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000607
 name: weight of 40 count US no. 1 storage roots
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box." []
 synonym: "Rt40ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3581,6 +3861,7 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000608
 name: weight of 32 count US no. 1 storage roots
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box." []
 synonym: "Rt32ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
@@ -3589,10 +3870,11 @@ created_by: C. Yencho
 [Term]
 id: CO_331:0000609
 name: weight of total US no. 1 storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects. Measured in kilograms per plot." []
 synonym: "RtUS1W_Ms_kgplot" EXACT []
 synonym: "US1" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000601 ! weight of total US no. 1 storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3600,10 +3882,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000610
 name: weight of canner storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length. Measured in kilograms per plot." []
 synonym: "CAN" EXACT []
 synonym: "RtCanW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000602 ! weight of canner storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3611,10 +3894,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000611
 name: weight of jumbo storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality. Measured in kilograms per plot." []
 synonym: "JUM" EXACT []
 synonym: "RtJumW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000603 ! weight of jumbo storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3622,10 +3906,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000612
 name: weight of cull storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades. Measured in kilograms per plot." []
 synonym: "CUL" EXACT []
 synonym: "RtCulW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000604 ! weight of cull storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3633,10 +3918,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000613
 name: weight of 90 count US no. 1 storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box. Measured in kilograms per plot." []
 synonym: "90CT" EXACT []
 synonym: "Rt90ctW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000605 ! weight of 90 count US no. 1 storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3644,10 +3930,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000614
 name: weight of 55 count US no. 1 storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box. Measured in kilograms per plot." []
 synonym: "55CT" EXACT []
 synonym: "Rt55ctW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000606 ! weight of 55 count US no. 1 storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3655,10 +3942,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000615
 name: weight of 40 count US no. 1 storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box. Measured in kilograms per plot." []
 synonym: "40CT" EXACT []
 synonym: "Rt40ctW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000607 ! weight of 40 count US no. 1 storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3666,10 +3954,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000616
 name: weight of 32 count US no. 1 storage roots measuring kg per plot
+namespace: SweetpotatoTrait
 def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box. Measured in kilograms per plot." []
 synonym: "32CT" EXACT []
 synonym: "Rt32ctW_Ms_kgplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000608 ! weight of 32 count US no. 1 storage roots
 relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
@@ -3677,10 +3966,11 @@ relationship: variable_of CO_331:0000893 ! kg/plot
 [Term]
 id: CO_331:0000678
 name: Plants planted counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of plants planted" []
 synonym: "NOPS" EXACT []
 synonym: "PltPld_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000303 ! number of plants planted
 relationship: variable_of CO_331:0000871 ! plants/plot
 relationship: variable_of CO_331:0000872 ! recording planting materials
@@ -3688,10 +3978,11 @@ relationship: variable_of CO_331:0000872 ! recording planting materials
 [Term]
 id: CO_331:0000679
 name: Plants harvested counting number per plot
+namespace: SweetpotatoTrait
 def: "Number of plants harvested" []
 synonym: "NOPH" EXACT []
 synonym: "PtHrv_Ct_plplot" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000304 ! number of plants harvested
 relationship: variable_of CO_331:0000871 ! plants/plot
 relationship: variable_of CO_331:0000885 ! evaluation of plants
@@ -3699,10 +3990,11 @@ relationship: variable_of CO_331:0000885 ! evaluation of plants
 [Term]
 id: CO_331:0000680
 name: Storage root marketable yield weight computation tons per ha
+namespace: SweetpotatoTrait
 def: "Average commercial root weight evaluated in the harvest" []
 synonym: "ACRW" EXACT []
 synonym: "RtACRW_Cp_g" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000308 ! average commercial root weight
 relationship: variable_of CO_331:0000896 ! estimated marketable yield per hectare - method
 relationship: variable_of CO_331:0000897 ! t/ha
@@ -3710,10 +4002,11 @@ relationship: variable_of CO_331:0000897 ! t/ha
 [Term]
 id: CO_331:0000681
 name: Storage root total yield computation tons per ha
+namespace: SweetpotatoTrait
 def: "Yield of total roots calculated after harvest" []
 synonym: "RtYPP_Cp_kpl" EXACT []
 synonym: "YPP" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000309 ! yield of total roots 2
 relationship: variable_of CO_331:0000897 ! t/ha
 relationship: variable_of CO_331:0000898 ! estimated yield of total roots per hectare - method
@@ -3721,10 +4014,11 @@ relationship: variable_of CO_331:0000898 ! estimated yield of total roots per he
 [Term]
 id: CO_331:0000682
 name: Storage root marketable yield fraction computation percent
+namespace: SweetpotatoTrait
 def: "Percentage of marketable roots after harvest" []
 synonym: "CI" EXACT []
 synonym: "RtCI_Cp_Pct" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000310 ! percentage of marketable roots
 relationship: variable_of CO_331:0000899 ! percentage of marketable - method
 relationship: variable_of CO_331:0000900 ! %
@@ -3732,10 +4026,11 @@ relationship: variable_of CO_331:0000900 ! %
 [Term]
 id: CO_331:0000683
 name: Biomass yield weight computation tons per ha
+namespace: SweetpotatoTrait
 def: "Biomass yield" []
 synonym: "BIOM" EXACT []
 synonym: "BioYld_Cp" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000311 ! biomass yield
 relationship: variable_of CO_331:0000897 ! t/ha
 relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
@@ -3743,10 +4038,11 @@ relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
 [Term]
 id: CO_331:0000684
 name: Foliage total yield computation tons per hectare
+namespace: SweetpotatoTrait
 def: "Foliage total yield" []
 synonym: "FYTHA" EXACT []
 synonym: "VnFolYld_Cp_tha" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000312 ! foliage total yield
 relationship: variable_of CO_331:0000897 ! t/ha
 relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
@@ -3754,10 +4050,11 @@ relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
 [Term]
 id: CO_331:0000685
 name: Content of iron on dry weight basis measuring mg per kg
+namespace: SweetpotatoTrait
 def: "Content of iron on dry weight basis of the root" []
 synonym: "FeDW" EXACT []
 synonym: "RtFlsFe_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000103 ! iron content
 relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: variable_of CO_331:0000926 ! mg/kg
@@ -3765,10 +4062,11 @@ relationship: variable_of CO_331:0000926 ! mg/kg
 [Term]
 id: CO_331:0000686
 name: Content of zinc on dry weight basis measuring mg per kg
+namespace: SweetpotatoTrait
 def: "Content of iron on dry weight basis of the root" []
 synonym: "FeDW" EXACT []
 synonym: "RtFlsZn_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000106 ! zinc content
 relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: variable_of CO_331:0000926 ! mg/kg
@@ -3776,10 +4074,11 @@ relationship: variable_of CO_331:0000926 ! mg/kg
 [Term]
 id: CO_331:0000687
 name: Content of calcium on dry weight basis measuring mg per kg
+namespace: SweetpotatoTrait
 def: "Content of iron on dry weight basis of the root" []
 synonym: "CaDW" EXACT []
 synonym: "RtFlsCa_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000281 ! calcium content
 relationship: variable_of CO_331:0000926 ! mg/kg
 relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
@@ -3787,10 +4086,11 @@ relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basi
 [Term]
 id: CO_331:0000688
 name: Content of magnesium on dry weight basis measuring mg per kg
+namespace: SweetpotatoTrait
 def: "Content of magnesium on dry weight basis of the root" []
 synonym: "MgDW" EXACT []
 synonym: "RtFlsMg_Ms_mgkgDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000285 ! magnesium content
 relationship: variable_of CO_331:0000926 ! mg/kg
 relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
@@ -3798,10 +4098,11 @@ relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight ba
 [Term]
 id: CO_331:0000689
 name: Color of boiled roots estimating 0-3
+namespace: SweetpotatoTrait
 def: "Color of boiled roots. O = Orange, IO = Intermediate orange, DO = Deep orange" []
 synonym: "COLBR" EXACT []
 synonym: "RtCb_Et_0to3" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000133 ! color of boiled roots
 relationship: variable_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
 relationship: variable_of CO_331:0000942 ! rtscb 3 pt. scale
@@ -3809,10 +4110,11 @@ relationship: variable_of CO_331:0000942 ! rtscb 3 pt. scale
 [Term]
 id: CO_331:0000690
 name: Storage Root Surface Defects estimating 1-9
+namespace: SweetpotatoTrait
 def: "Storage Root Surface Defects. 0 = Absent, 1 = Alligator-like skin, 2 = Veins, 3 = Shallow horizontal constrictions, 4 = Deep horizontal constrictions, 5 =Shallow longitudinal grooves, 6 = Deep longitudinal grooves, 7 = Deep constrictions and deep grooves, 8 = Other" []
 synonym: "RtSDef_Et_1to9" EXACT []
 synonym: "RTSUR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000326 ! storage root surface defects
 relationship: variable_of CO_331:0000943 ! observation of storage root surface defects
 relationship: variable_of CO_331:0000944 ! rtssdef 9 pt. scale
@@ -3820,10 +4122,11 @@ relationship: variable_of CO_331:0000944 ! rtssdef 9 pt. scale
 [Term]
 id: CO_331:0000691
 name: Storage Root Cortex Thickness estimating 1-9
+namespace: SweetpotatoTrait
 def: "Storage Root Cortex Thickness. 1 = Very thin (1 mm), 3 = Thin (1-2 mm), 5 = Intermediate (2-3 mm), 7 = Thick (3-4 mm), 9 = Very thick (>4 mm)" []
 synonym: "RTCOR" EXACT []
 synonym: "RtCThk_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000327 ! storage root cortex thickness
 relationship: variable_of CO_331:0000945 ! observation of storage root cortex thickness
 relationship: variable_of CO_331:0000946 ! rtscthi 5 pt. scale
@@ -3831,10 +4134,11 @@ relationship: variable_of CO_331:0000946 ! rtscthi 5 pt. scale
 [Term]
 id: CO_331:0000692
 name: Flowering habit estimating 0-7
+namespace: SweetpotatoTrait
 def: "An behavior pattern of the plant to produce flowers. 0 = None, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
 synonym: "FLWHAB" EXACT []
 synonym: "FrHab_Et_0to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000328 ! flowering habit
 relationship: variable_of CO_331:0000947 ! observation of number flowers in the inflorescence
 relationship: variable_of CO_331:0000948 ! flrhab 4 pt. scale
@@ -3842,10 +4146,11 @@ relationship: variable_of CO_331:0000948 ! flrhab 4 pt. scale
 [Term]
 id: CO_331:0000693
 name: Flower size measuring cm
+namespace: SweetpotatoTrait
 def: "Flower size" []
 synonym: "FLESIZ" EXACT []
 synonym: "FrSiz_Ms_cm" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000329 ! flower size
 relationship: variable_of CO_331:0000949 ! measurement of flower length and width in cm
 relationship: variable_of CO_331:0000950 ! cm
@@ -3853,10 +4158,11 @@ relationship: variable_of CO_331:0000950 ! cm
 [Term]
 id: CO_331:0000694
 name: Shape of limb estimating 3-7
+namespace: SweetpotatoTrait
 def: "Shape of limb. 3 = Semi-stellate, 5= Pentagonal, 7 = Rounded" []
 synonym: "FLLMB" EXACT []
 synonym: "FrShL_Et_3to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000330 ! shape of limb
 relationship: variable_of CO_331:0000951 ! observation of shape limb in the flowers in the inflorescence
 relationship: variable_of CO_331:0000952 ! flrshl 3 pt. scale
@@ -3864,10 +4170,11 @@ relationship: variable_of CO_331:0000952 ! flrshl 3 pt. scale
 [Term]
 id: CO_331:0000695
 name: Equality of sepal length estimating 1-2
+namespace: SweetpotatoTrait
 def: "Equality of sepal length. 1 = Outer two shorter, 2 = Equal" []
 synonym: "FrSepEql_Et_1to2" EXACT []
 synonym: "SEPLEQ" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000331 ! equality of sepal length
 relationship: variable_of CO_331:0000953 ! equality of sepal length
 relationship: variable_of CO_331:0000954 ! sepeql 2 pt. scale
@@ -3875,10 +4182,11 @@ relationship: variable_of CO_331:0000954 ! sepeql 2 pt. scale
 [Term]
 id: CO_331:0000696
 name: Sepal veins counting number
+namespace: SweetpotatoTrait
 def: "Number of veins observed in the sepals" []
 synonym: "FrSepNVn_Ct_perSpl" EXACT []
 synonym: "SEPVNM" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000332 ! number of sepal veins
 relationship: variable_of CO_331:0000955 ! record the most frequent number in ten typical flowers
 relationship: variable_of CO_331:0000956 ! number
@@ -3886,10 +4194,11 @@ relationship: variable_of CO_331:0000956 ! number
 [Term]
 id: CO_331:0000697
 name: Sepal shape estimating 1-9
+namespace: SweetpotatoTrait
 def: "Sepal shape. 1 = Ovate, 3 = Elliptic, 5 = Obovate, 7 = Oblong, 9 = Lanceolate" []
 synonym: "FrSepShp_Et_1to9" EXACT []
 synonym: "SEPSHP" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000333 ! sepal shape
 relationship: variable_of CO_331:0000957 ! observation of  sepal shape
 relationship: variable_of CO_331:0000958 ! sepshp 5 pt. scale
@@ -3897,10 +4206,11 @@ relationship: variable_of CO_331:0000958 ! sepshp 5 pt. scale
 [Term]
 id: CO_331:0000698
 name: Sepal apex estimating 1-7
+namespace: SweetpotatoTrait
 def: "Sepal apex. 1 = Acute, 3 = Obtuse, 5 = Acuminate, 7 = Caudate" []
 synonym: "FrSepApx_Et_1to7" EXACT []
 synonym: "SEPAPX" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000334 ! sepal apex
 relationship: variable_of CO_331:0000959 ! observation of sepal apex
 relationship: variable_of CO_331:0000960 ! sepapx 4 pt. scale
@@ -3908,10 +4218,11 @@ relationship: variable_of CO_331:0000960 ! sepapx 4 pt. scale
 [Term]
 id: CO_331:0000699
 name: Sepal pubescence estimating 0-7
+namespace: SweetpotatoTrait
 def: "Degree of hairiness registered in the sepals. 0 = Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
 synonym: "FrSepPub_Et_0to7" EXACT []
 synonym: "SEPPUB" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000335 ! sepal pubescence
 relationship: variable_of CO_331:0000961 ! observation of sepal pubescence
 relationship: variable_of CO_331:0000962 ! seppub 4 pt. scale
@@ -3919,10 +4230,11 @@ relationship: variable_of CO_331:0000962 ! seppub 4 pt. scale
 [Term]
 id: CO_331:0000700
 name: Sepal color estimating 1-9
+namespace: SweetpotatoTrait
 def: "Anthocyanin (purple) pigmentation present in the sepal. 1 = Green, 2 = Green with purple edge, 3 = Green with purple spots, 5 = Green with purple areas, 6 = Sorne sepals green, others purple, 9 = Totally pigrnented - dark purple" []
 synonym: "FrSepCol_Et_3to7" EXACT []
 synonym: "SEPCOL" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000336 ! sepal color
 relationship: variable_of CO_331:0000963 ! observation of sepal color
 relationship: variable_of CO_331:0000964 ! sepcol 7 pt. scale
@@ -3930,10 +4242,11 @@ relationship: variable_of CO_331:0000964 ! sepcol 7 pt. scale
 [Term]
 id: CO_331:0000701
 name: Color of stigma estimating 1-9
+namespace: SweetpotatoTrait
 def: "Color of stigma. 1 = White, 5 = Pale purple, 9 = Purple" []
 synonym: "FrStgCol_Et_1to9" EXACT []
 synonym: "STGCOL" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000337 ! color of stigma
 relationship: variable_of CO_331:0000965 ! observation of stigma color
 relationship: variable_of CO_331:0000966 ! stgcol 3 pt. scale
@@ -3941,10 +4254,11 @@ relationship: variable_of CO_331:0000966 ! stgcol 3 pt. scale
 [Term]
 id: CO_331:0000702
 name: Color of style estimating 1-9
+namespace: SweetpotatoTrait
 def: "Color of style. 1 = White, 3 = White with purple at the base, 5 = White with purple at the top, 7 = White with purple spots throughout, 9 = Purple" []
 synonym: "FrStyCol_Et_1to9" EXACT []
 synonym: "STYCOL" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000338 ! color of style
 relationship: variable_of CO_331:0000967 ! observation of style color
 relationship: variable_of CO_331:0000968 ! stycol 5 pt. scale
@@ -3952,10 +4266,11 @@ relationship: variable_of CO_331:0000968 ! stycol 5 pt. scale
 [Term]
 id: CO_331:0000703
 name: Stigma exertion estimating 1-7
+namespace: SweetpotatoTrait
 def: "The relative position of the stigma as compared to the highest anther.. 1 = Inserted (shorter than longest anther), 3 = Same height as highest anther, 5 = Slighty exerted, 7 = Exerted (longer than longest anther)" []
 synonym: "FrStgExt_Et_1to7" EXACT []
 synonym: "STGEXT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000339 ! stigma exertion
 relationship: variable_of CO_331:0000969 ! observation of stigma exertion
 relationship: variable_of CO_331:0000970 ! stgext 4 pt. scale
@@ -3963,10 +4278,11 @@ relationship: variable_of CO_331:0000970 ! stgext 4 pt. scale
 [Term]
 id: CO_331:0000704
 name: Seed capsule set estimating 0-7
+namespace: SweetpotatoTrait
 def: "Seed capsule set. 0 = None, 1 = Scarce, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
 synonym: "FrSdCp_Et_0to7" EXACT []
 synonym: "SEDCAP" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000340 ! seed capsule set
 relationship: variable_of CO_331:0000971 ! observation of seed capsule set
 relationship: variable_of CO_331:0000972 ! sedcap 5 pt. scale
@@ -3974,10 +4290,11 @@ relationship: variable_of CO_331:0000972 ! sedcap 5 pt. scale
 [Term]
 id: CO_331:0000705
 name: Storage root formation estimating 1-7
+namespace: SweetpotatoTrait
 def: "Arrangement of the storage roots on the underground stems.. 1 = Closed cluster, 3 = Open cluster, 5 = Dispersed, 7 = Very dispersed" []
 synonym: "RTFORM" EXACT []
 synonym: "RtFrm_Et_1to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000341 ! storage root formation
 relationship: variable_of CO_331:0000973 ! observation of storage root formation
 relationship: variable_of CO_331:0000974 ! strfor 4 pt. scale
@@ -3985,10 +4302,11 @@ relationship: variable_of CO_331:0000974 ! strfor 4 pt. scale
 [Term]
 id: CO_331:0000706
 name: Storage root stalk estimating 0-7
+namespace: SweetpotatoTrait
 def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
 synonym: "RTSTFM" EXACT []
 synonym: "RtStk_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000342 ! storage root stalk
 relationship: variable_of CO_331:0000975 ! observation of storage root stalk
 relationship: variable_of CO_331:0000976 ! strstk 6 pt. scale
@@ -3996,10 +4314,11 @@ relationship: variable_of CO_331:0000976 ! strstk 6 pt. scale
 [Term]
 id: CO_331:0000707
 name: Variability of storage root shape estimating 3-7
+namespace: SweetpotatoTrait
 def: "Variability of storage root shape. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
 synonym: "RTSHPV" EXACT []
 synonym: "RtShV_Et_3to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000343 ! variability of storage root shape
 relationship: variable_of CO_331:0000977 ! observation of variability of storage root shape
 relationship: variable_of CO_331:0000978 ! vrtssh 3 pt. scale
@@ -4007,10 +4326,11 @@ relationship: variable_of CO_331:0000978 ! vrtssh 3 pt. scale
 [Term]
 id: CO_331:0000708
 name: Variability of storage root size estimating 3-7
+namespace: SweetpotatoTrait
 def: "Variability of storage root size. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
 synonym: "RTSIZV" EXACT []
 synonym: "RtSzV_Et_3to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000344 ! variability of storage root size
 relationship: variable_of CO_331:0000979 ! observation of variability of storage root size
 relationship: variable_of CO_331:0000980 ! vrtssiz 3 pt. scale
@@ -4018,10 +4338,11 @@ relationship: variable_of CO_331:0000980 ! vrtssiz 3 pt. scale
 [Term]
 id: CO_331:0000709
 name: Keeping quality of storage roots estimating 3-7
+namespace: SweetpotatoTrait
 def: "Keeping quality of storage roots. 3 = Poor, 5 = Medium, 7 = Good" []
 synonym: "RTKQL" EXACT []
 synonym: "RtKQl_Et_3to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000345 ! keeping quality of storage roots
 relationship: variable_of CO_331:0000981 ! observation of keeping quality of storage roots
 relationship: variable_of CO_331:0000982 ! kqtyrts 3 pt. scale
@@ -4029,10 +4350,11 @@ relationship: variable_of CO_331:0000982 ! kqtyrts 3 pt. scale
 [Term]
 id: CO_331:0000710
 name: Consistency of boiled storage root estimating 1-9
+namespace: SweetpotatoTrait
 def: "Consistency of boiled storage root. 1 = Watery, 2 = Extremely soft, 3 = Very soft, 4 = Soft, 5 = Slighty hard, 6 = Moderately hard, 7 = Hard, 8 = Very hard, 9 = Very hard and non-cooked" []
 synonym: "RTBCOLD" EXACT []
 synonym: "RtBlCu_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000346 ! consistency of boiled storage root
 relationship: variable_of CO_331:0000983 ! observation of consistency of boiled storage root
 relationship: variable_of CO_331:0000984 ! cbolrts 9 pt. scale
@@ -4040,10 +4362,11 @@ relationship: variable_of CO_331:0000984 ! cbolrts 9 pt. scale
 [Term]
 id: CO_331:0000711
 name: Undesirable color of boiled storage root estimating 0-9
+namespace: SweetpotatoTrait
 def: "Undesirable color of boiled storage root. 0 = None, 1 = Sorne beige, 2 = Much beige, 3 = Slighty green or grey, 4 = Green, 5 = Grey, 6 = Beige and green, 7 = Beige and grey, 8 = Beige and purple, 9 = Purple" []
 synonym: "RTBCOLU" EXACT []
 synonym: "RtBlCd_Et_0to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000347 ! undesirable color of boiled storage root
 relationship: variable_of CO_331:0000985 ! observation of undesirable color of boiled storage root
 relationship: variable_of CO_331:0000986 ! ucolbrts 10 pt. scale
@@ -4051,10 +4374,11 @@ relationship: variable_of CO_331:0000986 ! ucolbrts 10 pt. scale
 [Term]
 id: CO_331:0000712
 name: Reaction to drought estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response to damage by water restriction.. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "DROUGHT" EXACT []
 synonym: "RnDrt_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000348 ! reaction to drought
 relationship: variable_of CO_331:0000987 ! visual estimation of the plant response to  limited water availability
 relationship: variable_of CO_331:0000988 ! rctdro 5 pt. scale
@@ -4062,10 +4386,11 @@ relationship: variable_of CO_331:0000988 ! rctdro 5 pt. scale
 [Term]
 id: CO_331:0000713
 name: Reaction to flooding estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of plant to inundation by water of all or part of the plant. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FLOOD" EXACT []
 synonym: "RnFld_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000349 ! reaction to flooding
 relationship: variable_of CO_331:0000989 ! visual estimation of the plant response to  flooding (watering saturated soil)
 relationship: variable_of CO_331:0000990 ! rctflo 5 pt. scale
@@ -4073,10 +4398,11 @@ relationship: variable_of CO_331:0000990 ! rctflo 5 pt. scale
 [Term]
 id: CO_331:0000714
 name: Reaction to heat estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of a plant or plant part to damage by higher than normal temperatures. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "HEAT" EXACT []
 synonym: "RnHeat_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000350 ! reaction to heat
 relationship: variable_of CO_331:0000991 ! visual estimation of the plant response to  hot season with night temperatures of more than 22°c
 relationship: variable_of CO_331:0000992 ! rctheat 5 pt. scale
@@ -4084,10 +4410,11 @@ relationship: variable_of CO_331:0000992 ! rctheat 5 pt. scale
 [Term]
 id: CO_331:0000715
 name: Reaction to salinity estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSlt_Et_1to9" EXACT []
 synonym: "SALINITY" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000351 ! reaction to salinity
 relationship: variable_of CO_331:0000993 ! visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
 relationship: variable_of CO_331:0000994 ! rctsty 5 pt. scale
@@ -4095,10 +4422,11 @@ relationship: variable_of CO_331:0000994 ! rctsty 5 pt. scale
 [Term]
 id: CO_331:0000716
 name: Reaction to shade estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of plant to damage by shade. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnShd_Et_1to9" EXACT []
 synonym: "SHADE" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000352 ! reaction to shade
 relationship: variable_of CO_331:0000995 ! visual estimation of the plant response to  shape
 relationship: variable_of CO_331:0000996 ! rctshd 5 pt. scale
@@ -4106,10 +4434,11 @@ relationship: variable_of CO_331:0000996 ! rctshd 5 pt. scale
 [Term]
 id: CO_331:0000717
 name: Reaction to soil pH estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of plant to damage by ph soil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSph_Et_1to9" EXACT []
 synonym: "SOILPH" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000353 ! reaction to soil
 relationship: variable_of CO_331:0000997 ! visual estimation of the plant response to  acid and heavy ph soil below 5
 relationship: variable_of CO_331:0000998 ! rctsph 5 pt. scale
@@ -4117,10 +4446,11 @@ relationship: variable_of CO_331:0000998 ! rctsph 5 pt. scale
 [Term]
 id: CO_331:0000718
 name: Reaction to high soil temperature estimating 1-9
+namespace: SweetpotatoTrait
 def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSTp_Et_1to9" EXACT []
 synonym: "SOILTEMP" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001000 ! rctstp 5 pt. scale
 relationship: variable_of CO_331:0000354 ! reaction to high soil temperature
 relationship: variable_of CO_331:0000999 ! visual estimation of the plant response to  hight soil temperature (40 °c)
@@ -4128,10 +4458,11 @@ relationship: variable_of CO_331:0000999 ! visual estimation of the plant respon
 [Term]
 id: CO_331:0000719
 name: Reaction to West Indian sweet potato weevil estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to West Indian sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnWISPW_Et_1to9" EXACT []
 synonym: "WISPWV" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001001 ! visual estimation of the plant response to  west indian sweet potato weevil
 relationship: variable_of CO_331:00001002 ! rcwispw 5 pt. scale
 relationship: variable_of CO_331:0000355 ! reaction to west indian sweet potato weevil
@@ -4139,10 +4470,11 @@ relationship: variable_of CO_331:0000355 ! reaction to west indian sweet potato 
 [Term]
 id: CO_331:0000720
 name: Reaction to Striped sweet potato weevil estimating 1-9
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSSPW_Et_1to9" EXACT []
 synonym: "STSPWV" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001003 ! visual estimation of the plant response to  striped sweet potato weevil
 relationship: variable_of CO_331:00001004 ! rcsspw 5 pt. scale
 relationship: variable_of CO_331:0000356 ! reaction to striped sweet potato weevil
@@ -4150,10 +4482,11 @@ relationship: variable_of CO_331:0000356 ! reaction to striped sweet potato weev
 [Term]
 id: CO_331:0000721
 name: Reaction to Sweet potato wire worms estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPWW_Et_1to9" EXACT []
 synonym: "SPWW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001005 ! visual estimation of the plant response to  sweet potato wire worms
 relationship: variable_of CO_331:00001006 ! rcspww 5 pt. scale
 relationship: variable_of CO_331:0000357 ! reaction to sweet potato wire worms
@@ -4161,10 +4494,11 @@ relationship: variable_of CO_331:0000357 ! reaction to sweet potato wire worms
 [Term]
 id: CO_331:0000722
 name: Reaction to Wire worms estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnWW_Et_1to9" EXACT []
 synonym: "WIREWORMS" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001007 ! visual estimation of the plant response to  wire worms
 relationship: variable_of CO_331:00001008 ! rcww 5 pt. scale
 relationship: variable_of CO_331:0000358 ! reaction to wire worms
@@ -4172,10 +4506,11 @@ relationship: variable_of CO_331:0000358 ! reaction to wire worms
 [Term]
 id: CO_331:0000723
 name: Reaction to Sweet potato flea beetles estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPFB_Et_1to9" EXACT []
 synonym: "SPFB" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001009 ! visual estimation of the plant response to  sweet potato flea beetles
 relationship: variable_of CO_331:00001010 ! rcspfb 5 pt. scale
 relationship: variable_of CO_331:0000359 ! reaction to sweet potato flea beetles
@@ -4183,10 +4518,11 @@ relationship: variable_of CO_331:0000359 ! reaction to sweet potato flea beetles
 [Term]
 id: CO_331:0000724
 name: Reaction to flea beetles estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FLEABEETLE" EXACT []
 synonym: "RnFB_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001011 ! visual estimation of the plant response to  flea beetles
 relationship: variable_of CO_331:00001012 ! rcfb 5 pt. scale
 relationship: variable_of CO_331:0000360 ! reaction to flea beetles
@@ -4194,10 +4530,11 @@ relationship: variable_of CO_331:0000360 ! reaction to flea beetles
 [Term]
 id: CO_331:0000725
 name: Reaction to Sweet potato leaf beetles estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato leaf beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPLB_Et_1to9" EXACT []
 synonym: "SPFB" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001013 ! visual estimation of the plant response to  sweet potato leaf beetles
 relationship: variable_of CO_331:00001014 ! rcsplb 5 pt. scale
 relationship: variable_of CO_331:0000361 ! reaction to sweet potato leaf beetles
@@ -4205,10 +4542,11 @@ relationship: variable_of CO_331:0000361 ! reaction to sweet potato leaf beetles
 [Term]
 id: CO_331:0000726
 name: Reaction to Beetles estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BEETLES" EXACT []
 synonym: "RnBTL_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001015 ! visual estimation of the plant response to  beetles
 relationship: variable_of CO_331:00001016 ! rcbtl 5 pt. scale
 relationship: variable_of CO_331:0000362 ! reaction to beetles
@@ -4216,10 +4554,11 @@ relationship: variable_of CO_331:0000362 ! reaction to beetles
 [Term]
 id: CO_331:0000727
 name: Reaction to Grubworm estimating 1-9
+namespace: SweetpotatoTrait
 def: "The reaction of the root to damage caused by Grub worm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "GRUBW" EXACT []
 synonym: "RnGrbW_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001017 ! visual estimation of the root response to  grub worm
 relationship: variable_of CO_331:00001018 ! rcgrbw 5 pt. scale
 relationship: variable_of CO_331:0000363 ! reaction to grubworm
@@ -4227,10 +4566,11 @@ relationship: variable_of CO_331:0000363 ! reaction to grubworm
 [Term]
 id: CO_331:0000728
 name: Reaction to Hornworm estimating 1-9
+namespace: SweetpotatoTrait
 def: "The reaction of the root to damage caused by Hornworm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "HORNW" EXACT []
 synonym: "RnHrnw_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001019 ! visual estimation of the root response to  hornworm
 relationship: variable_of CO_331:00001020 ! rchrnw 5 pt. scale
 relationship: variable_of CO_331:0000364 ! reaction to hornworm
@@ -4238,10 +4578,11 @@ relationship: variable_of CO_331:0000364 ! reaction to hornworm
 [Term]
 id: CO_331:0000729
 name: Reaction to Aphids estimating 1-9
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Aphis. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "APHIDS" EXACT []
 synonym: "RnAph_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001021 ! visual estimation of the plant response to  aphis
 relationship: variable_of CO_331:00001022 ! rcaph 5 pt. scale
 relationship: variable_of CO_331:0000365 ! reaction to aphids
@@ -4249,10 +4590,11 @@ relationship: variable_of CO_331:0000365 ! reaction to aphids
 [Term]
 id: CO_331:0000730
 name: Reaction to Sweet potato white fly estimating 1-9
+namespace: SweetpotatoTrait
 def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPWF_Et_1to9" EXACT []
 synonym: "SPWF" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001023 ! visual estimation of the plant response to  sweet potato white fly
 relationship: variable_of CO_331:00001024 ! rcspwf 5 pt. scale
 relationship: variable_of CO_331:0000366 ! reaction to sweet potato white fly
@@ -4260,10 +4602,11 @@ relationship: variable_of CO_331:0000366 ! reaction to sweet potato white fly
 [Term]
 id: CO_331:0000731
 name: Reaction to Sweet potato moth estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPMth_Et_1to9" EXACT []
 synonym: "SPMOTH" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001025 ! visual estimation of the plant response to  sweet potato moth
 relationship: variable_of CO_331:00001026 ! rcspmth 5 pt. scale
 relationship: variable_of CO_331:0000367 ! reaction to sweet potato moth
@@ -4271,10 +4614,11 @@ relationship: variable_of CO_331:0000367 ! reaction to sweet potato moth
 [Term]
 id: CO_331:0000732
 name: Reaction to Moth estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "MOTH" EXACT []
 synonym: "RnMth_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001027 ! visual estimation of the plant response to  moth
 relationship: variable_of CO_331:00001028 ! rcmth 5 pt. scale
 relationship: variable_of CO_331:0000368 ! reaction to moth
@@ -4282,10 +4626,11 @@ relationship: variable_of CO_331:0000368 ! reaction to moth
 [Term]
 id: CO_331:0000733
 name: Reaction to Sweet potato stem borer estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato stem borer. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPSB_Et_1to9" EXACT []
 synonym: "SPSB" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001029 ! visual estimation of the plant response to  sweet potato stem borer
 relationship: variable_of CO_331:00001030 ! rcspsb 5 pt. scale
 relationship: variable_of CO_331:0000369 ! reaction to sweet potato stem borer
@@ -4293,10 +4638,11 @@ relationship: variable_of CO_331:0000369 ! reaction to sweet potato stem borer
 [Term]
 id: CO_331:0000734
 name: Reaction to Other insects estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Other insects. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "INSECTS" EXACT []
 synonym: "RnIns_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001031 ! visual estimation of the plant response to  other insects
 relationship: variable_of CO_331:00001032 ! rcins 5 pt. scale
 relationship: variable_of CO_331:0000370 ! reaction to other insects
@@ -4304,10 +4650,11 @@ relationship: variable_of CO_331:0000370 ! reaction to other insects
 [Term]
 id: CO_331:0000735
 name: Reaction to Reniform nematode estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Reniform nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RENIN" EXACT []
 synonym: "RnRFN_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001033 ! visual estimation of the root response to  reniform nematode
 relationship: variable_of CO_331:00001034 ! rcrfn 5 pt. scale
 relationship: variable_of CO_331:0000371 ! reaction to reniform nematode
@@ -4315,10 +4662,11 @@ relationship: variable_of CO_331:0000371 ! reaction to reniform nematode
 [Term]
 id: CO_331:0000736
 name: Reaction to Sting nematode estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sting nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnStN_Et_1to9" EXACT []
 synonym: "STINGN" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001035 ! visual estimation of the root response to  sting nematode
 relationship: variable_of CO_331:00001036 ! rcstn 5 pt. scale
 relationship: variable_of CO_331:0000372 ! reaction to sting nematode
@@ -4326,10 +4674,11 @@ relationship: variable_of CO_331:0000372 ! reaction to sting nematode
 [Term]
 id: CO_331:0000737
 name: Reaction to Brown ring rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Brown ring rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BRROT" EXACT []
 synonym: "RnBRR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001037 ! visual estimation of the root response to  brown ring rot
 relationship: variable_of CO_331:00001038 ! rcbrr 5 pt. scale
 relationship: variable_of CO_331:0000373 ! reaction to brown ring rot
@@ -4337,10 +4686,11 @@ relationship: variable_of CO_331:0000373 ! reaction to brown ring rot
 [Term]
 id: CO_331:0000738
 name: Reaction to Root lesion nematode estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Root lesion nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnRLN_Et_1to9" EXACT []
 synonym: "ROOTLN" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
 relationship: variable_of CO_331:00001040 ! rcrln 5 pt. scale
 relationship: variable_of CO_331:0000374 ! reaction to root lesion nematode
@@ -4348,10 +4698,11 @@ relationship: variable_of CO_331:0000374 ! reaction to root lesion nematode
 [Term]
 id: CO_331:0000739
 name: Reaction to other nematodes estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to other nematodes. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "NEMATODS" EXACT []
 synonym: "RnON_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
 relationship: variable_of CO_331:00001041 ! rcon 5 pt. scale
 relationship: variable_of CO_331:0000375 ! reaction to other nematodes
@@ -4359,10 +4710,11 @@ relationship: variable_of CO_331:0000375 ! reaction to other nematodes
 [Term]
 id: CO_331:0000740
 name: Reaction to Wilt rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Wilt rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnWR_Et_1to9" EXACT []
 synonym: "WILT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001042 ! visual estimation of the root response to  wilt rot
 relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
 relationship: variable_of CO_331:0000376 ! reaction to wilt rot
@@ -4370,10 +4722,11 @@ relationship: variable_of CO_331:0000376 ! reaction to wilt rot
 [Term]
 id: CO_331:0000741
 name: Reaction to Fusarium surface rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium surface rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FUSSURF" EXACT []
 synonym: "RnFRS_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001044 ! visual estimation of the root response to  fusarium surface rot
 relationship: variable_of CO_331:00001045 ! rcfrs 5 pt. scale
 relationship: variable_of CO_331:0000377 ! reaction to fusarium surface rot
@@ -4381,10 +4734,11 @@ relationship: variable_of CO_331:0000377 ! reaction to fusarium surface rot
 [Term]
 id: CO_331:0000742
 name: Reaction to Fusarium root rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FUSROOT" EXACT []
 synonym: "RnFRR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001046 ! visual estimation of the root response to  fusarium root rot
 relationship: variable_of CO_331:00001047 ! rcfrr 5 pt. scale
 relationship: variable_of CO_331:0000378 ! reaction to fusarium root rot
@@ -4392,10 +4746,11 @@ relationship: variable_of CO_331:0000378 ! reaction to fusarium root rot
 [Term]
 id: CO_331:0000743
 name: Reaction to Sclerotial blight and circular spot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sclerotial blight and circular spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSBC_Et_1to9" EXACT []
 synonym: "SCLBLT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001048 ! visual estimation of the root response to  sclerotial blight and circular spot
 relationship: variable_of CO_331:00001049 ! rcsbc 5 pt. scale
 relationship: variable_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
@@ -4403,10 +4758,11 @@ relationship: variable_of CO_331:0000379 ! reaction to sclerotial blight and cir
 [Term]
 id: CO_331:0000744
 name: Reaction to Black rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BLACKROT" EXACT []
 synonym: "RnBR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001050 ! visual estimation of the root response to  black rot
 relationship: variable_of CO_331:00001051 ! rcbr 5 pt. scale
 relationship: variable_of CO_331:0000380 ! reaction to black rot
@@ -4414,10 +4770,11 @@ relationship: variable_of CO_331:0000380 ! reaction to black rot
 [Term]
 id: CO_331:0000745
 name: Reaction to Scurf estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Scurf. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnScrf_Et_1to9" EXACT []
 synonym: "SCURF" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001052 ! visual estimation of the root response to  scurf
 relationship: variable_of CO_331:00001053 ! rcscrf 5 pt. scale
 relationship: variable_of CO_331:0000381 ! reaction to scurf
@@ -4425,10 +4782,11 @@ relationship: variable_of CO_331:0000381 ! reaction to scurf
 [Term]
 id: CO_331:0000746
 name: Reaction to Soft rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Soft rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSR_Et_1to9" EXACT []
 synonym: "SOFTROT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001054 ! appearance of roots in response soft rot
 relationship: variable_of CO_331:00001055 ! rcsr 5 pt. scale
 relationship: variable_of CO_331:0000382 ! reaction to soft rot
@@ -4436,10 +4794,11 @@ relationship: variable_of CO_331:0000382 ! reaction to soft rot
 [Term]
 id: CO_331:0000747
 name: Reaction to Java black rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Java black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "JAVABR" EXACT []
 synonym: "RnJBR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001056 ! appearance of roots in response java black rot
 relationship: variable_of CO_331:00001057 ! rcjbr 5 pt. scale
 relationship: variable_of CO_331:0000383 ! reaction to java black rot
@@ -4447,10 +4806,11 @@ relationship: variable_of CO_331:0000383 ! reaction to java black rot
 [Term]
 id: CO_331:0000748
 name: Reaction to Diaporthe dry rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Diaporthe dry rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "DIAPORTHE" EXACT []
 synonym: "RnDDR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
 relationship: variable_of CO_331:00001059 ! rcddr 5 pt. scale
 relationship: variable_of CO_331:0000384 ! reaction to diaporthe dry rot
@@ -4458,10 +4818,11 @@ relationship: variable_of CO_331:0000384 ! reaction to diaporthe dry rot
 [Term]
 id: CO_331:0000749
 name: Reaction to Scab estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Scab. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnScb_Et_1to9" EXACT []
 synonym: "SCAB" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001060 ! visual estimation of the plant response to  scab
 relationship: variable_of CO_331:00001061 ! rcscb 5 pt. scale
 relationship: variable_of CO_331:0000385 ! reaction to scab
@@ -4469,10 +4830,11 @@ relationship: variable_of CO_331:0000385 ! reaction to scab
 [Term]
 id: CO_331:0000750
 name: Reaction to leaf spot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to leaf spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "LEAFSPOT" EXACT []
 synonym: "RnLS_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001062 ! visual estimation of the plant response to  leaf spot
 relationship: variable_of CO_331:00001063 ! rcls 5 pt. scale
 relationship: variable_of CO_331:0000386 ! reaction to leaf spot
@@ -4480,10 +4842,11 @@ relationship: variable_of CO_331:0000386 ! reaction to leaf spot
 [Term]
 id: CO_331:0000751
 name: Reaction to White rust estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to White rust. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnWR_Et_1to9" EXACT []
 synonym: "WHITERUST" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
 relationship: variable_of CO_331:00001064 ! visual estimation of the plant response to  white rust
 relationship: variable_of CO_331:0000387 ! reaction to white rust
@@ -4491,10 +4854,11 @@ relationship: variable_of CO_331:0000387 ! reaction to white rust
 [Term]
 id: CO_331:0000752
 name: Reaction to Foot rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Foot rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FOOTROT" EXACT []
 synonym: "RnFR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001065 ! visual estimation of the plant response to  foot rot
 relationship: variable_of CO_331:00001066 ! rcfr 5 pt. scale
 relationship: variable_of CO_331:0000388 ! reaction to foot rot
@@ -4502,10 +4866,11 @@ relationship: variable_of CO_331:0000388 ! reaction to foot rot
 [Term]
 id: CO_331:0000753
 name: Reaction to Charcoal rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Charcoal rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "CHARCROT" EXACT []
 synonym: "RnCR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001067 ! visual estimation of the plant response to  charcoal rot
 relationship: variable_of CO_331:00001068 ! rccr 5 pt. scale
 relationship: variable_of CO_331:0000389 ! reaction to charcoal rot
@@ -4513,10 +4878,11 @@ relationship: variable_of CO_331:0000389 ! reaction to charcoal rot
 [Term]
 id: CO_331:0000754
 name: Reaction to Other fungi estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Other fungi. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "FUNGI" EXACT []
 synonym: "RnOF_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001069 ! visual estimation of the plant response to  other fungi
 relationship: variable_of CO_331:00001070 ! rcof 5 pt. scale
 relationship: variable_of CO_331:0000390 ! reaction to other fungi
@@ -4524,10 +4890,11 @@ relationship: variable_of CO_331:0000390 ! reaction to other fungi
 [Term]
 id: CO_331:0000755
 name: Reaction to Pox or soil rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Pox or soil rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "POXROT" EXACT []
 synonym: "RnPSR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001071 ! visual estimation of the plant response to  pox or soil rot
 relationship: variable_of CO_331:00001072 ! rcpsr 5 pt. scale
 relationship: variable_of CO_331:0000391 ! reaction to pox or soil rot
@@ -4535,10 +4902,11 @@ relationship: variable_of CO_331:0000391 ! reaction to pox or soil rot
 [Term]
 id: CO_331:0000756
 name: Reaction to Bacterial stem and root rot estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Bacterial stem and root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnBSRt_Et_1to9" EXACT []
 synonym: "STEMROT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001073 ! visual estimation of the plant response to  bacterial stem and root rot
 relationship: variable_of CO_331:00001074 ! rcbsrt 5 pt. scale
 relationship: variable_of CO_331:0000392 ! reaction to bacterial stem and root rot
@@ -4546,10 +4914,11 @@ relationship: variable_of CO_331:0000392 ! reaction to bacterial stem and root r
 [Term]
 id: CO_331:0000757
 name: Reaction to Bacterial wilt estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Bacterial wilt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BACWILT" EXACT []
 synonym: "RnBW_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001075 ! visual estimation of the plant response to  bacterial wilt
 relationship: variable_of CO_331:00001076 ! rcbw 5 pt. scale
 relationship: variable_of CO_331:0000393 ! reaction to bacterial wilt
@@ -4557,10 +4926,11 @@ relationship: variable_of CO_331:0000393 ! reaction to bacterial wilt
 [Term]
 id: CO_331:0000758
 name: Reaction to Other bacteria estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Other bacteria. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BACTERIA" EXACT []
 synonym: "RnOB_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001077 ! visual estimation of the plant response to  other bacteria
 relationship: variable_of CO_331:00001078 ! rcob 5 pt. scale
 relationship: variable_of CO_331:0000394 ! reaction to other bacteria
@@ -4568,10 +4938,11 @@ relationship: variable_of CO_331:0000394 ! reaction to other bacteria
 [Term]
 id: CO_331:0000759
 name: Reaction to Sweet potato feathery mottle virus (SPMV)
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato feathery mottle virus (SPMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPMV_Et_1to9" EXACT []
 synonym: "SPMV" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001079 ! visual estimation of the plant response to  sweet potato feathery mottle virus
 relationship: variable_of CO_331:00001080 ! rcspmv 5 pt. scale
 relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus (spmv)
@@ -4579,10 +4950,11 @@ relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mot
 [Term]
 id: CO_331:0000760
 name: Reaction to Sweet potato mild mottle virus (SPMMV) estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato mild mottle virus (SPMMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPMMV_Et_1to9" EXACT []
 synonym: "SPMMV" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001081 ! visual estimation of the plant response to  sweet potato mild mottle virus
 relationship: variable_of CO_331:00001082 ! rcspmmv 5 pt. scale
 relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle virus (spmmv)
@@ -4590,10 +4962,11 @@ relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle 
 [Term]
 id: CO_331:0000761
 name: Reaction to Sweet potato vein mottle virus (SPVMV) estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato vein mottle virus (SPVMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPVMV_Et_1to9" EXACT []
 synonym: "SPVMV" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001083 ! visual estimation of the plant response to  sweet potato vein mottle virus
 relationship: variable_of CO_331:00001084 ! rcspvmv 5 pt. scale
 relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle virus (spvmv)
@@ -4601,10 +4974,11 @@ relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle 
 [Term]
 id: CO_331:0000762
 name: Reaction to Sweet potato virus disease complex (SPVD complex) estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Sweet potato virus disease complex (SPVD complex). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnSPVD_Et_1to9" EXACT []
 synonym: "SPVD" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001085 ! visual estimation of the plant response to  sweet potato virus disease complex
 relationship: variable_of CO_331:00001086 ! rcspvd 5 pt. scale
 relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus disease complex (spvd complex)
@@ -4612,10 +4986,11 @@ relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus diseas
 [Term]
 id: CO_331:0000763
 name: Reaction to Other virus estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Other virus. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "RnOV_Et_1to9" EXACT []
 synonym: "VIRUS" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001087 ! visual estimation of the plant response to  other virus
 relationship: variable_of CO_331:00001088 ! rcov 5 pt. scale
 relationship: variable_of CO_331:0000399 ! reaction to other virus
@@ -4623,10 +4998,11 @@ relationship: variable_of CO_331:0000399 ! reaction to other virus
 [Term]
 id: CO_331:0000764
 name: Reaction to Witches broom estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Witches broom. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "BROOM" EXACT []
 synonym: "RnWB_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001089 ! visual estimation of the plant response to  witches broom
 relationship: variable_of CO_331:00001090 ! rcwb 5 pt. scale
 relationship: variable_of CO_331:0000400 ! reaction to witches broom
@@ -4634,10 +5010,11 @@ relationship: variable_of CO_331:0000400 ! reaction to witches broom
 [Term]
 id: CO_331:0000765
 name: Reaction to Other mycoplasma estimating 1-9
+namespace: SweetpotatoTrait
 def: "Reaction to Other mycoplasma. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
 synonym: "MYCOPLASMA" EXACT []
 synonym: "RnOM_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001091 ! visual estimation of the plant response to  to other mycoplasma
 relationship: variable_of CO_331:00001092 ! rcom 5 pt. scale
 relationship: variable_of CO_331:0000401 ! reaction to other mycoplasma
@@ -4645,10 +5022,11 @@ relationship: variable_of CO_331:0000401 ! reaction to other mycoplasma
 [Term]
 id: CO_331:0000766
 name: Total sugar content estimating 1-9
+namespace: SweetpotatoTrait
 def: "Total sugar content" []
 synonym: "RtTSgC_Et_1to9" EXACT []
 synonym: "TOTSUG" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001094 ! rttsgc
 relationship: variable_of CO_331:0000402 ! total sugar content
@@ -4656,10 +5034,11 @@ relationship: variable_of CO_331:0000402 ! total sugar content
 [Term]
 id: CO_331:0000767
 name: Habitus measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of plant" []
 synonym: "FOTHAB" EXACT []
 synonym: "PtHbt_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001095 ! plant picture
 relationship: variable_of CO_331:0000403 ! appearance of plant
@@ -4667,10 +5046,11 @@ relationship: variable_of CO_331:0000403 ! appearance of plant
 [Term]
 id: CO_331:0000768
 name: Flower measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of flower" []
 synonym: "FOTFLW" EXACT []
 synonym: "FrCol_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001096 ! flower picture
 relationship: variable_of CO_331:0000404 ! appearance of flower
@@ -4678,10 +5058,11 @@ relationship: variable_of CO_331:0000404 ! appearance of flower
 [Term]
 id: CO_331:0000769
 name: Root measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of roots" []
 synonym: "FOTROT" EXACT []
 synonym: "RtCol_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001097 ! root picture
 relationship: variable_of CO_331:0000405 ! appearance of roots
@@ -4689,10 +5070,11 @@ relationship: variable_of CO_331:0000405 ! appearance of roots
 [Term]
 id: CO_331:0000770
 name: Seeds measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of seeds" []
 synonym: "FOTSDS" EXACT []
 synonym: "FrSds_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001098 ! seeds picture
 relationship: variable_of CO_331:0000406 ! appearance of seeds
@@ -4700,10 +5082,11 @@ relationship: variable_of CO_331:0000406 ! appearance of seeds
 [Term]
 id: CO_331:0000771
 name: Leaf measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of leaves" []
 synonym: "FOTLEA" EXACT []
 synonym: "Lf_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001099 ! leaf picture
 relationship: variable_of CO_331:0000407 ! appearance of leaves
@@ -4711,10 +5094,11 @@ relationship: variable_of CO_331:0000407 ! appearance of leaves
 [Term]
 id: CO_331:0000772
 name: Herbarium measuring image
+namespace: SweetpotatoTrait
 def: "Appearance of hearbarium" []
 synonym: "FOTHRB" EXACT []
 synonym: "PtHrb_Ms_img" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001093 ! taking standardized photo
 relationship: variable_of CO_331:00001099 ! leaf picture
 relationship: variable_of CO_331:0000408 ! appearance of hearbarium
@@ -4722,10 +5106,11 @@ relationship: variable_of CO_331:0000408 ! appearance of hearbarium
 [Term]
 id: CO_331:0000774
 name: Storage Root Shape primary estimating 1-8
+namespace: SweetpotatoTrait
 def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
 synonym: "RTSHP1" EXACT []
 synonym: "RtShpP_Et_1to8" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000069 ! storage root shape (primary)
 relationship: variable_of CO_331:00001100 ! observation of most frequennt storage root shape
 relationship: variable_of CO_331:00001101 ! rtshpp 8 pt. scale
@@ -4733,10 +5118,11 @@ relationship: variable_of CO_331:00001101 ! rtshpp 8 pt. scale
 [Term]
 id: CO_331:0000775
 name: Storage Root Shape secondary estimating 1-8
+namespace: SweetpotatoTrait
 def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
 synonym: "RTSHP2" EXACT []
 synonym: "RtShpS_Et_1to8" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001102 ! observation of 2nd most frequent storage root shape
 relationship: variable_of CO_331:00001103 ! rtshps 8 pt. scale
 relationship: variable_of CO_331:0000441 ! storage root shape (secondary)
@@ -4744,10 +5130,11 @@ relationship: variable_of CO_331:0000441 ! storage root shape (secondary)
 [Term]
 id: CO_331:0000776
 name: Storage Root Shape Uniformity estimating 1-9
+namespace: SweetpotatoTrait
 def: "Storage Root Shape uniformity within a single plant or plot. 1 = Very Poor, 2 = Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
 synonym: "RTSHPU" EXACT []
 synonym: "RtShpU_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001104 ! observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
 relationship: variable_of CO_331:00001105 ! rtshpu 9 pt. scale
 relationship: variable_of CO_331:0000409 ! storage root shape uniformity
@@ -4755,10 +5142,11 @@ relationship: variable_of CO_331:0000409 ! storage root shape uniformity
 [Term]
 id: CO_331:0000777
 name: Storage Root Stalk estimating 0-9
+namespace: SweetpotatoTrait
 def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
 synonym: "RTSTALK" EXACT []
 synonym: "RtStlk_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001107 ! rtstlk 6 pt. scale
 relationship: variable_of CO_331:0000410 ! storage root stalk length
@@ -4766,10 +5154,11 @@ relationship: variable_of CO_331:0000410 ! storage root stalk length
 [Term]
 id: CO_331:0000778
 name: Storage Root Attachement estimating 0-9
+namespace: SweetpotatoTrait
 def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off. 1 = Very tight, 3 = Tight, 5 = Moderate, 6.0, 7 = Light, 8.0, 9 = Very Light" []
 synonym: "RtAtt_Et_1to9" EXACT []
 synonym: "RTATTACH" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001108 ! rtatt 9 pt. scale
 relationship: variable_of CO_331:0000411 ! storage root attachment
@@ -4777,10 +5166,11 @@ relationship: variable_of CO_331:0000411 ! storage root attachment
 [Term]
 id: CO_331:0000779
 name: Length to Diameter Ratio computation
+namespace: SweetpotatoTrait
 def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
 synonym: "LDR" EXACT []
 synonym: "RtLDR_Cp_ratio" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
 relationship: variable_of CO_331:0000412 ! length to diameter ratio of roots
@@ -4788,10 +5178,11 @@ relationship: variable_of CO_331:0000412 ! length to diameter ratio of roots
 [Term]
 id: CO_331:0000780
 name: Skin Color estimating 1-12
+namespace: SweetpotatoTrait
 def: "The most representative skin color observed is recorded. 1 = White, 2 = Cream, 3 = Yellow, 4 = Tan, 5 = Orange, 6 = Rose, 7 = Pink, 8 = Red, 9 = Light Purple, 10 = Purple, 11 = Dark Purple, 12 = Brown" []
 synonym: "RtSknCol_Et_1to12" EXACT []
 synonym: "SKINCOLOR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001110 ! rtskncol 12 pt. scale
 relationship: variable_of CO_331:0000413 ! skin color of roots
@@ -4799,10 +5190,11 @@ relationship: variable_of CO_331:0000413 ! skin color of roots
 [Term]
 id: CO_331:0000781
 name: Skin Texture estimating 1-9
+namespace: SweetpotatoTrait
 def: "Storage root skin feel, appearance, or consistency by visual observation and touch. 1 = Very Rough, 2.0, 3 = Moderately Rough, 4.0, 5 = Moderately Smooth, 6.0, 7 = Smooth, 8.0, 9 = Very Smooth" []
 synonym: "RTSKNTEX" EXACT []
 synonym: "RtSknTxt_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001111 ! rtskntxt 9 pt. scale
 relationship: variable_of CO_331:0000414 ! skin texture of roots
@@ -4810,10 +5202,11 @@ relationship: variable_of CO_331:0000414 ! skin texture of roots
 [Term]
 id: CO_331:0000782
 name: Flesh Color Carotenoids estimating 0-4
+namespace: SweetpotatoTrait
 def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = White, 0.5, 1 = Cream, 2 = Yellow, 2.5 = Yellow with orange, 2.75 = Orange with yellow, 3 = Orange, 3.5 = Dark Orange, 4 = Very Dark Orange" []
 synonym: "RTFLESH1" EXACT []
 synonym: "RtFlsColC_Et_0to4" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001112 ! rtflscolc 9 pt. scale
 relationship: variable_of CO_331:0000415 ! flesh color (carotenoids)
@@ -4821,10 +5214,11 @@ relationship: variable_of CO_331:0000415 ! flesh color (carotenoids)
 [Term]
 id: CO_331:0000783
 name: Flesh Color Anthocyanins estimating 0-4
+namespace: SweetpotatoTrait
 def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = No Anthocyanins, 0.5, 1 = Light Purple, 1.5, 2 = Moderate Purple, 2.5, 3 = Dark Purple, 3.5, 4 = Very Dark Purple" []
 synonym: "RTFLESH2" EXACT []
 synonym: "RtFlsColA_Et_0to4" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001113 ! rtflscola 9 pt. scale
 relationship: variable_of CO_331:0000416 ! flesh color (anthocyanins)
@@ -4832,10 +5226,11 @@ relationship: variable_of CO_331:0000416 ! flesh color (anthocyanins)
 [Term]
 id: CO_331:0000784
 name: Adventitious buds estimating 1-9
+namespace: SweetpotatoTrait
 def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface. 1 = Very Deep, 3 = Deep, 5 = Moderate, 7 = Shallow, 9 = Very Shallow" []
 synonym: "EYES" EXACT []
 synonym: "RtAdvB_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001114 ! rtadvb 5 pt. scale
 relationship: variable_of CO_331:0000417 ! deep of eyes of roots
@@ -4843,10 +5238,11 @@ relationship: variable_of CO_331:0000417 ! deep of eyes of roots
 [Term]
 id: CO_331:0000785
 name: Lenticels estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall assessment of visible lenticels at the storage root interface. 1 = Very Prominent, 2.0, 3 = Prominent, 4.0, 5 = Moderate, 6.0, 7 = Few, 8.0, 9 = None" []
 synonym: "LENTS" EXACT []
 synonym: "RtLtcl_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001115 ! ses 9 pt. scale
 relationship: variable_of CO_331:0000418 ! number of lenticels
@@ -4854,10 +5250,11 @@ relationship: variable_of CO_331:0000418 ! number of lenticels
 [Term]
 id: CO_331:0000786
 name: Streptomyces Soil Rot estimating 0-5
+namespace: SweetpotatoTrait
 def: "Streptomyces ipomoeae symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
 synonym: "RnPSR_Et_0to5" EXACT []
 synonym: "SSR" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001116 ! observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
 relationship: variable_of CO_331:00001117 ! ses 6 pt. scale
 relationship: variable_of CO_331:0000419 ! reaction to streptomyces soil rot
@@ -4865,10 +5262,11 @@ relationship: variable_of CO_331:0000419 ! reaction to streptomyces soil rot
 [Term]
 id: CO_331:0000787
 name: Root Knot Nematode  Meloidogyne estimating 0-5
+namespace: SweetpotatoTrait
 def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
 synonym: "RKN" EXACT []
 synonym: "RnMgRKN_Et_0to5" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
 relationship: variable_of CO_331:00001119 ! rcmgrkn  6 pt. scale
 relationship: variable_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
@@ -4876,10 +5274,11 @@ relationship: variable_of CO_331:0000420 ! reaction to root knot nematode meloid
 [Term]
 id: CO_331:0000788
 name: Root Knot Nematode  Meloidogyne incognita estimating 0-7
+namespace: SweetpotatoTrait
 def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation. 1= highly resistant (HR), 2= Resistant (1-10%), 3 = Moderate resistant (MR)(11-25%), 4 = Susceptible (S) (26-75%), 5= (HS) Highly susceptible (>76%)" []
 synonym: "RKN, MELOI" EXACT []
 synonym: "RnMgIRKN_Et_0to7" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
 relationship: variable_of CO_331:00001120 ! rcmigrkn  5 pt. scale
 relationship: variable_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
@@ -4887,10 +5286,11 @@ relationship: variable_of CO_331:0000421 ! reaction to root knot nematode meloid
 [Term]
 id: CO_331:0000789
 name: Reaction to Fusarium Wilt estimating 0-5
+namespace: SweetpotatoTrait
 def: "Reaction to Fusarium oxysporum batatas symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
 synonym: "FWILT" EXACT []
 synonym: "RnFR_Et_0to5" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001121 ! visual estimation of the roots response to  fusarium oxysporum
 relationship: variable_of CO_331:00001122 ! rnfr 6 pt. scale
 relationship: variable_of CO_331:0000422 ! reaction to fusarium oxysporum
@@ -4898,10 +5298,11 @@ relationship: variable_of CO_331:0000422 ! reaction to fusarium oxysporum
 [Term]
 id: CO_331:0000790
 name: Storage Root Defects primary estimating 1-18
+namespace: SweetpotatoTrait
 def: "Type and/or name of primary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
 synonym: "RTDEF1" EXACT []
 synonym: "RtDefP_Et_1to18" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001123 ! rtdam 14 pt. scale
 relationship: variable_of CO_331:0000423 ! storage root defects (primary)
@@ -4909,10 +5310,11 @@ relationship: variable_of CO_331:0000423 ! storage root defects (primary)
 [Term]
 id: CO_331:0000791
 name: Relative Storage Root Yield estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root yield. 1 = Very Poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = Excellent" []
 synonym: "RTRYIELD" EXACT []
 synonym: "RtYldR_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001124 ! rtyldr 5 pt. scale
 relationship: variable_of CO_331:0000424 ! relative storage root yield
@@ -4920,10 +5322,11 @@ relationship: variable_of CO_331:0000424 ! relative storage root yield
 [Term]
 id: CO_331:0000792
 name: Yield as percent of check
+namespace: SweetpotatoTrait
 def: "Overall calculation of relative root yield" []
 synonym: "RtYldChk_Cp_pct" EXACT []
 synonym: "RTYLDPCT" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
 relationship: variable_of CO_331:0000425 ! storage root yield relative to check
 relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
@@ -4931,10 +5334,11 @@ relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
 [Term]
 id: CO_331:0000793
 name: Storage Root Appearance estimating 1-9
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root yield appearance. 1 = Very Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
 synonym: "RTAPPEAR" EXACT []
 synonym: "RtApr_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:0000426 ! storage root appearance
 relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
@@ -4942,10 +5346,11 @@ relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
 [Term]
 id: CO_331:0000794
 name: Season maturity estimating 0-4
+namespace: SweetpotatoTrait
 def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season. 0 = Late Season, 1 = Mid to Late Season, 2 = Mid Season, 3 = Early to Mid Season, 4 = Early Season" []
 synonym: "PtMtSs_Et_0to4" EXACT []
 synonym: "SEASON" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001125 ! ptmtss 5 pt. scale
 relationship: variable_of CO_331:0000427 ! growing season
@@ -4953,10 +5358,11 @@ relationship: variable_of CO_331:0000427 ! growing season
 [Term]
 id: CO_331:0000795
 name: Amylose content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Amylose content in sweetpotato" []
 synonym: "AMY" EXACT []
 synonym: "RtFlsAmy_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001126 ! amylose - method
 relationship: variable_of CO_331:00001127 ! g/100 g fw
 relationship: variable_of CO_331:0000428 ! amylose content
@@ -4964,10 +5370,11 @@ relationship: variable_of CO_331:0000428 ! amylose content
 [Term]
 id: CO_331:0000796
 name: Asparagine content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "peonidin content of purple flesh sweetpotato" []
 synonym: "ASP" EXACT []
 synonym: "RtFlsAsp_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001128 ! asparagine - method
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:0000429 ! asparagine content
@@ -4975,10 +5382,11 @@ relationship: variable_of CO_331:0000429 ! asparagine content
 [Term]
 id: CO_331:0000797
 name: Cyanidin content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
 synonym: "CYAN" EXACT []
 synonym: "RtFlsCya_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:00001130 ! cyanidin - method
 relationship: variable_of CO_331:0000430 ! cyanidin content
@@ -4986,10 +5394,11 @@ relationship: variable_of CO_331:0000430 ! cyanidin content
 [Term]
 id: CO_331:0000798
 name: Total Monomeric Anthocyanin content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
 synonym: "RtFlsAntM_Ms_mgpergDW" EXACT []
 synonym: "TMA" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:00001131 ! total monomeric anthocyanins - method
 relationship: variable_of CO_331:0000431 ! total monomeric anthocyanin content
@@ -4997,10 +5406,11 @@ relationship: variable_of CO_331:0000431 ! total monomeric anthocyanin content
 [Term]
 id: CO_331:0000799
 name: Peonidin content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Peonidin content of purple flesh sweetpotato" []
 synonym: "PEO" EXACT []
 synonym: "RtFlsPeo_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:00001132 ! peonidin - method
 relationship: variable_of CO_331:0000432 ! peonidin content
@@ -5008,10 +5418,11 @@ relationship: variable_of CO_331:0000432 ! peonidin content
 [Term]
 id: CO_331:0000800
 name: Anthocyanin content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Anthocyanin content of purple flesh sweetpotato" []
 synonym: "ANTHO" EXACT []
 synonym: "RtFlsAnt_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:00001133 ! anthocyanin - method
 relationship: variable_of CO_331:0000433 ! anthocyanin content
@@ -5019,10 +5430,11 @@ relationship: variable_of CO_331:0000433 ! anthocyanin content
 [Term]
 id: CO_331:0000801
 name: Phenol content measuring  mg per g DW
+namespace: SweetpotatoTrait
 def: "Phenol content of purple flesh sweetpotato" []
 synonym: "PHEN" EXACT []
 synonym: "RtFlsPhe_Ms_mgpergDW" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001129 ! mg/g dw
 relationship: variable_of CO_331:00001134 ! phenol - method
 relationship: variable_of CO_331:0000434 ! phenol content
@@ -5030,10 +5442,11 @@ relationship: variable_of CO_331:0000434 ! phenol content
 [Term]
 id: CO_331:0000802
 name: Node number counting nodes per vine
+namespace: SweetpotatoTrait
 def: "Nodes per vine" []
 synonym: "VINTND" EXACT []
 synonym: "VnNds_Ct_pervine" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001135 ! nodes per vine evaluation
 relationship: variable_of CO_331:00001136 ! nodes/plant
 relationship: variable_of CO_331:0000435 ! nodes per vine
@@ -5041,10 +5454,11 @@ relationship: variable_of CO_331:0000435 ! nodes per vine
 [Term]
 id: CO_331:0000803
 name: Total number of leaves counting per plant
+namespace: SweetpotatoTrait
 def: "Leaves per plant" []
 synonym: "LEFTPP" EXACT []
 synonym: "PtLvs_ct_perplant" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001137 ! leaves per plant evaluation
 relationship: variable_of CO_331:00001138 ! leaf/plant
 relationship: variable_of CO_331:0000436 ! leaves per plant
@@ -5052,10 +5466,11 @@ relationship: variable_of CO_331:0000436 ! leaves per plant
 [Term]
 id: CO_331:0000804
 name: Leaf color by picture measuring by picture using method
+namespace: SweetpotatoTrait
 def: "Color of leave" []
 synonym: "LEFCPC" EXACT []
 synonym: "LfCol_Ms_image" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001139 ! color of leave picture
 relationship: variable_of CO_331:00001140 ! picture
 relationship: variable_of CO_331:0000437 ! color of leave
@@ -5063,10 +5478,11 @@ relationship: variable_of CO_331:0000437 ! color of leave
 [Term]
 id: CO_331:0000805
 name: Millipede damage estimating 1-9
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by Millipede in roots. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
 synonym: "MILLDAM" EXACT []
 synonym: "RtsMillDam_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 relationship: variable_of CO_331:00001141 ! rtsmilldam 5 pt. scale
 relationship: variable_of CO_331:0000438 ! millipede damage
@@ -5074,10 +5490,11 @@ relationship: variable_of CO_331:0000438 ! millipede damage
 [Term]
 id: CO_331:0000806
 name: Alcidodes sp. damage estimating 1-9
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by Alcidodes sp, causes crown enlargement/galling or death by girdling. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
 synonym: "ALCDAM" EXACT []
 synonym: "RtAlcDam_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001142 ! rtalcdam 5 pt. scale
 relationship: variable_of CO_331:0000439 ! alcidodes sp. damage
 relationship: variable_of CO_331:0000883 ! weevil damage evaluation
@@ -5085,10 +5502,11 @@ relationship: variable_of CO_331:0000883 ! weevil damage evaluation
 [Term]
 id: CO_331:0000807
 name: Soil insect damage estimating 1-9
+namespace: SweetpotatoTrait
 def: "Observation of damage caused by soil insect. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
 synonym: "INSDAM" EXACT []
 synonym: "RtSInsDam_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:00001143 ! soils insect evaluation
 relationship: variable_of CO_331:00001144 ! rtsinsdam  5 pt. scale
 relationship: variable_of CO_331:0000440 ! soil insect damage
@@ -5096,6 +5514,7 @@ relationship: variable_of CO_331:0000440 ! soil insect damage
 [Term]
 id: CO_331:0000808
 name: overall storage root disease symptoms
+namespace: SweetpotatoTrait
 def: "Overall storage root disease symptoms evaluation" []
 synonym: "RtDSm" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
@@ -5105,10 +5524,11 @@ creation_date: 2016-12-01T02:33:40Z
 [Term]
 id: CO_331:0000809
 name: Storage root total marketable yield weight computation tons per ha
+namespace: SweetpotatoTrait
 def: "Marketable root yield" []
 synonym: "RtCYld_Cp_tha" EXACT []
 synonym: "RYTHA" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000307 ! marketable root yield
 created_by: W. Grueneberg
 creation_date: 2016-11-30T21:23:23Z
@@ -5116,10 +5536,11 @@ creation_date: 2016-11-30T21:23:23Z
 [Term]
 id: CO_331:0000810
 name: Storage Root Defects secondary estimating 1-18
+namespace: SweetpotatoTrait
 def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
 synonym: "RTDEF2" EXACT []
 synonym: "RtDefS_Et_1to18" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
 created_by: C. Yencho
 creation_date: 2016-11-30T20:44:25Z
@@ -5127,6 +5548,7 @@ creation_date: 2016-11-30T20:44:25Z
 [Term]
 id: CO_331:0000811
 name: storage root defects (secondary)
+namespace: SweetpotatoTrait
 def: "Type and/or name of secondary visible storage root defect" []
 synonym: "RtDefS" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
@@ -5786,7 +6208,7 @@ relationship: method_of CO_331:0000308 ! average commercial root weight
 id: CO_331:0000897
 name: t/ha
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000896 ! estimated marketable yield per hectare - method
 relationship: scale_of CO_331:0000898 ! estimated yield of total roots per hectare - method
 relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
@@ -5812,7 +6234,7 @@ relationship: method_of CO_331:0000310 ! percentage of marketable roots
 id: CO_331:0000900
 name: %
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000899 ! percentage of marketable - method
 relationship: scale_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
 relationship: scale_of CO_331:0000923 ! protein content - method
@@ -6018,7 +6440,7 @@ relationship: method_of CO_331:0000106 ! zinc content
 id: CO_331:0000925
 name: mg/100g
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: scale_of CO_331:0000927 ! content of zinc in dry weight basis - method
 relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
@@ -6030,7 +6452,7 @@ relationship: scale_of CO_331:0000931 ! total carotenoids - method
 id: CO_331:0000926
 name: mg/kg
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
 relationship: scale_of CO_331:0000929 ! content of magnesium in dry weight basis - method
@@ -6218,7 +6640,7 @@ relationship: method_of CO_331:0000329 ! flower size
 id: CO_331:0000950
 name: cm
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000949 ! measurement of flower length and width in cm
 
 [Term]
@@ -6263,7 +6685,7 @@ relationship: method_of CO_331:0000332 ! number of sepal veins
 id: CO_331:0000956
 name: number
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 relationship: scale_of CO_331:0000955 ! record the most frequent number in ten typical flowers
 
 [Term]
@@ -6590,79 +7012,104 @@ is_a: CO_331:1000014 ! Estimation
 relationship: method_of CO_331:0000354 ! reaction to high soil temperature
 
 [Term]
+id: CO_331:1000001
+name: Methods
+namespace: SweetpotatoMethod
+is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
+
+[Term]
+id: CO_331:1000002
+name: Scales
+namespace: SweetpotatoScale
+is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
+
+[Term]
+id: CO_331:1000003
+name: Variables
+namespace: SweetpotatoTrait
+is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
+
+[Term]
 id: CO_331:1000004
 name: Abiotic_stress_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000005
 name: Biotic_stress_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000007
 name: Quality_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000008
 name: Agronomic_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000009
 name: Biochemical_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000010
 name: Morphological_trait
+namespace: SweetpotatoTrait
 is_a: CO_331:0000000 ! CGIAR sweetpotato trait ontology
 
 [Term]
 id: CO_331:1000011
 name: Measurement
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 
 [Term]
 id: CO_331:1000012
 name: Counting
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 
 [Term]
 id: CO_331:1000013
 name: Computation
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 
 [Term]
 id: CO_331:1000014
 name: Estimation
 namespace: SweetpotatoMethod
-is_a: CO_331:1000001
+is_a: CO_331:1000001 ! Methods
 
 [Term]
 id: CO_331:1000015
 name: Ordinal
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 
 [Term]
 id: CO_331:1000019
 name: Numerical
 namespace: SweetpotatoScale
-is_a: CO_331:1000002
+is_a: CO_331:1000002 ! Scales
 
 [Term]
 id: CO_331:2000004
 name: Virus symptoms 2 estimating 1-9
+namespace: SweetpotatoTrait
 def: "Virus symptoms 2." [Grueneberg2010:Def_14]
 comment: | Context of use:  Evaluation in Trials | Growth stage: W13 | Variable status: Recommended | Scientist: W. Grueneberg | Institution: CIP, SASHA | Language of submission: EN | Date of submission: 2015-10-22.
 synonym: "VIR2" EXACT []
 synonym: "VirSm2_Et_1to9" EXACT []
-is_a: CO_331:1000003
+is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000094 ! virus symptoms
 relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
 relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
@@ -6670,12 +7117,14 @@ relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
 [Typedef]
 id: method_of
 name: method_of
+namespace: SweetpotatoTrait
 
 [Typedef]
 id: scale_of
 name: scale_of
+namespace: SweetpotatoTrait
 
 [Typedef]
 id: variable_of
 name: variable_of
-
+namespace: SweetpotatoTrait

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -951,6 +951,13 @@ is_a: CO_331:1000015 ! Ordinal
 relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
 
 [Term]
+id: CO_331:00001124
+name: rtyldr 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
+
+[Term]
 id: CO_331:00001125
 name: ptmtss 5 pt. scale
 namespace: SweetpotatoScale
@@ -3499,6 +3506,7 @@ def: "Virus symptoms 2." [Grueneberg2010:Def_14]
 comment: | Context of use:  Evaluation in Trials | Growth stage: W13 | Variable status: Recommended | Scientist: W. Grueneberg | Institution: CIP, SASHA | Language of submission: EN | Date of submission: 2015-10-22.
 synonym: "VIR2" EXACT []
 synonym: "VirSm2_Et_1to9" EXACT []
+is_a: CO_331:1000003 ! Variable
 relationship: variable_of CO_331:0000094 ! virus symptoms
 relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
 relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
@@ -6890,6 +6898,7 @@ name: Storage Root Defects secondary estimating 1-18
 def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
 synonym: "RTDEF2" EXACT []
 synonym: "RtDefS_Et_1to18" EXACT []
+is_a: CO_331:1000003 ! Variable
 relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
 created_by: C. Yencho
 creation_date: 2016-11-30T20:44:25Z
@@ -6900,6 +6909,7 @@ name: Storage root total marketable yield weight computation tons per ha
 def: "Marketable root yield" []
 synonym: "RtCYld_Cp_tha" EXACT []
 synonym: "RYTHA" EXACT []
+is_a: CO_331:1000003 ! Variable
 relationship: variable_of CO_331:0000307 ! marketable root yield
 created_by: W. Grueneberg
 creation_date: 2016-11-30T21:23:23Z
@@ -6919,6 +6929,7 @@ name: Overall storage root disease symptoms estimating 1-9
 def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
 synonym: "DISEASE" EXACT []
 synonym: "RtDSm_Et_1to9" EXACT []
+is_a: CO_331:1000003 ! Variable
 relationship: variable_of CO_331:0000815   ! overall storage root disease symptoms
 created_by: C. Yencho
 creation_date: 2016-12-01T04:02:09Z

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -3523,6 +3523,158 @@ created_by: C. Yencho
 creation_date: 2016-12-01T04:02:09Z
 
 [Term]
+id: CO_331:0000601
+name: weight of total US no. 1 storage roots
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects." []
+synonym: "RtUS1W" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000602
+name: weight of canner storage roots
+def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length." []
+synonym: "RtCanW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000603
+name: weight of jumbo storage roots
+def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality." []
+synonym: "RtJumW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000604
+name: weight of cull storage roots
+def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades" []
+synonym: "RtCulW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000605
+name: weight of 90 count US no. 1 storage roots
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box." []
+synonym: "Rt90ctW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000606
+name: weight of 55 count US no. 1 storage roots
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box." []
+synonym: "Rt55ctW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000607
+name: weight of 40 count US no. 1 storage roots
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box." []
+synonym: "Rt40ctW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000608
+name: weight of 32 count US no. 1 storage roots
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box." []
+synonym: "Rt32ctW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+created_by: C. Yencho
+
+[Term]
+id: CO_331:0000609
+name: weight of total US no. 1 storage roots measuring kg per plot
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects. Measured in kilograms per plot." []
+synonym: "RtUS1W_Ms_kgplot" EXACT []
+synonym: "US1" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000601 ! weight of total US no. 1 storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000610
+name: weight of canner storage roots measuring kg per plot
+def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length. Measured in kilograms per plot." []
+synonym: "CAN" EXACT []
+synonym: "RtCanW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000602 ! weight of canner storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000611
+name: weight of jumbo storage roots measuring kg per plot
+def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality. Measured in kilograms per plot." []
+synonym: "JUM" EXACT []
+synonym: "RtJumW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000603 ! weight of jumbo storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000612
+name: weight of cull storage roots measuring kg per plot
+def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades. Measured in kilograms per plot." []
+synonym: "CUL" EXACT []
+synonym: "RtCulW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000604 ! weight of cull storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000613
+name: weight of 90 count US no. 1 storage roots measuring kg per plot
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box. Measured in kilograms per plot." []
+synonym: "90CT" EXACT []
+synonym: "Rt90ctW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000605 ! weight of 90 count US no. 1 storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000614
+name: weight of 55 count US no. 1 storage roots measuring kg per plot
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box. Measured in kilograms per plot." []
+synonym: "55CT" EXACT []
+synonym: "Rt55ctW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000606 ! weight of 55 count US no. 1 storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000615
+name: weight of 40 count US no. 1 storage roots measuring kg per plot
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box. Measured in kilograms per plot." []
+synonym: "40CT" EXACT []
+synonym: "Rt40ctW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000607 ! weight of 40 count US no. 1 storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
+id: CO_331:0000616
+name: weight of 32 count US no. 1 storage roots measuring kg per plot
+def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box. Measured in kilograms per plot." []
+synonym: "32CT" EXACT []
+synonym: "Rt32ctW_Ms_kgplot" EXACT []
+is_a: CO_331:1000003
+relationship: variable_of CO_331:0000608 ! weight of 32 count US no. 1 storage roots
+relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000893 ! kg/plot
+
+[Term]
 id: CO_331:0000678
 name: Plants planted counting number per plot
 def: "Number of plants planted" []


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

I ran into problems with some terms while trying to open the obo file in protege and then save again in obo format.

I removed two invalid scale definitions, and reassigned unused ids to new traits and variables whose ids were conflicted with some re-added scale and method ids. Also checked in spbase to make sure there weren't any measurements associated with the changed variables.

<!-- If there are relevant issues, link them here: -->
Closes #7

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [x] An OBO file generated from an OWL file
- [x] New terms
  - [x] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] CHECKS
  - [x] New variables have a parent trait ID 
    - [x] New variables have methods and scales 
  - [x] The OBO file has been validated
    - [x] checked in sweetpotatobase
    - [ ] checked CropOntology
