### PR TITLE
Update from td

### DIFF
--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -3,6 +3,7 @@ date: 12:02:2018 19:35
 saved-by: vagrant
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: SweetpotatoDefault
+ontology: TEMP
 
 [Term]
 id: CO_331:0000000
@@ -14,2737 +15,2380 @@ def: "A controlled vocabulary to describe each trait as a distinguishable, chara
 id: CO_331:0000001
 name: plant type
 namespace: SweetpotatoTrait
-def: "Length of the main vines" []
-synonym: "Main vine length" EXACT []
+def: "The growth habit of the plant" []
 synonym: "PtTyp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000002
+name: visual estimation - plant type method
+namespace: SweetpotatoMethod
+def: "Observe the plant type and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000003
+name: PtTyp 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000004
 name: ground cover
 namespace: SweetpotatoTrait
-def: "Soil area covered by plant canopy" []
+def: "The ground cover of the plant" []
 synonym: "VnFolGRnv" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000005
+name: visual estimation - ground cover method
+namespace: SweetpotatoMethod
+def: "Observe the ground cover and rate it. Estimated percentage of ground cover recorded 35-40 days after planting" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000006
+name: VnFolGRnv 4pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000007
 name: twining
 namespace: SweetpotatoTrait
-def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics" []
+def: "The twining of the plant" []
 synonym: "PtTwg" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000008
+name: visual estimation - twining method
+namespace: SweetpotatoMethod
+def: "Observe the twining and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000009
+name: PtTwg 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000010
-name: predominant vine color
+name: vine predominant color
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color" []
+def: "The predominant color of the vine. The predominant color should be evaluated considering the whole vine from base to tip" []
 synonym: "VnColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000011
+name: visual estimation - vine predominant color method
+namespace: SweetpotatoMethod
+def: "Observe the predominant color of the vine and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000012
+name: VnColP 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000013
-name: secondary vine color
+name: vine secondary color
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color" []
+def: "The secondary color of the vine. The secondary color is more easily evaluated using younger vines" []
 synonym: "VnColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000014
+name: visual estimation - vine secondary color method
+namespace: SweetpotatoMethod
+def: "Observe the secondary color of the vine and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000015
+name: VnColS 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000016
 name: vine tips pubescence
 namespace: SweetpotatoTrait
-def: "Degree of hairiness of immature leaves recorded at the apex of the vines" []
+def: "The pubescence of the vine apex or tips" []
 synonym: "VnTipP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000017
+name: visual estimation - vine apex pubescence method
+namespace: SweetpotatoMethod
+def: "Observe the pubescence of the vine apex and rate it. Degree of hairiness of immature leaves recorded at the apex of the vines" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000018
+name: VnTipP 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000019
-name: general outline of the leaf
+name: leaf general outline
 namespace: SweetpotatoTrait
-def: "Outline i.e., shape of a leaf located in the middle section of the vine" []
+def: "The general outline of the leaf" []
 synonym: "LfOut" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000020
+name: visual estimation - leaf general outline method
+namespace: SweetpotatoMethod
+def: "Observe the leaf general outline and rate it. Described from leaves located in the middle section of the vine" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000021
+name: LfOut 7 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000022
 name: leaf lobe type
 namespace: SweetpotatoTrait
-def: "Type of the lobe of a leaf located in the middle section of the vine" []
+def: "The type of the leaf lobe" []
 synonym: "LfLbT" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000023
+name: visual estimation - leaf lobe type
+namespace: SweetpotatoMethod
+def: "Observe the leaf lobe type and rate it. Described from leaves located in the middle section of the vine" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000024
+name: LfLbT 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000025
 name: leaf lobe number
 namespace: SweetpotatoTrait
-def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine" []
+def: "The number of the leaf lobes" []
 synonym: "LfLbN" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000026
+name: counting - leaf lobe number
+namespace: SweetpotatoMethod
+def: "Count the number of leaf lobes and rate it. Described from leaves located in the middle section of the vine" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0000027
+name: LfLbN 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000028
-name: shape of central leaf lobe
+name: leaf central lobe shape
 namespace: SweetpotatoTrait
-def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine" []
+def: "The shape of the central leaf lobe" []
 synonym: "LfLCS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000029
+name: visual estimation - leaf central lobe shape
+namespace: SweetpotatoMethod
+def: "Observe the leaf central lobe shape and rate it. Described from leaves located in the middle section of the vine" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000030
+name: LfLCS 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000031
 name: mature leaf size
 namespace: SweetpotatoTrait
-def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave." []
+def: "The size of the mature leaf" []
 synonym: "LfLMS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000032
+name: visual estimation - mature leaf size
+namespace: SweetpotatoMethod
+def: "Observe the mature leaf size and rate it. Length from the basal lobes to the tip of the leaves. Record the average expression of at least 3 leaves located in the middle section of the vine" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000033
+name: LfLMS 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000034
 name: abaxial leaf vein pigmentation
 namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf" []
+def: "The pigmentation of the abaxial leaf vein" []
 synonym: "LfAVP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000035
+name: visual estimation - abaxial leaf vein pigmentation
+namespace: SweetpotatoMethod
+def: "Observe the pigmentation of the abaxial leaf vein and rate it. Describe the most frequent expression of the distribution of the anthocyanin (purple) pigmentation shown in the veins of the lower surface of leaves" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000036
+name: LfAVP 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000037
 name: mature leaf color
 namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants." []
+def: "The color of the mature leaf" []
 synonym: "LfCMt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000038
+name: visual estimation - mature leaf color
+namespace: SweetpotatoMethod
+def: "Observe the mature leaf color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000039
+name: LfCMt 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000040
 name: immature leaf color
 namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants." []
+def: "The color of the inmature leaf" []
 synonym: "LfColI" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000041
+name: visual estimation - inmature leaf color
+namespace: SweetpotatoMethod
+def: "Observe the immature leaf color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000042
+name: LfColI 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000043
 name: petiole pigmentation
 namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first." []
+def: "The pigmentation of the petiole" []
 synonym: "FrPtP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000044
+name: visual estimation -petiole pigmentation
+namespace: SweetpotatoMethod
+def: "Observe the petiole pigmentation and rate it. Distribution of anthocyanin (purple) pigmentation in the petioles of leaves" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000045
+name: FrPtP 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000046
 name: flower color
 namespace: SweetpotatoTrait
-def: "The most representative color in the flowers" []
+def: "The color of the flower" []
 synonym: "FRnol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000047
+name: visual estimation - flower color
+namespace: SweetpotatoMethod
+def: "Observe the flower color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000048
+name: Frnol 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000049
-name: predominant skin color
+name: storage root skin predominant color
 namespace: SweetpotatoTrait
-def: "The most representative skin color  of the root" []
-synonym: "RtSknColP" EXACT []
+def: "The predominant or the most representative color of the storage root skin observed is recorded" []
+synonym: "RtSknCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000051
+name: RtSknColP 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000052
-name: intensity of predominant skin color
+name: storage root skin intensity of predominant color
 namespace: SweetpotatoTrait
-def: "Intensity of Predominant Skin color of the root" []
+def: "The intensity of predominant color of the storage root skin" []
 synonym: "RtSknColPI" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000053
+name: visual estimation - storage root skin intensity of predominant color
+namespace: SweetpotatoMethod
+def: "Observe the predominant color intensity of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000054
+name: RtSknColPI 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000055
-name: secondary skin color
+name: storage root skin secondary skin color
 namespace: SweetpotatoTrait
-def: "The less representative skin color of the root" []
+def: "The secondary color of the storage root skin" []
 synonym: "RtSknColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000056
+name: visual estimation - storage root skin secondary color
+namespace: SweetpotatoMethod
+def: "Observe the secondary skin color of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000057
+name: RtSknColS 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000058
-name: predominant flesh color
+name: storage root predominant flesh color
 namespace: SweetpotatoTrait
-def: "The most representative flesh color of the root" []
+def: "The predominant color of the storage root flesh in a longitudinal section of the root" []
 synonym: "RtFlsColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000059
+name: visual estimation - storage root flesh predominant color
+namespace: SweetpotatoMethod
+def: "Observe the predominant color of the storage root flesh and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000060
+name: RtFlsColP 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000061
-name: secondary flesh color
+name: storage root flesh secondary color
 namespace: SweetpotatoTrait
-def: "The less representative flesh color of the root" []
+def: "The secondary color of the storage root flesh" []
 synonym: "RtFlsColS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000062
+name: visual estimation - storage root flesh secondary color
+namespace: SweetpotatoMethod
+def: "Observe the secondary color of the storage root flesh and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000063
+name: RtFlsColS 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000064
-name: distribution of secondary flesh color
+name: storage root flesh distribution of secondary color
 namespace: SweetpotatoTrait
-def: "Distribution of Secondary Flesh color of the root" []
+def: "The distribution of secondary color of the storage root flesh" []
 synonym: "RtFlsColSD" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000065
+name: visual estimation - storage root flesh distribution of secondary color
+namespace: SweetpotatoMethod
+def: "Observe the distribution of secondary color of the storage root flesh and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000066
+name: RtFlsColSD 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000067
-name: storage root shape
+name: storage root primary shape
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root shape" []
+def: "The shape of the storage root" []
 synonym: "RtShp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
-id: CO_331:0000069
-name: storage root shape (primary)
-namespace: SweetpotatoTrait
-def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtShpP" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
+id: CO_331:0000068
+name: visual estimation - storage root shape
+namespace: SweetpotatoMethod
+def: "Observe the shape of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:0000070
-name: latex production in storage roots
+name: storage root latex production
 namespace: SweetpotatoTrait
-def: "Amount of latex observed after cross sectioning medium-sized storage roots" []
+def: "The latex production of the storage root" []
 synonym: "RtLxP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000071
+name: visual estimation - storage root latex production. amount of latex observed after cross sectioning medium-sized storage roots
+namespace: SweetpotatoMethod
+def: "Observe the latex production of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000072
+name: RtLxP 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000073
-name: oxidation in storage roots
+name: storage root oxidation
 namespace: SweetpotatoTrait
-def: "Amount of browning due to oxidation" []
+def: "The oxidation of the storage root" []
 synonym: "RtOxi" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000074
+name: visual estimation - storage root oxidation
+namespace: SweetpotatoMethod
+def: "Observe the oxidation of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000075
+name: RtOxi 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000076
 name: storage root size
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root size based on inspection of the harvested roots" []
+def: "The size of the storage root" []
 synonym: "RtSiz" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000077
+name: visual estimation - storage root size
+namespace: SweetpotatoMethod
+def: "Observe the storage root size and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000078
+name: RtSiz 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000079
-name: total number of root
+name: number of storage roots
 namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: CloneSelector2015
+def: "The number of storage roots" []
+synonym: "RtNum" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
 
 [Term]
 id: CO_331:0000082
-name: yield of total roots
+name: total storage roots yield
 namespace: SweetpotatoTrait
-def: "Yield evaluated in the harvest" []
+def: "The yield of the total storage roots" []
 synonym: "RtYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000083
+name: computation - total storage roots yield method
+namespace: SweetpotatoMethod
+def: "Compute the yield of the total storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000085
 name: harvest index
 namespace: SweetpotatoTrait
-def: "Harvest index" []
-synonym: "IxHrv" EXACT []
+def: "The index of the harvest" []
+synonym: "HrvInx" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000086
+name: computation - harvest index evaluation method
+namespace: SweetpotatoMethod
+def: "Compute the total weight of commercial tubers per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000088
 name: reaction to sweet potato weevil
 namespace: SweetpotatoTrait
-def: "Overall assessment of weevil damage based on inspection of the harvested roots; early." []
+def: "The reaction of the storage root to sweet potato weevil" []
 synonym: "RnWvl" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000089
+name: visual estimation - reaction to sweet potato weevil
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to sweet potato weevil and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000090
+name: RnWvl 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000091
-name: reaction to early blight: (alternaria spp)
+name: reaction to alternaria spp
 namespace: SweetpotatoTrait
-def: "Alternaria symptoms evaluation" []
+def: "The symptoms of the plant to Alternaria" []
 synonym: "RnAlt" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000092
+name: visual estimation - reaction of the plant to alternaria spp
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Early Blight: Alternaria spp and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000093
+name: RnAlt 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000094
 name: virus symptoms
 namespace: SweetpotatoTrait
-def: "Virus symptoms evaluation" []
+def: "The symptoms of the plant to virus" []
 synonym: "RnVir" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000095
+name: visual estimation - virus symptoms
+namespace: SweetpotatoMethod
+def: "Observe the virus symptoms and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000096
+name: RnVir 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000097
 name: storage root cracking
 namespace: SweetpotatoTrait
-def: "Storage root cracking" []
+def: "The cracking of the storage root" []
 synonym: "RtCrk" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000099
+name: RtCrk 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000100
-name: protein content
+name: storage root protein content in dry weight basis
 namespace: SweetpotatoTrait
-def: "Protein content of the root" []
-synonym: "RtFlsPrt" EXACT []
+def: "Protein content in dry weight basis of the storage root" []
+synonym: "RtPrtDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:00001000
-name: rctstp 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000999 ! visual estimation of the plant response to  hight soil temperature (40 °c)
-
-[Term]
-id: CO_331:00001001
-name: visual estimation of the plant response to  west indian sweet potato weevil
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to west indian sweet potato weevil" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000355 ! reaction to west indian sweet potato weevil
-
-[Term]
-id: CO_331:00001002
-name: rcwispw 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001001 ! visual estimation of the plant response to  west indian sweet potato weevil
-
-[Term]
-id: CO_331:00001003
-name: visual estimation of the plant response to  striped sweet potato weevil
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Striped sweet potato weevil" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000356 ! reaction to striped sweet potato weevil
-
-[Term]
-id: CO_331:00001004
-name: rcsspw 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001003 ! visual estimation of the plant response to  striped sweet potato weevil
-
-[Term]
-id: CO_331:00001005
-name: visual estimation of the plant response to  sweet potato wire worms
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato wire worms" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000357 ! reaction to sweet potato wire worms
-
-[Term]
-id: CO_331:00001006
-name: rcspww 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001005 ! visual estimation of the plant response to  sweet potato wire worms
-
-[Term]
-id: CO_331:00001007
-name: visual estimation of the plant response to  wire worms
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to wire worms" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000358 ! reaction to wire worms
-
-[Term]
-id: CO_331:00001008
-name: rcww 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001007 ! visual estimation of the plant response to  wire worms
-
-[Term]
-id: CO_331:00001009
-name: visual estimation of the plant response to  sweet potato flea beetles
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato flea beetles" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000359 ! reaction to sweet potato flea beetles
-
-[Term]
-id: CO_331:00001010
-name: rcspfb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001009 ! visual estimation of the plant response to  sweet potato flea beetles
-
-[Term]
-id: CO_331:00001011
-name: visual estimation of the plant response to  flea beetles
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to flea beetles" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000360 ! reaction to flea beetles
-
-[Term]
-id: CO_331:00001012
-name: rcfb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001011 ! visual estimation of the plant response to  flea beetles
-
-[Term]
-id: CO_331:00001013
-name: visual estimation of the plant response to  sweet potato leaf beetles
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato leaf beetles" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000361 ! reaction to sweet potato leaf beetles
-
-[Term]
-id: CO_331:00001014
-name: rcsplb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001013 ! visual estimation of the plant response to  sweet potato leaf beetles
-
-[Term]
-id: CO_331:00001015
-name: visual estimation of the plant response to  beetles
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to beetles" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000362 ! reaction to beetles
-
-[Term]
-id: CO_331:00001016
-name: rcbtl 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001015 ! visual estimation of the plant response to  beetles
-
-[Term]
-id: CO_331:00001017
-name: visual estimation of the root response to  grub worm
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Grub worm" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000363 ! reaction to grubworm
-
-[Term]
-id: CO_331:00001018
-name: rcgrbw 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001017 ! visual estimation of the root response to  grub worm
-
-[Term]
-id: CO_331:00001019
-name: visual estimation of the root response to  hornworm
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Hornworm" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000364 ! reaction to hornworm
-
-[Term]
-id: CO_331:00001020
-name: rchrnw 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001019 ! visual estimation of the root response to  hornworm
-
-[Term]
-id: CO_331:00001021
-name: visual estimation of the plant response to  aphis
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Aphis" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000365 ! reaction to aphids
-
-[Term]
-id: CO_331:00001022
-name: rcaph 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001021 ! visual estimation of the plant response to  aphis
-
-[Term]
-id: CO_331:00001023
-name: visual estimation of the plant response to  sweet potato white fly
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato white fly" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000366 ! reaction to sweet potato white fly
 
 [Term]
 id: CO_331:00001024
-name: rcspwf 5 pt. scale
+name: RnSPWF 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001023 ! visual estimation of the plant response to  sweet potato white fly
-
-[Term]
-id: CO_331:00001025
-name: visual estimation of the plant response to  sweet potato moth
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato moth" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000367 ! reaction to sweet potato moth
 
 [Term]
 id: CO_331:00001026
-name: rcspmth 5 pt. scale
+name: RnSPMth 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001025 ! visual estimation of the plant response to  sweet potato moth
-
-[Term]
-id: CO_331:00001027
-name: visual estimation of the plant response to  moth
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Moth" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000368 ! reaction to moth
 
 [Term]
 id: CO_331:00001028
-name: rcmth 5 pt. scale
+name: RnMth 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001027 ! visual estimation of the plant response to  moth
-
-[Term]
-id: CO_331:00001029
-name: visual estimation of the plant response to  sweet potato stem borer
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato stem borer" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000369 ! reaction to sweet potato stem borer
 
 [Term]
 id: CO_331:0000103
-name: iron content
+name: storage root iron concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "RtFlsFe" EXACT []
+def: "The iron concentration in dry weight basis of the storage root" []
+synonym: "RtFlsFeDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:00001030
-name: rcspsb 5 pt. scale
+name: RnSPSB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001029 ! visual estimation of the plant response to  sweet potato stem borer
-
-[Term]
-id: CO_331:00001031
-name: visual estimation of the plant response to  other insects
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to other insects" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000370 ! reaction to other insects
 
 [Term]
 id: CO_331:00001032
-name: rcins 5 pt. scale
+name: RnIns 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001031 ! visual estimation of the plant response to  other insects
-
-[Term]
-id: CO_331:00001033
-name: visual estimation of the root response to  reniform nematode
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Reniform nematode" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000371 ! reaction to reniform nematode
 
 [Term]
 id: CO_331:00001034
-name: rcrfn 5 pt. scale
+name: RnRFN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001033 ! visual estimation of the root response to  reniform nematode
-
-[Term]
-id: CO_331:00001035
-name: visual estimation of the root response to  sting nematode
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Sting nematode" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000372 ! reaction to sting nematode
 
 [Term]
 id: CO_331:00001036
-name: rcstn 5 pt. scale
+name: RnStN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001035 ! visual estimation of the root response to  sting nematode
-
-[Term]
-id: CO_331:00001037
-name: visual estimation of the root response to  brown ring rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Brown ring rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000373 ! reaction to brown ring rot
 
 [Term]
 id: CO_331:00001038
-name: rcbrr 5 pt. scale
+name: RnBRR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001037 ! visual estimation of the root response to  brown ring rot
-
-[Term]
-id: CO_331:00001039
-name: visual estimation of the root response to  nematode
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to nematode" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000374 ! reaction to root lesion nematode
-relationship: method_of CO_331:0000375 ! reaction to other nematodes
 
 [Term]
 id: CO_331:00001040
-name: rcrln 5 pt. scale
+name: RnRLN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001039 ! visual estimation of the root response to  nematode
 
 [Term]
 id: CO_331:00001041
-name: rcon 5 pt. scale
+name: RnON 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001039 ! visual estimation of the root response to  nematode
-
-[Term]
-id: CO_331:00001042
-name: visual estimation of the root response to  wilt rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Wilt rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000376 ! reaction to wilt rot
 
 [Term]
 id: CO_331:00001043
-name: rcwr 5 pt. scale
+name: RnWR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001042 ! visual estimation of the root response to  wilt rot
-relationship: scale_of CO_331:00001064 ! visual estimation of the plant response to  white rust
-
-[Term]
-id: CO_331:00001044
-name: visual estimation of the root response to  fusarium surface rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Fusarium surface rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000377 ! reaction to fusarium surface rot
 
 [Term]
 id: CO_331:00001045
-name: rcfrs 5 pt. scale
+name: RnFRS 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001044 ! visual estimation of the root response to  fusarium surface rot
-
-[Term]
-id: CO_331:00001046
-name: visual estimation of the root response to  fusarium root rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Fusarium root rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000378 ! reaction to fusarium root rot
 
 [Term]
 id: CO_331:00001047
-name: rcfrr 5 pt. scale
+name: RnFRR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001046 ! visual estimation of the root response to  fusarium root rot
-
-[Term]
-id: CO_331:00001048
-name: visual estimation of the root response to  sclerotial blight and circular spot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Sclerotial blight and circular spot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
 
 [Term]
 id: CO_331:00001049
-name: rcsbc 5 pt. scale
+name: RnSBC 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001048 ! visual estimation of the root response to  sclerotial blight and circular spot
-
-[Term]
-id: CO_331:00001050
-name: visual estimation of the root response to  black rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Black rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000380 ! reaction to black rot
 
 [Term]
 id: CO_331:00001051
-name: rcbr 5 pt. scale
+name: RnBR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001050 ! visual estimation of the root response to  black rot
-
-[Term]
-id: CO_331:00001052
-name: visual estimation of the root response to  scurf
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response to Scurf" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000381 ! reaction to scurf
 
 [Term]
 id: CO_331:00001053
-name: rcscrf 5 pt. scale
+name: RnScrf 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001052 ! visual estimation of the root response to  scurf
-
-[Term]
-id: CO_331:00001054
-name: appearance of roots in response soft rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response Soft rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000382 ! reaction to soft rot
 
 [Term]
 id: CO_331:00001055
-name: rcsr 5 pt. scale
+name: RnSR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001054 ! appearance of roots in response soft rot
-
-[Term]
-id: CO_331:00001056
-name: appearance of roots in response java black rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response Java black rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000383 ! reaction to java black rot
-
-[Term]
-id: CO_331:00001057
-name: rcjbr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001056 ! appearance of roots in response java black rot
-
-[Term]
-id: CO_331:00001058
-name: appearance of roots in response diaporthe dry rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of roots in response Diaporthe dry rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000384 ! reaction to diaporthe dry rot
-
-[Term]
-id: CO_331:00001059
-name: rcddr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
 
 [Term]
 id: CO_331:0000106
-name: zinc content
+name: storage root zinc concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Content of zinc on dry weight basis of the root" []
-synonym: "RtFlsZn" EXACT []
+def: "The zinc concentration in dry weight basis of the storage root" []
+synonym: "RtFlsZnDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:00001060
-name: visual estimation of the plant response to  scab
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Scab" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000385 ! reaction to scab
-
-[Term]
-id: CO_331:00001061
-name: rcscb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001060 ! visual estimation of the plant response to  scab
-
-[Term]
-id: CO_331:00001062
-name: visual estimation of the plant response to  leaf spot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to leaf spot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000386 ! reaction to leaf spot
-
-[Term]
-id: CO_331:00001063
-name: rcls 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001062 ! visual estimation of the plant response to  leaf spot
-
-[Term]
-id: CO_331:00001064
-name: visual estimation of the plant response to  white rust
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to White rust" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000387 ! reaction to white rust
-
-[Term]
-id: CO_331:00001065
-name: visual estimation of the plant response to  foot rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Foot rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000388 ! reaction to foot rot
-
-[Term]
-id: CO_331:00001066
-name: rcfr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001065 ! visual estimation of the plant response to  foot rot
-
-[Term]
-id: CO_331:00001067
-name: visual estimation of the plant response to  charcoal rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Charcoal rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000389 ! reaction to charcoal rot
-
-[Term]
-id: CO_331:00001068
-name: rccr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001067 ! visual estimation of the plant response to  charcoal rot
-
-[Term]
-id: CO_331:00001069
-name: visual estimation of the plant response to  other fungi
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Other fungi" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000390 ! reaction to other fungi
-
-[Term]
-id: CO_331:00001070
-name: rcof 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001069 ! visual estimation of the plant response to  other fungi
-
-[Term]
-id: CO_331:00001071
-name: visual estimation of the plant response to  pox or soil rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Pox or soil rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000391 ! reaction to pox or soil rot
-
-[Term]
-id: CO_331:00001072
-name: rcpsr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001071 ! visual estimation of the plant response to  pox or soil rot
-
-[Term]
-id: CO_331:00001073
-name: visual estimation of the plant response to  bacterial stem and root rot
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Bacterial stem and root rot" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000392 ! reaction to bacterial stem and root rot
-
-[Term]
-id: CO_331:00001074
-name: rcbsrt 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001073 ! visual estimation of the plant response to  bacterial stem and root rot
-
-[Term]
-id: CO_331:00001075
-name: visual estimation of the plant response to  bacterial wilt
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Bacterial wilt" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000393 ! reaction to bacterial wilt
-
-[Term]
-id: CO_331:00001076
-name: rcbw 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001075 ! visual estimation of the plant response to  bacterial wilt
-
-[Term]
-id: CO_331:00001077
-name: visual estimation of the plant response to  other bacteria
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to other bacteria" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000394 ! reaction to other bacteria
-
-[Term]
-id: CO_331:00001078
-name: rcob 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001077 ! visual estimation of the plant response to  other bacteria
-
-[Term]
-id: CO_331:00001079
-name: visual estimation of the plant response to  sweet potato feathery mottle virus
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato feathery mottle virus" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus (spmv)
-
-[Term]
-id: CO_331:00001080
-name: rcspmv 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001079 ! visual estimation of the plant response to  sweet potato feathery mottle virus
-
-[Term]
-id: CO_331:00001081
-name: visual estimation of the plant response to  sweet potato mild mottle virus
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato mild mottle virus" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000396 ! reaction to sweet potato mild mottle virus (spmmv)
-
-[Term]
-id: CO_331:00001082
-name: rcspmmv 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001081 ! visual estimation of the plant response to  sweet potato mild mottle virus
-
-[Term]
-id: CO_331:00001083
-name: visual estimation of the plant response to  sweet potato vein mottle virus
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato vein mottle virus" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000397 ! reaction to sweet potato vein mottle virus (spvmv)
-
-[Term]
-id: CO_331:00001084
-name: rcspvmv 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001083 ! visual estimation of the plant response to  sweet potato vein mottle virus
-
-[Term]
-id: CO_331:00001085
-name: visual estimation of the plant response to  sweet potato virus disease complex
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to Sweet potato virus disease complex" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000398 ! reaction to sweet potato virus disease complex (spvd complex)
-
-[Term]
-id: CO_331:00001086
-name: rcspvd 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001085 ! visual estimation of the plant response to  sweet potato virus disease complex
-
-[Term]
-id: CO_331:00001087
-name: visual estimation of the plant response to  other virus
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to other virus" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000399 ! reaction to other virus
-
-[Term]
-id: CO_331:00001088
-name: rcov 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001087 ! visual estimation of the plant response to  other virus
-
-[Term]
-id: CO_331:00001089
-name: visual estimation of the plant response to  witches broom
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to witches broom" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000400 ! reaction to witches broom
 
 [Term]
 id: CO_331:0000109
-name: beta-carotene content
+name: storage root beta-carotene concentration in fresh weight basis
 namespace: SweetpotatoTrait
-def: "Beta carotene content of the root" []
-synonym: "RtFlsBC" EXACT []
+def: "The beta-carotene concentration in fresh weight basis of the storage root" []
+synonym: "RtBCFw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
-
-[Term]
-id: CO_331:00001090
-name: rcwb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001089 ! visual estimation of the plant response to  witches broom
-
-[Term]
-id: CO_331:00001091
-name: visual estimation of the plant response to  to other mycoplasma
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to to other mycoplasma" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000401 ! reaction to other mycoplasma
-
-[Term]
-id: CO_331:00001092
-name: rcom 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001091 ! visual estimation of the plant response to  to other mycoplasma
 
 [Term]
 id: CO_331:00001093
-name: taking standardized photo
+name: visual estimation - total sugar content
 namespace: SweetpotatoMethod
-def: "Visual estimation" []
+def: "Observe the total sugar content of the raw storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000402 ! total sugar content
-relationship: method_of CO_331:0000403 ! appearance of plant
-relationship: method_of CO_331:0000404 ! appearance of flower
-relationship: method_of CO_331:0000405 ! appearance of roots
-relationship: method_of CO_331:0000406 ! appearance of seeds
-relationship: method_of CO_331:0000407 ! appearance of leaves
-relationship: method_of CO_331:0000408 ! appearance of hearbarium
-
-[Term]
-id: CO_331:00001094
-name: rttsgc
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001095
-name: plant picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001096
-name: flower picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001097
-name: root picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001098
-name: seeds picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001099
-name: leaf picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001093 ! taking standardized photo
-
-[Term]
-id: CO_331:00001100
-name: observation of most frequennt storage root shape
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000069 ! storage root shape (primary)
-
-[Term]
-id: CO_331:00001101
-name: rtshpp 8 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001100 ! observation of most frequennt storage root shape
-
-[Term]
-id: CO_331:00001102
-name: observation of 2nd most frequent storage root shape
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000441 ! storage root shape (secondary)
-
-[Term]
-id: CO_331:00001103
-name: rtshps 8 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001102 ! observation of 2nd most frequent storage root shape
-
-[Term]
-id: CO_331:00001104
-name: observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000409 ! storage root shape uniformity
-
-[Term]
-id: CO_331:00001105
-name: rtshpu 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001104 ! observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
-
-[Term]
-id: CO_331:00001106
-name: observation of an average or all storage roots within a single plant or plot
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000410 ! storage root stalk length
-relationship: method_of CO_331:0000411 ! storage root attachment
-relationship: method_of CO_331:0000412 ! length to diameter ratio of roots
-relationship: method_of CO_331:0000413 ! skin color of roots
-relationship: method_of CO_331:0000414 ! skin texture of roots
-relationship: method_of CO_331:0000415 ! flesh color (carotenoids)
-relationship: method_of CO_331:0000416 ! flesh color (anthocyanins)
-relationship: method_of CO_331:0000417 ! deep of eyes of roots
-relationship: method_of CO_331:0000418 ! number of lenticels
-relationship: method_of CO_331:0000423 ! storage root defects (primary)
-relationship: method_of CO_331:0000424 ! relative storage root yield
-relationship: method_of CO_331:0000426 ! storage root appearance
-relationship: method_of CO_331:0000427 ! growing season
-relationship: method_of CO_331:0000438 ! millipede damage
-
-[Term]
-id: CO_331:00001107
-name: rtstlk 6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001108
-name: rtatt 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001109
-name: scale_of CO_331:00001106
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
-
-[Term]
-id: CO_331:00001110
-name: rtskncol 12 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001111
-name: rtskntxt 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001112
-name: rtflscolc 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001113
-name: rtflscola 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001114
-name: rtadvb 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001115
-name: ses 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001116
-name: observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000419 ! reaction to streptomyces soil rot
-
-[Term]
-id: CO_331:00001117
-name: ses 6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001116 ! observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
-
-[Term]
-id: CO_331:00001118
-name: visual estimation of the roots response to  root-knot nematode
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Root-knot nematode" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
-relationship: method_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
-
-[Term]
-id: CO_331:00001119
-name: rcmgrkn  6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
 
 [Term]
 id: CO_331:0000112
-name: total carotenoids
+name: storage root total carotenoid concentration in fresh weight basis
 namespace: SweetpotatoTrait
-def: "Total carotenoids content of the root" []
-synonym: "RtFlsTC" EXACT []
+def: "The total carotenoid concentration in fresh weight basis of the storage root" []
+synonym: "RtTCFw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:00001120
-name: rcmigrkn  5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
-
-[Term]
-id: CO_331:00001121
-name: visual estimation of the roots response to  fusarium oxysporum
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of an average or all fibrous roots within a single plant or plotin response to Fusarium oxysporum" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000422 ! reaction to fusarium oxysporum
-
-[Term]
-id: CO_331:00001122
-name: rnfr 6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001121 ! visual estimation of the roots response to  fusarium oxysporum
-
-[Term]
-id: CO_331:00001123
-name: rtdam 14 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001124
-name: rtyldr 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001125
-name: ptmtss 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001126
-name: amylose - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000428 ! amylose content
 
 [Term]
 id: CO_331:00001127
-name: g/100 g fw
+name: g/100g
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001126 ! amylose - method
-
-[Term]
-id: CO_331:00001128
-name: asparagine - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000429 ! asparagine content
-
-[Term]
-id: CO_331:00001129
-name: mg/g dw
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001128 ! asparagine - method
-relationship: scale_of CO_331:00001130 ! cyanidin - method
-relationship: scale_of CO_331:00001131 ! total monomeric anthocyanins - method
-relationship: scale_of CO_331:00001132 ! peonidin - method
-relationship: scale_of CO_331:00001133 ! anthocyanin - method
-relationship: scale_of CO_331:00001134 ! phenol - method
-
-[Term]
-id: CO_331:00001130
-name: cyanidin - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000430 ! cyanidin content
-
-[Term]
-id: CO_331:00001131
-name: total monomeric anthocyanins - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000431 ! total monomeric anthocyanin content
-
-[Term]
-id: CO_331:00001132
-name: peonidin - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000432 ! peonidin content
-
-[Term]
-id: CO_331:00001133
-name: anthocyanin - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000433 ! anthocyanin content
-
-[Term]
-id: CO_331:00001134
-name: phenol - method
-namespace: SweetpotatoMethod
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000434 ! phenol content
-
-[Term]
-id: CO_331:00001135
-name: nodes per vine evaluation
-namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000435 ! nodes per vine
-
-[Term]
-id: CO_331:00001136
-name: nodes/plant
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001135 ! nodes per vine evaluation
-
-[Term]
-id: CO_331:00001137
-name: leaves per plant evaluation
-namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000436 ! leaves per plant
-
-[Term]
-id: CO_331:00001138
-name: leaf/plant
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001137 ! leaves per plant evaluation
-
-[Term]
-id: CO_331:00001139
-name: color of leave picture
-namespace: SweetpotatoMethod
-def: "Taking picture" []
-is_a: CO_331:1000001 ! Methods
-relationship: method_of CO_331:0000437 ! color of leave
-
-[Term]
-id: CO_331:00001140
-name: picture
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:00001139 ! color of leave picture
-
-[Term]
-id: CO_331:00001141
-name: rtsmilldam 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-
-[Term]
-id: CO_331:00001142
-name: rtalcdam 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000883 ! weevil damage evaluation
-
-[Term]
-id: CO_331:00001143
-name: soils insect evaluation
-namespace: SweetpotatoMethod
-def: "Overall assessment of soil insect damage based on inspection of the harvested roots. Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000440 ! soil insect damage
-
-[Term]
-id: CO_331:00001144
-name: rtsinsdam  5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001143 ! soils insect evaluation
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000115
-name: starch content
+name: storage root starch content in dry weight basis
 namespace: SweetpotatoTrait
-def: "Storage root starch content evaluated in percentage dry weight" []
-synonym: "RtFlsSta" EXACT []
+def: "Starch content in dry weight basis of the storage root" []
+synonym: "RtStaDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000118
-name: fructose content
+name: storage root fructose content
 namespace: SweetpotatoTrait
-def: "Fructose content of the root" []
-synonym: "RtFlsFru" EXACT []
+def: "Fructose content of the storage root" []
+synonym: "RtFru" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000121
-name: glucose content
+name: storage root glucose content
 namespace: SweetpotatoTrait
-def: "Glucose content of the root" []
-synonym: "RtFlsGlu" EXACT []
+def: "Glucose content of the storage root" []
+synonym: "RtGlu" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000124
-name: sucrose content
+name: storage root sucrose content
 namespace: SweetpotatoTrait
-def: "Sucrose content  of the root" []
-synonym: "RtFlsSuc" EXACT []
+def: "Sucrose content of the storage root" []
+synonym: "RtSuc" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000127
-name: maltose content
+name: storage root maltose content
 namespace: SweetpotatoTrait
-def: "Maltose content  of the root" []
-synonym: "RtFlsMal" EXACT []
+def: "Maltose content of the storage root" []
+synonym: "RtMal" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000130
-name: fiber content
+name: storage root fiber content
 namespace: SweetpotatoTrait
-def: "Fiber content in fresh samples" []
+def: "The fiber content of the raw storage root" []
 synonym: "RtFlsFf" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000131
+name: estimation - fiber content
+namespace: SweetpotatoMethod
+def: "Observe the fiber content of storage roots evaluated in percentage fresh weight" []
+is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:0000133
-name: color of boiled roots
+name: flesh color of boiled storage roots
 namespace: SweetpotatoTrait
-def: "Color of boiled roots" []
+def: "Flesh color of boiled storage roots" []
 synonym: "RtCb" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: R.Kapinga
+
+[Term]
+id: CO_331:0000134
+name: visual estimation - flesh color of boiled storage roots method
+namespace: SweetpotatoMethod
+def: "Visual estimation- Observe the flesh color of boiled storage roots of flesh color of cooked roots immediately after cooking" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000135
+name: RtCb 3pt scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000136
-name: texture of boiled storage root flesh
+name: storage root flesh texture
 namespace: SweetpotatoTrait
-def: "Storage root texture after boiled" []
-synonym: "RtFlsTxH" EXACT []
+def: "The texture of storage root flesh" []
+synonym: "RtFlsTx" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000137
+name: estimation - texture method
+namespace: SweetpotatoMethod
+def: "Taste the boiled storage root flesh texture and rate it" []
+is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:0000139
-name: sweetness of boiled storage root flesh
+name: boiled storage root flesh sweetness
 namespace: SweetpotatoTrait
-def: "Sweetness of boiled root" []
+def: "The sweetness of the boiled storage root flesh" []
 synonym: "RtFlsSwt" EXACT []
-synonym: "Storage root sweetness" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman,W. Grueneberg
+
+[Term]
+id: CO_331:0000140
+name: estimation - sweetness method
+namespace: SweetpotatoMethod
+def: "Taste the boiled storage root flesh sweetness and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000141
+name: RtFlsSwt 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000142
 name: storage root dry matter content
 namespace: SweetpotatoTrait
-def: "Storage root dry matter content" []
+def: "The dry matter content of the storage root" []
 synonym: "RtDMC" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000143
+name: computation - storage root dry matter content
+namespace: SweetpotatoMethod
+def: "Compute the storage root dry matter content using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000145
+name: counting - number of commercial storage roots method
+namespace: SweetpotatoMethod
+def: "Count the number of commercial storage roots per net plot and record it. Evaluation of the number of all storage roots that weigh more or equal than 100 g per NET plot" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0000146
+name: measurement - weight of commercial storage root within net plot method
+namespace: SweetpotatoMethod
+def: "Measure the weight of commercial storage roots within net plot and record it. Select those that are heavier or equal than 100 g" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000147
 name: Plant Type estimating 3-9
 namespace: SweetpotatoTrait
-def: "Length of the main vines. 3= Erect (<75 cm), 5= Semi-erect (75-150 cm), 7= Spreading (151-250 cm), 9= Extremely spreading (> 250 cm)" []
+def: "The growth habit of the plant estimating 3-9" []
 synonym: "PLANT" EXACT []
 synonym: "PtTyp_Et_3to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000001 ! plant type
-relationship: variable_of CO_331:0000812 ! observation of plant type
-relationship: variable_of CO_331:0000813 ! plttyp 4 pt. scale
+relationship: variable_of CO_331:0000002 ! visual estimation - plant type method
+relationship: variable_of CO_331:0000003 ! PtTyp 4 pt. scale
 
 [Term]
 id: CO_331:0000148
 name: Ground Cover estimating 3-9
 namespace: SweetpotatoTrait
-def: "Soil area covered by plant canopy. 3= Low (<50%), 5= Medium (<50-74%), 7= High (75-90%), 9= Total (> 90%)" []
+def: "The ground cover of the plant estimating 3-9" []
 synonym: "GRNDCOVR" EXACT []
 synonym: "VnFolGRnv_Et_3to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000004 ! ground cover
-relationship: variable_of CO_331:0000814 ! observation of ground cover
-relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
+relationship: variable_of CO_331:0000005 ! visual estimation - ground cover method
+relationship: variable_of CO_331:0000006 ! VnFolGRnv 4pt. scale
 
 [Term]
 id: CO_331:0000149
-name: Twining  estimating 0-9
+name: Twining estimating 0-9
 namespace: SweetpotatoTrait
-def: "Ability of vines to climb adjacent stakes placed in those accessions showing twining characteristics. 0= Non-Twining, 3= Slightly twining, 5 = Moderately twining, 7= Twining, 9 = Very twining" []
+def: "The twining of the plant estimating 0-9" []
 synonym: "PtTwg_Et_0to9" EXACT []
 synonym: "TWING" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000007 ! twining
-relationship: variable_of CO_331:0000816 ! observation of twining
-relationship: variable_of CO_331:0000817 ! plttwg 5 pt. scale
+relationship: variable_of CO_331:0000008 ! visual estimation - twining method
+relationship: variable_of CO_331:0000009 ! PtTwg 5 pt. scale
 
 [Term]
 id: CO_331:0000150
 name: Predominant Vine Color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the predominant vine besides the green color. 1= Green, 3= Green with few purple spots, 4= Green with many purple spots, 5= Green with many dark purple spots, 6 = Mostly purple, 7= Mostly dark purple, 8= Totally purple, 9= Totally dark purple" []
+def: "The predominant color of the vine evaluated considering the whole vine from base to tip" []
 synonym: "VINCO1" EXACT []
 synonym: "VnColP_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000010 ! predominant vine color
-relationship: variable_of CO_331:0000818 ! observation of predominant vine color
-relationship: variable_of CO_331:0000819 ! vinclp 9 pt. scale
+relationship: variable_of CO_331:0000010 ! vine predominant color
+relationship: variable_of CO_331:0000011 ! visual estimation - vine predominant color method
+relationship: variable_of CO_331:0000012 ! VnColP 8 pt. scale
 
 [Term]
 id: CO_331:0000151
 name: Secondary Vine Color estimating 0-7
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the secondary vine besides the green color. 0 = Absent, 1 = Green base, 2 = Green tip, 3 = Green nodes, 4 = Purple base, 5 = Purple tip, 6 = Purple nodes, 7 = Other" []
+def: "The secondary color of the vine. The secondary color is more easily evaluated using younger vines" []
 synonym: "VINCO2" EXACT []
 synonym: "VnColS_Et_0to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000013 ! secondary vine color
-relationship: variable_of CO_331:0000820 ! observation of secondary vine color
-relationship: variable_of CO_331:0000821 ! vincls 8 pt. scale
+relationship: variable_of CO_331:0000013 ! vine secondary color
+relationship: variable_of CO_331:0000014 ! visual estimation - vine secondary color method
+relationship: variable_of CO_331:0000015 ! VnColS 8 pt. scale
 
 [Term]
 id: CO_331:0000152
 name: Vine Tips Pubescence estimating 0-7
 namespace: SweetpotatoTrait
-def: "Degree of hairiness of immature leaves recorded at the apex of the vines. 0= Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
+def: "The pubescence of the vine apex or tips estimating 0-7" []
 synonym: "VINPUBS" EXACT []
 synonym: "VnTipP_Et_0to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000016 ! vine tips pubescence
-relationship: variable_of CO_331:0000822 ! observation of vine tips pubescence
-relationship: variable_of CO_331:0000823 ! vintpp 8 pt. scale
+relationship: variable_of CO_331:0000017 ! visual estimation - vine apex pubescence method
+relationship: variable_of CO_331:0000018 ! VnTipP 4 pt. scale
 
 [Term]
 id: CO_331:0000153
 name: vine internode length
 namespace: SweetpotatoTrait
-def: "Measurement of the vine internode length" []
+def: "The length of the vine internode" []
 synonym: "VnInLg" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000154
+name: estimation - vine internode length method
+namespace: SweetpotatoMethod
+def: "Measure vine internode length and rate it. Average expression of at least three internodes located in the middle section of the vine" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0000155
+name: VnInLg 5pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000156
 name: Vine internode length estimating 1-9
 namespace: SweetpotatoTrait
-def: "Measurement of the vine internode length. 1= Very short (<3 cm), 3= Short (3-5 cm), 5=Intermediate (6-9 cm), 7=Long (10-12 cm), 9 =Very long (>12 cm)" []
+def: "The length of the vine internode estimating 1-9" []
 synonym: "VINLG" EXACT []
 synonym: "VnInLg_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000153 ! vine internode length
-relationship: variable_of CO_331:0000824 ! average length of at least three internodes located in the middle section of the vine
-relationship: variable_of CO_331:0000825 ! vininlg 5 pt. scale
+relationship: variable_of CO_331:0000154 ! estimation - vine internode length method
+relationship: variable_of CO_331:0000155 ! VnInLg 5pt. scale
 
 [Term]
 id: CO_331:0000157
 name: vine internode diameter
 namespace: SweetpotatoTrait
-def: "Measurement of the vine internode diameter" []
+def: "The diameter of the vine internode" []
 synonym: "VnInD" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000158
+name: measurement - vine internode diameter
+namespace: SweetpotatoMethod
+def: "Measure vine internode diameter and rate it. Average expression of at least three internodes located in the middle section of the vine" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000160
 name: Vine internode diameter estimating 1-9
 namespace: SweetpotatoTrait
-def: "Measurement of the vine internode diameter. 1= Very thin (<4 mm), 3= Thin (4-6 mm), 5=Intermediate (7-9 mm), 7=Thick (10-12 mm), 9=Very thick (>12 mm)" []
+def: "The diameter of the vine internode estimating 1-9" []
 synonym: "VINDIA" EXACT []
 synonym: "VnInD_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000157 ! vine internode diameter
-relationship: variable_of CO_331:0000826 ! average diameter of at least three internodes located in the middle section of the vine
-relationship: variable_of CO_331:0000827 ! vinind 5 pt. scale
+relationship: variable_of CO_331:0000158 ! measurement - vine internode diameter
+relationship: variable_of CO_331:0002031 ! mm
 
 [Term]
 id: CO_331:0000161
-name: General Outline of the Leaf estimating 1-7
+name: Leaf general outline estimating 1-7
 namespace: SweetpotatoTrait
-def: "Outline i.e., shape of a leaf located in the middle section of the vine. 1= Rounded, 2= Reniform (kidney-shaped), 3 = Chordate (heart-shaped), 4 = Triangular, 5= Hastate, 6 = Lobed, 7 = Almost divided" []
+def: "The general outline of the leaf estimating 1-7" []
 synonym: "LEAFSHAP1" EXACT []
 synonym: "LfOut_Et_1to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000019 ! general outline of the leaf
-relationship: variable_of CO_331:0000828 ! observation of general outline of the leaf
-relationship: variable_of CO_331:0000829 ! lefout 7 pt. scale
+relationship: variable_of CO_331:0000019 ! leaf general outline
+relationship: variable_of CO_331:0000020 ! visual estimation - leaf general outline method
+relationship: variable_of CO_331:0000021 ! LfOut 7 pt. scale
 
 [Term]
 id: CO_331:0000162
 name: Leaf Lobes Type estimating 0-9
 namespace: SweetpotatoTrait
-def: "Type of the lobe of a leaf located in the middle section of the vine. 0 = No lateral lobes (entire), 1 = Very slight (teeth), 3 = Slight, 5 = Moderate, 7 = Deep, 9= Very deep" []
+def: "The type of the leaf lobe Type estimating 0-9" []
 synonym: "LEAFSHAP2" EXACT []
 synonym: "LfLbT_Et_0to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000022 ! leaf lobe type
-relationship: variable_of CO_331:0000830 ! observation of leaf lobes type
-relationship: variable_of CO_331:0000831 ! leflbt  6 pt. scale
+relationship: variable_of CO_331:0000023 ! visual estimation - leaf lobe type
+relationship: variable_of CO_331:0000024 ! LfLbT 6 pt. scale
 
 [Term]
 id: CO_331:0000163
 name: Leaf Lobe Number estimating 1-9
 namespace: SweetpotatoTrait
-def: "Number of lateral and central leaf lobes of leaves located in the middle section of the vine. 1= 1 Lobe, 3 = 3 Lobe, 5 = 5 Lobe, 7 = 7 Lobe, 9 = 9 Lobe" []
+def: "The number of the leaf lobes estimating 1-9" []
 synonym: "LEAFSHAP3" EXACT []
 synonym: "LfLbN_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000025 ! leaf lobe number
-relationship: variable_of CO_331:0000832 ! observation of leaf lobe number
-relationship: variable_of CO_331:0000833 ! leflbn 5 pt. scale
+relationship: variable_of CO_331:0000026 ! counting - leaf lobe number
+relationship: variable_of CO_331:0000027 ! LfLbN 5 pt. scale
 
 [Term]
 id: CO_331:0000164
-name: Shape of Central Leaf Lobe estimating 0-9
+name: Leaf central lobe shape estimating 0-9
 namespace: SweetpotatoTrait
-def: "Shape of the central leaf lobe of a leaf located in the middle section of the vine. 0 = Absent, 1 = Toothed, 2 = Triangular, 3 = Semi-circular, 4 = Semi-elliptic, 5 = Elliptic, 6 = Lanceolate, 7 = Oblanceolate, 8 = Linear (broad), 9 = Linear (narrow)" []
+def: "The shape of the central leaf lobe estimating 0-9" []
 synonym: "LEAFSHAP4" EXACT []
 synonym: "LfLCS_Et_0to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000028 ! shape of central leaf lobe
-relationship: variable_of CO_331:0000834 ! observation of shape of central leaf lobe
-relationship: variable_of CO_331:0000835 ! leflcs 10 pt. scale
+relationship: variable_of CO_331:0000028 ! leaf central lobe shape
+relationship: variable_of CO_331:0000029 ! visual estimation - leaf central lobe shape
+relationship: variable_of CO_331:0000030 ! LfLCS 10 pt. scale
 
 [Term]
 id: CO_331:0000165
 name: Mature Leaf Size estimating 3-9
 namespace: SweetpotatoTrait
-def: "Length of the leaf defined as the distance between the basal lobes and the tip of the leave.. 3 = Small (<8 cm), 5 = Medium (8-15 cm), 7 = Large (16-25 cm), 9 = Very large (> 25 cm)" []
+def: "The size of the mature leaf estimating 3-9" []
 synonym: "LfLMS_Et_3to9" EXACT []
 synonym: "LFSIZE" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000031 ! mature leaf size
-relationship: variable_of CO_331:0000836 ! observation of mature leaf size
-relationship: variable_of CO_331:0000837 ! leflms 9 pt. scale
+relationship: variable_of CO_331:0000032 ! visual estimation - mature leaf size
+relationship: variable_of CO_331:0000033 ! LfLMS 4 pt. scale
 
 [Term]
 id: CO_331:0000166
 name: Abaxial Leaf Vein Pigmentation estimating 1-9
 namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation shown in the veins of the lower surface of a leaf. 1 = Yellow, 2 = Green, 3 = Purple spot in the base of main rib, 4 = Purple spot in several veins, 5 = Main rib partially purple, 6 = Main rib mostly or totally purple, 7 = All veins partial purple, 8 = All veins mostly or totally purple, 9 = Lower surface and veins totally purple" []
+def: "The pigmentation of the abaxial leaf vein estimating 1-9" []
 synonym: "LfAVP_Et_1to9" EXACT []
 synonym: "LFVEIN" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000034 ! abaxial leaf vein pigmentation
-relationship: variable_of CO_331:0000838 ! observation of abaxial leaf vein pigmentation
-relationship: variable_of CO_331:0000839 ! lefavp 9 pt. scale
+relationship: variable_of CO_331:0000035 ! visual estimation - abaxial leaf vein pigmentation
+relationship: variable_of CO_331:0000036 ! LfAVP 9 pt. scale
 
 [Term]
 id: CO_331:0000167
 name: Mature Leaf Color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded mature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
+def: "The color of the mature leaf estimating 1-9" []
 synonym: "LfCMt_Et_1to9" EXACT []
 synonym: "LFMATCO" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000037 ! mature leaf color
-relationship: variable_of CO_331:0000840 ! observation of mature leaf color
-relationship: variable_of CO_331:0000841 ! lefcmt 9 pt. scale
+relationship: variable_of CO_331:0000038 ! visual estimation - mature leaf color
+relationship: variable_of CO_331:0000039 ! LfCMt 9 pt. scale
 
 [Term]
 id: CO_331:0000168
 name: Immature Leaf Color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Describe the overall foliage color considering the color of fully expanded immature leaves of several plants.. 1 = Yellow-green, 2 = Green, 3 = Green with purple edge, 4 = Greyish-green (due to heavy pubescent), 5 = Green with purple veins on upper surface, 6 = Slightly purple, 7 = Mostly purple, 8 = Green upper purple lower, 9 = Purple both surfaces" []
+def: "The color of the inmature leaf estimating 1-9" []
 synonym: "LfColI_Et_1to9" EXACT []
 synonym: "LFINMCO" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000040 ! immature leaf color
-relationship: variable_of CO_331:0000842 ! observation of immature leaf color
-relationship: variable_of CO_331:0000843 ! lefcim 9 pt. scale
+relationship: variable_of CO_331:0000041 ! visual estimation - inmature leaf color
+relationship: variable_of CO_331:0000042 ! LfColI 9 pt. scale
 
 [Term]
 id: CO_331:0000169
 name: Petiole Pigmentation estimating 1-9
 namespace: SweetpotatoTrait
-def: "Distribution of anthocyanin (purple) pigmentation in the petioles of leaves. Indicate the most predominant color first.. 1 = Green, 2 = Green with purple near steam, 3 = Green width purple near leaf, 4 = Green with purple both ends, 5 = Green with purple spots throughout petiole, 6 = Green with multiple stripes, 7 = Purple with green near leaf, 8 = Some petioles purple others green, 9 = Totally or mostly purple" []
+def: "The pigmentation of the petiole estimating 1-9" []
 synonym: "FrPtP_Et_1to9" EXACT []
 synonym: "PTIOPG" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000043 ! petiole pigmentation
-relationship: variable_of CO_331:0000844 ! observation of petiole pigmentation
-relationship: variable_of CO_331:0000845 ! flrptp 9 pt. scale
+relationship: variable_of CO_331:0000044 ! visual estimation -petiole pigmentation
+relationship: variable_of CO_331:0000045 ! FrPtP 9 pt. scale
 
 [Term]
 id: CO_331:0000170
 name: petiole length
 namespace: SweetpotatoTrait
-def: "Petiole length from the base to the insertion with the blade" []
+def: "The length of the petiole" []
 synonym: "FrPtL" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000171
+name: measurement - petiole length
+namespace: SweetpotatoMethod
+def: "Measure petiole length and rate it. Average petiole length from the base to the insertion with the blade of at least 3 leaves in the middle portion of a main vine" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0000172
+name: FrPtL 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000173
 name: Petiole length estimating 1-9
 namespace: SweetpotatoTrait
-def: "Petiole length from the base to the insertion with the blade. 1=Very short (<10 cm), 3=Short (10-20 cm), 5=Intermediate (21-30 cm), 7=Long (31-40 cm), 9=Very long (>40 cm)" []
+def: "The length of the petiole estimating 1-9" []
 synonym: "FrPtL_Et_1to9" EXACT []
 synonym: "PETIOL" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000170 ! petiole length
-relationship: variable_of CO_331:0000846 ! average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
-relationship: variable_of CO_331:0000847 ! flrptl 5 pt. scale
+relationship: variable_of CO_331:0000171 ! measurement - petiole length
+relationship: variable_of CO_331:0000172 ! FrPtL 5 pt. scale
 
 [Term]
 id: CO_331:0000174
 name: Flower color estimating 1-6
 namespace: SweetpotatoTrait
-def: "The most representative color in the flowers. 1= White, 2 = White limb with purple throat, 3 = White limb with pale purple ring and purple throat, 4 = Pale purple limb with purple throat, 5 = Purple, 6 = Other" []
+def: "The color of the flower estimating 1-6" []
 synonym: "FLORCOL" EXACT []
 synonym: "FRnol_Et_1to6" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000046 ! flower color
-relationship: variable_of CO_331:0000848 ! observation of newly opened flowers
-relationship: variable_of CO_331:0000849 ! flrcol  6 pt. scale
+relationship: variable_of CO_331:0000047 ! visual estimation - flower color
+relationship: variable_of CO_331:0000048 ! Frnol 6 pt. scale
 
 [Term]
 id: CO_331:0000175
-name: Predominant Skin color estimating 1-9
+name: Storage root skin predominant color estimating 1-9 CIP
 namespace: SweetpotatoTrait
-def: "The most representative skin color of the root. 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
-synonym: "RTSKN1, SCOL" EXACT []
-synonym: "RtSknColP_Et_1to9" EXACT []
+def: "The most representative color of the storage root skin observed is recorded, estimating 1-9 by CIP" []
+synonym: " SCOL" EXACT []
+synonym: "RTSKN1" EXACT []
+synonym: "RtSknColP_Et_1to9_CIP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000049 ! predominant skin color
-relationship: variable_of CO_331:0000850 ! observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
-relationship: variable_of CO_331:0000851 ! prdskncol 9 pt. scale
+relationship: variable_of CO_331:0000049 ! storage root skin predominant color
+relationship: variable_of CO_331:0000051 ! RtSknColP 9 pt. scale
+relationship: variable_of CO_331:0002080 ! visual estimation - storage root skin color
 
 [Term]
 id: CO_331:0000176
-name: Intensity of Predominant Skin color estimating 1-3
+name: Storage root skin intensity of predominant color estimating 1-3
 namespace: SweetpotatoTrait
-def: "Intensity of Predominant Skin color of the root. 1= Pale, 2 = Intermediate, 3 = Dark" []
+def: "The intensity of predominant color of the storage root skin estimating 1-3" []
 synonym: "RTSKN2" EXACT []
 synonym: "RtSknColPI_Et_1to3" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000052 ! intensity of predominant skin color
-relationship: variable_of CO_331:0000852 ! observation of intensity of predominant skin color
-relationship: variable_of CO_331:0000853 ! skncpi  3 pt. scale
+relationship: variable_of CO_331:0000052 ! storage root skin intensity of predominant color
+relationship: variable_of CO_331:0000053 ! visual estimation - storage root skin intensity of predominant color
+relationship: variable_of CO_331:0000054 ! RtSknColPI 3 pt. scale
 
 [Term]
 id: CO_331:0000177
-name: Secondary Skin color estimating 1-10
+name: Storage root skin secondary skin color estimating 1-10
 namespace: SweetpotatoTrait
-def: "The less representative skin color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Brownish orange, 6 = Pink, 7 = Red, 8 = Purple-red, 9 = Dark purple" []
+def: "The secondary color of the storage root skin estimating 1-10" []
 synonym: "RTSKN3" EXACT []
 synonym: "RtSknColS_Et_1to10" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000055 ! secondary skin color
-relationship: variable_of CO_331:0000854 ! observation of secondary skin color
-relationship: variable_of CO_331:0000855 ! skncsc  10 pt. scale
+relationship: variable_of CO_331:0000055 ! storage root skin secondary skin color
+relationship: variable_of CO_331:0000056 ! visual estimation - storage root skin secondary color
+relationship: variable_of CO_331:0000057 ! RtSknColS 10 pt. scale
 
 [Term]
 id: CO_331:0000178
-name: Predominant Flesh color estimating 1-9
+name: Storage root predominant Flesh color estimating 1-9
 namespace: SweetpotatoTrait
-def: "The most representative flesh color of the root. 1 = White, 2 = Cream, 3 = Dark cream, 4 = Pale yellow, 5 = Dark yellow, 6 = Pale orange, 7 = Intermediate orange, 8 = Dark orange, 9 = Strongly pigmented with anthocyanins" []
+def: "The predominant color of the storage root flesh in a longitudinal section of the root estimating 1-9" []
+synonym: " FCOL" EXACT []
 synonym: "RtFlsColP_Et_1to9" EXACT []
-synonym: "RTFSH1, FCOL" EXACT []
+synonym: "RTFSH1" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000058 ! predominant flesh color
-relationship: variable_of CO_331:0000856 ! observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000857 ! prdflshcol 9 pt. scale
+relationship: variable_of CO_331:0000058 ! storage root predominant flesh color
+relationship: variable_of CO_331:0000059 ! visual estimation - storage root flesh predominant color
+relationship: variable_of CO_331:0000060 ! RtFlsColP 9 pt. scale
 
 [Term]
 id: CO_331:0000179
-name: Secondary Flesh color estimating 0-9
+name: Storage root flesh secondary color estimating 0-9
 namespace: SweetpotatoTrait
-def: "The less representative flesh color of the root. 0 = Absent, 1 = White, 2 = Cream, 3 = Yellow, 4 = Orange, 5 = Pink, 6 = Red, 7 = Purple-red, 8 = Purple, 9 = Dark purple" []
+def: "The secondary color of the storage root flesh estimating 0-9" []
 synonym: "RtFlsColS_Et_0to9" EXACT []
 synonym: "RTFSH2" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000061 ! secondary flesh color
-relationship: variable_of CO_331:0000858 ! observation of secondary flesh color
-relationship: variable_of CO_331:0000859 ! flscsc 10 pt. scale
+relationship: variable_of CO_331:0000061 ! storage root flesh secondary color
+relationship: variable_of CO_331:0000062 ! visual estimation - storage root flesh secondary color
+relationship: variable_of CO_331:0000063 ! RtFlsColS 10 pt. scale
 
 [Term]
 id: CO_331:0000180
-name: Distribution of Secondary Flesh color estimating 0-9
+name: Storage root flesh distribution of secondary color estimating 0-9
 namespace: SweetpotatoTrait
-def: "Distribution of Secondary Flesh color of the root. 0 = Absent, 1 = Narrow ring in cortex, 2 = Broad ring in cortex, 3 = Scattered spots in flesh, 4 = Narrow ring in flesh, 5 = Broad ring in flesh, 6 = Ring and other areas in flesh, 7 = In longitudinal sections, 8 = Covering most of the flesh, 9 = Covering all flesh" []
+def: "The distribution of secondary color of the storage root flesh estimating 0-9" []
 synonym: "RtFlsColSD_Et_1to9" EXACT []
 synonym: "RTFSH3" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000064 ! distribution of secondary flesh color
-relationship: variable_of CO_331:0000860 ! observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000861 ! flscsd 10 pt. scale
+relationship: variable_of CO_331:0000064 ! storage root flesh distribution of secondary color
+relationship: variable_of CO_331:0000065 ! visual estimation - storage root flesh distribution of secondary color
+relationship: variable_of CO_331:0000066 ! RtFlsColSD 10 pt. scale
 
 [Term]
 id: CO_331:0000181
-name: Storage Root Shape estimating 1-9
+name: Storage root shape estimating 1-9 CIP
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root shape. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Ovate, 5 = Obovate, 6 = Oblong, 7 = Long oblong, 8 = Long elliptic, 9 = Long irregular or curved" []
+def: "The shape of the storage root estimating 1-9 CIP" []
 synonym: "RTSHP" EXACT []
 synonym: "RtShp_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000067 ! storage root shape
-relationship: variable_of CO_331:0000862 ! observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
-relationship: variable_of CO_331:0000863 ! rtshp 9 pt. scale
+relationship: variable_of CO_331:0000067 ! storage root primary shape
+relationship: variable_of CO_331:0000068 ! visual estimation - storage root shape
+relationship: variable_of CO_331:0000863 ! RtShp 9 pt. scale
 
 [Term]
 id: CO_331:0000182
-name: Latex Production in Storage Roots estimating 3-7
+name: Storage root latex production estimating 3-7
 namespace: SweetpotatoTrait
-def: "Amount of latex observed after cross sectioning medium-sized storage roots. 3 = Little, 5 = Some, 7 = Abundant" []
+def: "The latex production of the storage root estimating 3-7" []
 synonym: "RTLATX" EXACT []
 synonym: "RtLxP_Et_3to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000070 ! latex production in storage roots
-relationship: variable_of CO_331:0000864 ! observation of latex production in storage roots
-relationship: variable_of CO_331:0000865 ! rtlat 3 pt. scale
+relationship: variable_of CO_331:0000070 ! storage root latex production
+relationship: variable_of CO_331:0000071 ! visual estimation - storage root latex production. amount of latex observed after cross sectioning medium-sized storage roots
+relationship: variable_of CO_331:0000072 ! RtLxP 3 pt. scale
 
 [Term]
 id: CO_331:0000183
-name: Oxidation in Storage Roots estimating 3-7
+name: Storage root oxidation estimating 3-7
 namespace: SweetpotatoTrait
-def: "Amount of browning due to oxidation. 3 = Little, 5 = Some, 7 = Abundant" []
+def: "The oxidation of the storage root estimating 3-7" []
 synonym: "RtOxi_Et_3to7" EXACT []
 synonym: "RTOXID" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000073 ! oxidation in storage roots
-relationship: variable_of CO_331:0000866 ! observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
-relationship: variable_of CO_331:0000867 ! rtoxi 3 pt. scale
+relationship: variable_of CO_331:0000073 ! storage root oxidation
+relationship: variable_of CO_331:0000074 ! visual estimation - storage root oxidation
+relationship: variable_of CO_331:0000075 ! RtOxi 3 pt. scale
 
 [Term]
 id: CO_331:0000184
 name: Storage root size estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root size based on inspection of the harvested roots. 1 = Excellent, 3 = Good, 5 = Fair, 7 = Poor, 9 = terrible" []
+def: "The size of the storage root estimating 1-9" []
 synonym: "RS" EXACT []
 synonym: "RtSiz_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000076 ! storage root size
-relationship: variable_of CO_331:0000868 ! storage root size - method
-relationship: variable_of CO_331:0000869 ! rtsize 5 pt. scale
+relationship: variable_of CO_331:0000077 ! visual estimation - storage root size
+relationship: variable_of CO_331:0000078 ! RtSiz 5 pt. scale
 
 [Term]
 id: CO_331:0000189
 name: number of plants established
 namespace: SweetpotatoTrait
-def: "Number of plants established" []
+def: "Evaluation of the number of plants established" []
 synonym: "PltEst" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0000190
+name: counting - number of plants planted method
+namespace: SweetpotatoMethod
+def: "Count the number of plants planted per net plot and record it" []
+is_a: CO_331:1000012 ! Counting
 
 [Term]
 id: CO_331:0000192
-name: Plants established counting number per plot
+name: Number of plants established per NET plot
 namespace: SweetpotatoTrait
-def: "Number of plants established" []
+def: "Evaluation of the number of plants established per NET plot" []
 synonym: "NOPE" EXACT []
 synonym: "PltEst_Ct_plplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000189 ! number of plants established
-relationship: variable_of CO_331:0000870 ! evaluation of plant vine establishment
 relationship: variable_of CO_331:0000871 ! plants/plot
+relationship: variable_of CO_331:0002046 ! counting - number of plants established method
 
 [Term]
 id: CO_331:0000193
-name: Virus symptoms 1 estimating 1-9
+name: Virus symptoms estimating 1-9
 namespace: SweetpotatoTrait
-def: "Virus symptoms evaluation. 1= No virus symptoms, 2= Unclear virus symptoms, 3= Clear virus symptoms < 5% of plants per plot, 4= Clear virus symptoms at 6 to 15% of plants per plot, 5= Clear virus symptoms at 16 to 33% of plants per plot, 6= Clear virus symptoms at 34 to 66% of plants per plot (more than 1/3 less than 2/3), 7= Clear virus symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8= Clear virus symptoms at all plants per plot (not stunted), 9= Severe virus symptoms in all plants per plot (stunted)." []
+def: "Virus symptoms estimating 1-9" []
+synonym: "RnVir_Et_1to9" EXACT []
 synonym: "VIR1" EXACT []
-synonym: "VirSm1_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000094 ! virus symptoms
-relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
-relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
+relationship: variable_of CO_331:0000095 ! visual estimation - virus symptoms
+relationship: variable_of CO_331:0000096 ! RnVir 9 pt. scale
 
 [Term]
 id: CO_331:0000194
 name: vine vigor
 namespace: SweetpotatoTrait
-def: "Vine vigor evaluation" []
+def: "The vigor of the vine" []
 synonym: "VnVg" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000195
+name: estimation - observation of plant vigor method
+namespace: SweetpotatoMethod
+def: "Observe the vigor of the vine and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000196
+name: VnVg 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000197
-name: Vine vigor  estimating 1-9
+name: Vine vigor estimating 1-9
 namespace: SweetpotatoTrait
-def: "Vine vigor evaluation. 1= Nearly no vines, 2= Weak vines, 3= Weak to medium strong vines, medium thick stems, and long internode distances, 4= Medium strong vines, medium thick stems, and medium internode distances, 5= Medium strong vines, thick vines, and long internode distances, 6= Medium strong vines, thick stems, and medium internode distances, 7= Strong vines, thick stems, short internode distances, and medium-long vines, 8= Strong vines, thick stems, short internode distances, and long vines,, 9= Very strong vine strength, thick stems, short internode distances, and very long vines" []
+def: "The vigor of the vine estimating 1-9" []
 synonym: "VnVg_Et_1to9" EXACT []
-synonym: "VV1" EXACT []
+synonym: "VV" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000194 ! vine vigor
-relationship: variable_of CO_331:0000875 ! observation of plant vigour
-relationship: variable_of CO_331:0000876 ! vinvgr 9 pt. scale
+relationship: variable_of CO_331:0000195 ! estimation - observation of plant vigor method
+relationship: variable_of CO_331:0000196 ! VnVg 9 pt. scale
 
 [Term]
 id: CO_331:0000198
-name: Reaction to Alternaria symptom estimating 1-9
+name: Alternaria symptoms estimating 1-9
 namespace: SweetpotatoTrait
-def: "Alternaria symptoms evaluation. 1 = No symptoms, 2 = Unclear symptoms, 3 = Clear symptoms at <5% per plot, 4 = Clear symptoms at 6 to 15% of plants per plot, 5 = Clear symptoms at 16 to 33% of plants per plot (less than 1/3), 6 = Clear symptoms at 34 to 66% of plants per plot (more than 1/3, 7 = Clear symptoms at 67 to 99 % of plants per plot (2/3 to almost all), 8 = Clear symptoms at all plants (not fully defoliated), 9 = Severe symptoms at all plants per plot (fully defoliated)" []
-synonym: "ALT1, AS1" EXACT []
+def: "Alternaria symptoms estimating 1-9" []
+synonym: " AS1" EXACT []
+synonym: "ALT1" EXACT []
 synonym: "RnAlt_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000091 ! reaction to early blight: (alternaria spp)
-relationship: variable_of CO_331:0000877 ! early blight evaluation: (alternaria)
-relationship: variable_of CO_331:0000878 ! altsm 9 pt. scale
+relationship: variable_of CO_331:0000091 ! reaction to alternaria spp
+relationship: variable_of CO_331:0000092 ! visual estimation - reaction of the plant to alternaria spp
+relationship: variable_of CO_331:0000093 ! RnAlt 9 pt. scale
 
 [Term]
 id: CO_331:0000199
-name: storage root form
+name: storage root appearance
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root form" []
-synonym: "RtFrm" EXACT []
+def: "The appearance of the storage root" []
+synonym: "RtApr" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000200
+name: visual estimation - storage root appearance
+namespace: SweetpotatoMethod
+def: "Observe the appearance of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000201
+name: RtFrm 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000202
-name: Storage root form estimating 1-9
+name: Storage root appearance estimating 1-9 CIP
 namespace: SweetpotatoTrait
-def: "Overall assessment of storage root form. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+def: "Overall assessment of storage root form CIP estimating 1-9" []
 synonym: "RF" EXACT []
-synonym: "RtFrm_Et_1to9" EXACT []
+synonym: "RtApr_Et_1to9_CIP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000199 ! storage root form
-relationship: variable_of CO_331:0000879 ! storage root form - method
-relationship: variable_of CO_331:0000880 ! rtform 9 pt. scale
+relationship: variable_of CO_331:0000199 ! storage root appearance
+relationship: variable_of CO_331:0000200 ! visual estimation - storage root appearance
+relationship: variable_of CO_331:0000201 ! RtFrm 9 pt. scale
 
 [Term]
 id: CO_331:0000203
-name: number of storage root damages
+name: storage root damage
 namespace: SweetpotatoTrait
-def: "Root with structural damages" []
+def: "The overall assessment of damage to storage roots" []
 synonym: "RtDam" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: W. Grueneberg
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+
+[Term]
+id: CO_331:0000204
+name: visual estimation - storage root damage
+namespace: SweetpotatoMethod
+def: "Observe the storage root damage and rate it. Observe storage root defects: prominent, including cracks, veins, constrictions and grooves, or a predominance of pencil roots" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000205
+name: RtDam 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000206
-name: Storage root damages estimating 1-9
+name: Storage root damage estimating 1-9
 namespace: SweetpotatoTrait
-def: "Root with structural damages. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
+def: "The overall assessment of damage to storage roots estimating 1-9" []
 synonym: "DAMR" EXACT []
 synonym: "RtDam_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000203 ! number of storage root damages
-relationship: variable_of CO_331:0000881 ! storage root damage
-relationship: variable_of CO_331:0000882 ! rtsdam 9 pt. scale
+relationship: variable_of CO_331:0000203 ! storage root damage
+relationship: variable_of CO_331:0000204 ! visual estimation - storage root damage
+relationship: variable_of CO_331:0000205 ! RtDam 5 pt. scale
 
 [Term]
 id: CO_331:0000207
-name: Reaction to Sweet potato weevil symptoms estimating 1-9
+name: Reaction to sweet potato weevil estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall assessment of weevil damage based on inspection of the harvested roots; early.. 1= No damage, 2= Very minor, 3= Minor, 4= Minor to moderate, 5= Moderate, 6= Moderate to heavy, 7= Heavy, 8= Heavy to severe damage, 9= Severe damage" []
+def: "Overall assessment of weevil damage estimating 1-9" []
+synonym: " WED" EXACT []
 synonym: "RnWvl_Et_1to9" EXACT []
-synonym: "WED1, WED" EXACT []
+synonym: "WED1" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000088 ! reaction to sweet potato weevil
-relationship: variable_of CO_331:0000883 ! weevil damage evaluation
-relationship: variable_of CO_331:0000884 ! rtdam 9 pt. scale
+relationship: variable_of CO_331:0000089 ! visual estimation - reaction to sweet potato weevil
+relationship: variable_of CO_331:0000090 ! RnWvl 5 pt. scale
 
 [Term]
 id: CO_331:0000208
 name: number of plants with storage roots
 namespace: SweetpotatoTrait
-def: "Number of plants with storage roots" []
+def: "Evaluation of the number of plants with storage roots after harvest" []
 synonym: "PtRt" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+is_a: CO_331:1000004 ! Abiotic_stress_trait
+
+[Term]
+id: CO_331:0000209
+name: counting - number of plants with storage roots method
+namespace: SweetpotatoMethod
+def: "Count the number of plants with storage roots within net plot and record it" []
+is_a: CO_331:1000012 ! Counting
 
 [Term]
 id: CO_331:0000211
-name: Plants with storage roots counting number per plot
+name: Number of plants with storage roots per NET plot
 namespace: SweetpotatoTrait
-def: "Number of plants with storage roots" []
+def: "Evaluation of the number of plants with storage roots after harvest per NET plot" []
 synonym: "NOPR" EXACT []
 synonym: "PtRt_Ct_plplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000208 ! number of plants with storage roots
+relationship: variable_of CO_331:0000209 ! counting - number of plants with storage roots method
 relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000885 ! evaluation of plants
 
 [Term]
 id: CO_331:0000212
 name: number of commercial storage roots
 namespace: SweetpotatoTrait
-def: "Roots 12-20 cm long and 10 cm in diameter" []
+def: "Evaluation of the number of all storage roots that weigh more or equal than 100 g" []
 synonym: "RtCmN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+is_a: CO_331:1000004 ! Abiotic_stress_trait
 
 [Term]
 id: CO_331:0000214
-name: Number of commercial storage roots counting number per plot
+name: Number of commercial storage roots per NET plot
 namespace: SweetpotatoTrait
-def: "Number of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+def: "Evaluation of the number of all storage roots that weigh more or equal than 100 g per NET plot" []
 synonym: "NOCR" EXACT []
-synonym: "RtCmN_Ct_plplot" EXACT []
+synonym: "RtCmN_Ct_rtplot" EXACT []
 is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000145 ! counting - number of commercial storage roots method
 relationship: variable_of CO_331:0000212 ! number of commercial storage roots
-relationship: variable_of CO_331:0000886 ! evaluation of roots
-relationship: variable_of CO_331:0000887 ! roots/plot
+relationship: variable_of CO_331:0000887 ! storage root/plot
 
 [Term]
 id: CO_331:0000215
 name: number of non-commercial storage roots
 namespace: SweetpotatoTrait
-def: "Number of small and large roots (10 > x < 20 cm long)" []
+def: "Evaluation of the number of all storage roots that weigh less than 100 g" []
 synonym: "RtNCmN" EXACT []
-is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+is_a: CO_331:1000004 ! Abiotic_stress_trait
 
 [Term]
 id: CO_331:0000217
-name: Number of non-commercial storage roots counting number per plot
+name: Number of non-commercial storage roots per NET plot
 namespace: SweetpotatoTrait
-def: "Number of root shorter than 10 cm long and greater than 20 cm long." []
+def: "Evaluation of the number of all storage roots that weigh less than 100 g per NET plot" []
 synonym: "NONC" EXACT []
-synonym: "RtNCmN_Ct_plplot" EXACT []
+synonym: "RtNCmN_Ct_rtplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000215 ! number of non-commercial storage roots
-relationship: variable_of CO_331:0000886 ! evaluation of roots
-relationship: variable_of CO_331:0000887 ! roots/plot
+relationship: variable_of CO_331:0000887 ! storage root/plot
+relationship: variable_of CO_331:0002045 ! counting - number of non-commercial storage roots method
 
 [Term]
 id: CO_331:0000218
 name: weight of commercial storage roots
 namespace: SweetpotatoTrait
-def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+def: "The weight of the commercial storage roots" []
 synonym: "RtCmW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000220
-name: Weight of commercial storage roots measuring kg per plot
+name: Weight of commercial storage roots per NET plot in kg
 namespace: SweetpotatoTrait
-def: "Weight of root that are 12 to 20 cm long and at least 10 cm in diameter" []
+def: "The weight of the commercial storage roots per NET plot in kg" []
 synonym: "CRW" EXACT []
 synonym: "RtCmW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000146 ! measurement - weight of commercial storage root within net plot method
 relationship: variable_of CO_331:0000218 ! weight of commercial storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
 
 [Term]
 id: CO_331:0000221
 name: weight of non-commercial storage roots
 namespace: SweetpotatoTrait
-def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
+def: "The weight of the non-commercial storage roots" []
 synonym: "RtNCmW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000223
-name: Weight of non-commercial storage roots measuring kg per plot
+name: Weight of non-commercial storage roots per NET plot in kg
 namespace: SweetpotatoTrait
-def: "Weight of root shorter than 10 cm long and greater than 20 cm long." []
+def: "The weight of the non-commercial storage roots per NET plot in kg" []
 synonym: "NCRW" EXACT []
 synonym: "RtNCmW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000221 ! weight of non-commercial storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002047 ! measurement - weight of non-commercial storage root within net plot method
 
 [Term]
 id: CO_331:0000224
-name: weight of vines
+name: vine weight
 namespace: SweetpotatoTrait
-def: "Weight of vines" []
+def: "The weight of the vines" []
 synonym: "VnW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000225
+name: measurement - weight of vines method
+namespace: SweetpotatoMethod
+def: "Measure the weight of vines after harvest per net plot in kg and record it" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000227
-name: Weight of vines measuring kg per plot
+name: Weight of vines per NET plot in kg
 namespace: SweetpotatoTrait
-def: "Weight of vines" []
+def: "The weight of the vines per NET plot in kg" []
 synonym: "VnW_Ms_kgplot" EXACT []
 synonym: "VW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000224 ! weight of vines
+relationship: variable_of CO_331:0000224 ! vine weight
+relationship: variable_of CO_331:0000225 ! measurement - weight of vines method
 relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000894 ! measurements of vine mass
+
+[Term]
+id: CO_331:0000228
+name: computation - number of storage roots per plant harvested method
+namespace: SweetpotatoMethod
+def: "Compute the number of storage roots per plant harvested within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000230
-name: Total number of roots computation per plant
+name: Number of storage roots-after harvest per plant harvested
 namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN_Ct_rtplant" EXACT []
-synonym: "TNROOT,NRPP" EXACT []
+def: "The number of storage roots-after harvest per plant harvested" []
+synonym: "NRPP" EXACT []
+synonym: "RtNumh_Ct_rtplant" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000079 ! total number of root
-relationship: variable_of CO_331:0000890 ! total root number per plant - method
-relationship: variable_of CO_331:0000891 ! roots/ plant
+relationship: variable_of CO_331:0000079 ! number of storage roots
+relationship: variable_of CO_331:0000228 ! computation - number of storage roots per plant harvested method
+relationship: variable_of CO_331:0000891 ! storage root/plant
+
+[Term]
+id: CO_331:0000231
+name: computation - number of storage roots per plot method
+namespace: SweetpotatoMethod
+def: "Compute the number of storage roots per plot in net plot after harvest using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000233
-name: Total number of root counting per plot
+name: Number of storage roots after harvest per NET plot
 namespace: SweetpotatoTrait
-def: "Total number of root after harvest" []
-synonym: "RtTtN_Ct_rtplot" EXACT []
+def: "The number of storage roots after harvest per NET plot" []
+synonym: "RtNum_Ct_rtplot" EXACT []
 synonym: "TNRPLOT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000079 ! total number of root
-relationship: variable_of CO_331:0000888 ! estimated number per plot - method
-relationship: variable_of CO_331:0000889 ! roots/ plot
+relationship: variable_of CO_331:0000079 ! number of storage roots
+relationship: variable_of CO_331:0000231 ! computation - number of storage roots per plot method
+relationship: variable_of CO_331:0000887 ! storage root/plot
 
 [Term]
 id: CO_331:0000234
-name: total root weight
+name: total storage root weight
 namespace: SweetpotatoTrait
-def: "Total weight of root  after harvest" []
+def: "The total weight of the storage roots" []
 synonym: "RtTWt" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: CloneSelector2015
+
+[Term]
+id: CO_331:0000235
+name: computation - total storage root weight per net plot method
+namespace: SweetpotatoMethod
+def: "Compute the total weight of storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000237
-name: Total root weight computation per plot
+name: Total storage root weight per NET plot in kg
 namespace: SweetpotatoTrait
-def: "Total weight of root after harvest" []
-synonym: "RtTWt_Cp_plot" EXACT []
+def: "The total weight of the storage roots per NET plot in kg" []
+synonym: "RtTWt_Cp_kgplot" EXACT []
 synonym: "TRW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000234 ! total root weight
+relationship: variable_of CO_331:0000234 ! total storage root weight
+relationship: variable_of CO_331:0000235 ! computation - total storage root weight per net plot method
 relationship: variable_of CO_331:0000893 ! kg/plot
-relationship: variable_of CO_331:0000895 ! estimated weight per plot - method
+
+[Term]
+id: CO_331:0000238
+name: estimation - storage root cracking method
+namespace: SweetpotatoMethod
+def: "Observe the cracking of the storage root and rate it. Average cracking shown in ten plants" []
+is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:0000239
 name: Storage root cracking estimating 0-7
 namespace: SweetpotatoTrait
-def: "Storage root cracking. 0 = Absent, 3 = Few cracks, 5 = Medium number of cracks, 7 = Many cracks" []
+def: "The cracking of the storage root estimating 0-7" []
 synonym: "RtCrk_Et_0to7" EXACT []
 synonym: "SGROOT" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000097 ! storage root cracking
-relationship: variable_of CO_331:0000902 ! estimation of cracking roots
-relationship: variable_of CO_331:0000903 ! rtscr 4 pt. scale
+relationship: variable_of CO_331:0000099 ! RtCrk 4 pt. scale
+relationship: variable_of CO_331:0000238 ! estimation - storage root cracking method
 
 [Term]
 id: CO_331:0000240
-name: Fresh weight of storage root
+name: fresh weight of the storage root
 namespace: SweetpotatoTrait
-def: "Fresh weight of storage root samples" []
+def: "The fresh weight of the storage root samples" []
 synonym: "RtFWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000241
+name: measurement - fresh weight of the storage root
+namespace: SweetpotatoMethod
+def: "Measure the fresh weight of the storage root sample and record it" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000243
-name: Fresh weight of storage root samples measuring g of sample
+name: Fresh weight of storage root samples measuring g
 namespace: SweetpotatoTrait
-def: "Fresh weight of storage root samples" []
+def: "The fresh weight of the storage root samples" []
 synonym: "DMF" EXACT []
 synonym: "RtFWt_Ms_g" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000240 ! Fresh weight of storage root
-relationship: variable_of CO_331:0000904 ! measurements of fresh root mass
+relationship: variable_of CO_331:0000240 ! fresh weight of the storage root
+relationship: variable_of CO_331:0000241 ! measurement - fresh weight of the storage root
 relationship: variable_of CO_331:0000905 ! g
 
 [Term]
 id: CO_331:0000244
-name: Dry weight of storage root
+name: dry weight of the storage root
 namespace: SweetpotatoTrait
-def: "Dry weight of storage root samples" []
+def: "The dry weight of the storage root samples" []
 synonym: "RtDWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000245
+name: measurement - dry weight of the storage root
+namespace: SweetpotatoMethod
+def: "Measure the dry weight of the storage root sample and record it" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000247
-name: Dry weight of storage root samples measuring g of sample
+name: Dry weight of storage root samples measuring g
 namespace: SweetpotatoTrait
-def: "Dry weight of storage root samples" []
+def: "The dry weight of the storage root samples" []
 synonym: "DMD" EXACT []
 synonym: "RtDWt_Ms_g" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000244 ! Dry weight of storage root
+relationship: variable_of CO_331:0000244 ! dry weight of the storage root
+relationship: variable_of CO_331:0000245 ! measurement - dry weight of the storage root
 relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000906 ! measurements of dry root mass
 
 [Term]
 id: CO_331:0000248
-name: Fresh weight of vines
+name: fresh weight of vines
 namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
+def: "The fresh weight of the vines samples" []
 synonym: "VnFWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000249
+name: measurement - fresh weight of the vine
+namespace: SweetpotatoMethod
+def: "Measure the fresh weight of vines sample and record it" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000251
 name: Fresh weight of vines measuring g of sample
 namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
+def: "The fresh weight of the vines samples measuring in g" []
 synonym: "DMFV" EXACT []
+synonym: "DMVF" EXACT []
 synonym: "VnFWt_Et_g" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000248 ! Fresh weight of vines
+relationship: variable_of CO_331:0000248 ! fresh weight of vines
+relationship: variable_of CO_331:0000249 ! measurement - fresh weight of the vine
 relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000907 ! measurements of fresh vine mass
 
 [Term]
 id: CO_331:0000252
-name: Dry weight of vines
+name: dry weight of vines
 namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
+def: "The dry weight of the vines samples" []
 synonym: "VnDWt" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000253
+name: measurement - dry weight of vines
+namespace: SweetpotatoMethod
+def: "Measure the dry weight of vines sample and record it" []
+is_a: CO_331:1000011 ! Measurement
 
 [Term]
 id: CO_331:0000255
-name: Dry weight of vines measuring g of sample
+name: Dry weight of vines samples measuring g
 namespace: SweetpotatoTrait
-def: "Weight of vines samples" []
+def: "The dry weight of the vines samples measuring in g" []
 synonym: "DMDV" EXACT []
+synonym: "DMVD" EXACT []
 synonym: "VnDWt_Ms_g" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000252 ! Dry weight of vines
+relationship: variable_of CO_331:0000252 ! dry weight of vines
+relationship: variable_of CO_331:0000253 ! measurement - dry weight of vines
 relationship: variable_of CO_331:0000905 ! g
-relationship: variable_of CO_331:0000908 ! measurements of dry vine mass
 
 [Term]
 id: CO_331:0000256
-name: fiber cooked
+name: boiled storage root fiber content
 namespace: SweetpotatoTrait
-def: "Fiber content in cooked samples" []
-synonym: "RtFlsFbC" EXACT []
+def: "The fiber content of the boiled storage root" []
+synonym: "BlRtFlsFbC" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000257
+name: estimation - fiber method in boiled storage root
+namespace: SweetpotatoMethod
+def: "Observe and taste the boiled storage root fiber and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000258
+name: BlRtFlsFbC 5 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000259
-name: Fibers in cooked samples estimating 1-9
+name: Fiber content in boiled storage roots estimating 1-9
 namespace: SweetpotatoTrait
-def: "Fiber content in cooked samples. 1= Non-fibrous, 2= Non-fibrous to slightly fibrous, 3= Slightly fibrous, 4= Slightly to moderately fibrous, 5= Moderately fibrous, 6= Moderately fibrous to fibrous, 7= Fibrous, 8= Fibrous to very fibrous, 9= Very fibrous" []
+def: "The fiber content of the boiled storage root flesh estimating 1-9" []
+synonym: "BlRtFlsFbC_Et_1to9" EXACT []
 synonym: "COOF" EXACT []
-synonym: "RtFlsFbC_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000256 ! fiber cooked
-relationship: variable_of CO_331:0000909 ! evaluation of cooked samples for fibers
-relationship: variable_of CO_331:0000910 ! rtfbr 9 pt. scale
+relationship: variable_of CO_331:0000256 ! boiled storage root fiber content
+relationship: variable_of CO_331:0000257 ! estimation - fiber method in boiled storage root
+relationship: variable_of CO_331:0000258 ! BlRtFlsFbC 5 pt. Scale
 
 [Term]
 id: CO_331:0000260
-name: Fibers content in fresh samples measuring percent
+name: Fiber content in raw storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Fiber content in fresh samples" []
+def: "Fiber content in fresh root samples measuring percent" []
 synonym: "FIBER" EXACT []
 synonym: "RtFlsFf_Ms_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000130 ! fiber content
+relationship: variable_of CO_331:0000130 ! storage root fiber content
+relationship: variable_of CO_331:0000131 ! estimation - fiber content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
 
 [Term]
 id: CO_331:0000261
-name: Storage root sweetness estimating 1-9
+name: Storage root sweetness in cooked samples estimating 1-9
 namespace: SweetpotatoTrait
-def: "Sweetness of boiled root. 1 = Not at all sweet, 2= Non-sweet to slightly sweet, 3 = Slightly sweet, 4= Slightly to moderately sweet, 5 = Moderately sweet, 6= Moderately sweet to sweet, 7 = Sweet, 8= Sweet to very sweet, 9= Very sweet" []
+def: "The sweetness of the boiled storage root flesh estimating 1-9" []
+synonym: "COOSU" EXACT []
 synonym: "RtFlsSwt_Et_1to9" EXACT []
-synonym: "TASTE, COOSU" EXACT []
+synonym: "TASTE" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000139 ! sweetness of boiled storage root flesh
-relationship: variable_of CO_331:0000912 ! evaluation of cooked samples for sweetness
-relationship: variable_of CO_331:0000913 ! rtswt 9 pt. scale
+relationship: variable_of CO_331:0000139 ! boiled storage root flesh sweetness
+relationship: variable_of CO_331:0000140 ! estimation - sweetness method
+relationship: variable_of CO_331:0000141 ! RtFlsSwt 9 pt. scale
+
+[Term]
+id: CO_331:0000262
+name: RtFlsTxH 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000263
-name: Storage root texture estimating 1-9 by Huaman
+name: Storage root texture in boiled estimating 1-9 by Huaman
 namespace: SweetpotatoTrait
-def: "Storage root texture after boiled. 1 = Dry, 3 = Somewhat dry, 5 = Intermediate, 7 = Moist, 9 = Very moist" []
+def: "The texture of the boiled storage root flesh estimating 1-9 by Huaman" []
 synonym: "RtFlsTxH_Et_1to9" EXACT []
 synonym: "RTTEXT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
-relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
-relationship: variable_of CO_331:0000915 ! flstxch 5 pt. scale
+relationship: variable_of CO_331:0000136 ! storage root flesh texture
+relationship: variable_of CO_331:0000137 ! estimation - texture method
+relationship: variable_of CO_331:0000262 ! RtFlsTxH 5 pt. scale
+
+[Term]
+id: CO_331:0000264
+name: RtFlsTxG 9 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000265
-name: Storage root texture estimating 1-9 by Grueneberg
+name: Storage root texture in boiled samples estimating 1-9 by Gruneberg
 namespace: SweetpotatoTrait
-def: "Storage root texture after boiled. 1= very moist, 2= Very moist to moist, 3= Moist, 4= Moist to moderately dry, 5= Moderately dry, 6= Moderately dry to dry, 7= Dry, 8= Dry to very dry, 9= Very dry" []
+def: "The texture of the boiled storage root flesh estimating 1-9" []
+synonym: " COOST" EXACT []
 synonym: "RtFlsTxG_Et_1to9" EXACT []
 synonym: "TEXTBR" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000136 ! texture of boiled storage root flesh
-relationship: variable_of CO_331:0000914 ! evaluation of cooked samples for texture
-relationship: variable_of CO_331:0000916 ! flstxcg 9 pt. scale
+relationship: variable_of CO_331:0000136 ! storage root flesh texture
+relationship: variable_of CO_331:0000137 ! estimation - texture method
+relationship: variable_of CO_331:0000264 ! RtFlsTxG 9 pt. Scale
 
 [Term]
 id: CO_331:0000266
-name: overall taste of cooked sample
+name: boiled storage root flesh taste
 namespace: SweetpotatoTrait
-def: "Overall taste of cooked sample" []
+def: "The overall taste of the boiled storage root flesh" []
 synonym: "RtFlsTs" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000267
+name: estimation - taste method
+namespace: SweetpotatoMethod
+def: "Taste the boiled storage root flesh and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000268
+name: RtFlsTs 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000269
-name: Overall taste of cooked sample estimating 1-9
+name: Boiled storage root flesh taste estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall taste of cooked sample. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+def: "The overall taste of the boiled storage root flesh estimating 1-9" []
 synonym: "COOT" EXACT []
 synonym: "RtFlsTs_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000266 ! overall taste of cooked sample
-relationship: variable_of CO_331:0000917 ! evaluation of cooked samples for taste
-relationship: variable_of CO_331:0000918 ! rttst 9 pt. scale
+relationship: variable_of CO_331:0000266 ! boiled storage root flesh taste
+relationship: variable_of CO_331:0000267 ! estimation - taste method
+relationship: variable_of CO_331:0000268 ! RtFlsTs 9 pt. scale
 
 [Term]
 id: CO_331:0000270
-name: overall appearance of cooked sample
+name: boiled storage root appearance
 namespace: SweetpotatoTrait
-def: "Appearance of cooked sample" []
+def: "The overall appearance of the boiled storage root flesh" []
 synonym: "RtFlsAp" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000271
+name: estimation - appearance method
+namespace: SweetpotatoMethod
+def: "Visual estimation of the storage root flesh appearance and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000272
+name: RtFlsAp 9 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000273
-name: Overall appearance of cooked sample estimating 1-9
+name: Boiled storage root appearance estimating 1-9
 namespace: SweetpotatoTrait
-def: "Appearance of cooked sample. 1= Very appealing, 2= Very appealing to appealing, 3= Appealing, 4= Appealing to somewhat appealing, 5= Somewhat appealing, 6= Somewhat appealing to unappealing, 7= Unappealing, 8= Unappealing to very unappealing, 9= Very unappealing" []
+def: "The overall appearance of the boiled storage root flesh" []
 synonym: "COOAP" EXACT []
 synonym: "RtFlsAp_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000270 ! overall appearance of cooked sample
-relationship: variable_of CO_331:0000919 ! evaluation of cooked samples for appearance
-relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
+relationship: variable_of CO_331:0000270 ! boiled storage root appearance
+relationship: variable_of CO_331:0000271 ! estimation - appearance method
+relationship: variable_of CO_331:0000272 ! RtFlsAp 9 pt. Scale
 
 [Term]
 id: CO_331:0000274
 name: sprouting ability
 namespace: SweetpotatoTrait
-def: "ability to produce new sprout" []
+def: "Ability to produce new sprout" []
 synonym: "RtSpA" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: Z. Huaman
+
+[Term]
+id: CO_331:0000275
+name: evaluation of roots for sprouting ability
+namespace: SweetpotatoMethod
+def: "Overall assessment using a scale of 1 to 9." []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000276
+name: RtSprt 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000277
 name: Sprouting ability estimating 1-9
 namespace: SweetpotatoTrait
-def: "ability to produce new sprout. 1= Excellent, 2= Excellent to good, 3= Good, 4= Good to fair, 5= Fair, 6= Fair to poor, 7= Poor, 8= Poor to terrible, 9= Terrible" []
+def: "The sprouting ability estimating 1-9" []
 synonym: "RSPR" EXACT []
-synonym: "RtSpA_Et_1to9" EXACT []
+synonym: "RtSpA_Et_1to9,RSPR" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000274 ! sprouting ability
-relationship: variable_of CO_331:0000921 ! evaluation of roots for sprouting ability
-relationship: variable_of CO_331:0000922 ! rtsprt 9 pt. scale
+relationship: variable_of CO_331:0000275 ! evaluation of roots for sprouting ability
+relationship: variable_of CO_331:0000276 ! RtSprt 9 pt. scale
 
 [Term]
 id: CO_331:0000278
-name: Protein content measuring percent
+name: Content of protein in dry weight basis in raw storage roots measuring percentage
 namespace: SweetpotatoTrait
-def: "Protein content of the root" []
-synonym: "PRO, PROTEIN" EXACT []
-synonym: "RtFlsPrt_Ms_pct" EXACT []
+def: "Protein content in dry weight basis in raw storage roots measuring percentage" []
+synonym: "PRODW" EXACT []
+synonym: "RwRtPrt_Ms_%DW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000100 ! protein content
+relationship: variable_of CO_331:0000100 ! storage root protein content in dry weight basis
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000923 ! protein content - method
+relationship: variable_of CO_331:0002108 ! measurement protein - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
 
 [Term]
 id: CO_331:0000279
-name: Content of iron on dry weight basis measuring mg per 100g
+name: Content of iron in fresh weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "FeDW" EXACT []
-synonym: "RtFlsFe_Ms_mg100gDW" EXACT []
+def: "The iron concentration in fresh weight basis of the storage root measuring mg per 100g by ICP" []
+synonym: "FeFW" EXACT []
+synonym: "RtFlsFe_Ms_ICP_mg100gFW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000103 ! iron content
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
 relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002079 ! storage root iron concentration in fresh weight basis
+relationship: variable_of CO_331:0002101 ! measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
 
 [Term]
 id: CO_331:0000280
-name: Content of zinc on dry weight basis measuring mg per 100g
+name: Content of zinc in fresh weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of zinc on dry weight basis of the root" []
-synonym: "RtFlsZn_Ms_mg100gDW" EXACT []
-synonym: "ZnDW" EXACT []
+def: "The zinc concentration in fresh weight basis of the storage root measuring mg per 100g by ICP" []
+synonym: "RtFlsZn_Ms_ICP_mg100gFW" EXACT []
+synonym: "ZnFW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000106 ! zinc content
 relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000927 ! content of zinc in dry weight basis - method
+relationship: variable_of CO_331:0002054 ! storage root zinc concentration in fresh weight basis
+relationship: variable_of CO_331:0002143 ! measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
 
 [Term]
 id: CO_331:0000281
-name: calcium content
+name: storage root calcium concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Content of calcium on dry weight basis of the root" []
-synonym: "RtFlsCa" EXACT []
+def: "The calcium concentration in dry weight basis of the storage root" []
+synonym: "RtFlsCaDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000284
-name: Content of calcium on dry weight basis measuringm g per 100g
+name: Content of calcium in fresh weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of calcium on dry weight basis of the root" []
-synonym: "CaDW" EXACT []
-synonym: "RtFlsCa_Ms_mg100gDW" EXACT []
+def: "The calcium concentration in fresh weight basis of the storage root measuring mg per 100g by ICP" []
+synonym: "CaFW" EXACT []
+synonym: "RtFlsCa_Ms_ICP_mg100gFW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000281 ! calcium content
 relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
+relationship: variable_of CO_331:0002053 ! storage root calcium concentration in fresh weight basis
+relationship: variable_of CO_331:0002084 ! measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
 
 [Term]
 id: CO_331:0000285
-name: magnesium content
+name: storage root magnesium concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
-synonym: "RtFlsMg" EXACT []
+def: "Content of magnesium in dry weight basis of the storage root" []
+synonym: "RtFlsMgDw" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000288
-name: Content of magnesium on dry weight basis measuring mg per 100g
+name: Content of magnesium in fresh weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
-synonym: "MgDW" EXACT []
-synonym: "RtFlsMg_Ms_mg100gDW" EXACT []
+def: "The magnesium content in fresh weight basis of the storage root measuring mg per 100g by ICP" []
+synonym: "MgFW" EXACT []
+synonym: "RtFlsMg_Ms_ICP_mg100gFW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000285 ! magnesium content
 relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
+relationship: variable_of CO_331:0002057 ! storage root magnesium concentration in fresh weight basis
+relationship: variable_of CO_331:0002126 ! measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
 
 [Term]
 id: CO_331:0000289
-name: Beta carotene content measuring mg per 100g
+name: Content of beta-carotene in dry weight basis in raw storage roots measuring mg per 100g
 namespace: SweetpotatoTrait
-def: "Beta carotene content of the root" []
-synonym: "BCDW" EXACT []
-synonym: "RtFlsBC_Ms_mg100gDW" EXACT []
+def: "The beta-carotene concentration in dry weight basis in raw storage roots measuring mg per 100g" []
+synonym: "RWBCDW" EXACT []
+synonym: "RwRtBC_Ms_mg100gDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000109 ! beta-carotene content
 relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000930 ! beta carotene content - method
+relationship: variable_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
+relationship: variable_of CO_331:0002120 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
 
 [Term]
 id: CO_331:0000290
-name: Total carotenoids measuring mg per 100g
+name: Content of total carotenoids in dry weight basis in raw storage roots measuring mg per 100g
 namespace: SweetpotatoTrait
-def: "Total carotenoids content of the root" []
-synonym: "RtFlsTC_Ms_mg100gDW" EXACT []
+def: "The total carotenoid concentration in dry weight basis in raw storage roots measuring mg per 100g" []
+synonym: "RwRtTC_Ms_mg100gDW" EXACT []
 synonym: "TCDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000112 ! total carotenoids
 relationship: variable_of CO_331:0000925 ! mg/100g
-relationship: variable_of CO_331:0000931 ! total carotenoids - method
+relationship: variable_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
+relationship: variable_of CO_331:0002137 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
 
 [Term]
 id: CO_331:0000291
-name: Starch content of raw storage roots percent
+name: Content of starch in dry weight basis in raw storage roots measuring percentage
 namespace: SweetpotatoTrait
-def: "Starch content of the raw storage root expressed as percent dry weight" []
-synonym: "RAWSTAR" EXACT []
-synonym: "RwRtSta_Ms_pct" EXACT []
+def: "Starch content in dry weight basis in raw storage roots measuring percentage" []
+synonym: "RwRtSta_Ms_%DW" EXACT []
+synonym: "STARDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000115 ! starch content
+relationship: variable_of CO_331:0000115 ! storage root starch content in dry weight basis
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000932 ! measurement of raw starch content
+relationship: variable_of CO_331:0002090 ! measurement  the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
 
 [Term]
 id: CO_331:0000292
-name: Fructose content of raw storage roots percent
+name: Content of fructose in raw storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Fructose content of the raw storage root expressed as percent" []
-synonym: "RAWFRUC" EXACT []
+def: "The fructose content of the raw storage root computing percent" []
+synonym: "RAWFRUCP" EXACT []
 synonym: "RwRtFru_Ms_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000118 ! fructose content
+relationship: variable_of CO_331:0000118 ! storage root fructose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000933 ! measurement of raw fructose content
+relationship: variable_of CO_331:0000933 ! measurement - fructose content of the raw storage root
 
 [Term]
 id: CO_331:0000293
-name: Glucose content of raw storage roots percent
+name: Content of glucose in raw storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Glucose content of the raw storage root expressed as percent" []
-synonym: "RAWGLUC" EXACT []
+def: "The glucose content of the raw storage root computing percent" []
+synonym: "RAWGLUCP" EXACT []
 synonym: "RwRtGlu_Ms_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000121 ! glucose content
+relationship: variable_of CO_331:0000121 ! storage root glucose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000934 ! measurement of raw glucose content
+relationship: variable_of CO_331:0000934 ! measurement - glucose content of the raw storage root
 
 [Term]
 id: CO_331:0000294
-name: Sucrose content of raw storage roots percent
+name: Content of sucrose in raw storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Sucrose content of the raw storage root expressed as percent" []
-synonym: "RAWSUCR" EXACT []
+def: "The sucrose content of the raw storage root computing percent" []
+synonym: "RAWSUCRP" EXACT []
 synonym: "RwRtSuc_Ms_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000124 ! sucrose content
+relationship: variable_of CO_331:0000124 ! storage root sucrose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000935 ! measurement of raw sucrose content
+relationship: variable_of CO_331:0000935 ! measurement - sucrose content of the raw storage root
 
 [Term]
 id: CO_331:0000295
-name: Maltose content of raw storage roots percent
+name: Content of maltose in raw storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Maltose content of the raw storage root expressed as percent" []
-synonym: "RAWMALT" EXACT []
+def: "The maltose content of the raw storage root computing percent" []
+synonym: "RAWMALTP" EXACT []
 synonym: "RwRtMal_Ms_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000127 ! maltose content
+relationship: variable_of CO_331:0000127 ! storage root maltose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000936 ! measurement of raw maltose content
+relationship: variable_of CO_331:0000936 ! measurement - maltose content of the raw storage root
 
 [Term]
 id: CO_331:0000296
-name: Yield of total roots per hectar computing tons per ha
+name: Total storage roots yield computation tons per ha
 namespace: SweetpotatoTrait
-def: "Yield evaluated in the harvest" []
+def: "The yield of the total storage roots tons per ha" []
 synonym: "RtYld_Cp_tha" EXACT []
 synonym: "RYTHA" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000082 ! yield of total roots
+relationship: variable_of CO_331:0000082 ! total storage roots yield
+relationship: variable_of CO_331:0000083 ! computation - total storage roots yield method
 relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000937 ! estimated yield per hectare - method
 
 [Term]
 id: CO_331:0000297
 name: Storage root dry matter content computing percent
 namespace: SweetpotatoTrait
-def: "Storage root dry matter content" []
+def: "The dry matter content of the storage root in percent" []
 synonym: "DM" EXACT []
 synonym: "RtDMC_Cp_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000142 ! storage root dry matter content
+relationship: variable_of CO_331:0000143 ! computation - storage root dry matter content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000938 ! storage root dry matter content - method
 
 [Term]
 id: CO_331:0000298
 name: survival index
 namespace: SweetpotatoTrait
-def: "Survival index" []
-synonym: "IxSrv" EXACT []
+def: "The index of survival or establishment of the plant" []
+synonym: "SrvInx" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000299
+name: computation - survival index method
+namespace: SweetpotatoMethod
+def: "Compute the survival index at harvest per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000301
 name: Survival index computing percent
 namespace: SweetpotatoTrait
-def: "Survival index" []
+def: "The index of survival or establishment of the plant computing percent" []
 synonym: "IxSrv_Cp_pct" EXACT []
 synonym: "SHI" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000298 ! survival index
+relationship: variable_of CO_331:0000299 ! computation - survival index method
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000939 ! survival index - method
 
 [Term]
 id: CO_331:0000302
 name: Harvest index computing percent
 namespace: SweetpotatoTrait
-def: "Harvest index" []
+def: "The index of the harvest computing percent" []
 synonym: "HI" EXACT []
-synonym: "IxHrv_Cp_pct" EXACT []
+synonym: "HrvInx_Cp_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000085 ! harvest index
+relationship: variable_of CO_331:0000086 ! computation - harvest index evaluation method
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:0000940 ! harvest index evaluation  - method
 
 [Term]
 id: CO_331:0000303
 name: number of plants planted
 namespace: SweetpotatoTrait
-def: "Number of plants planted" []
+def: "Evaluation of the number of plants planted" []
 synonym: "PltPld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000304
 name: number of plants harvested
 namespace: SweetpotatoTrait
-def: "Number of plants harvested" []
+def: "Evaluation of the number of plants harvested" []
 synonym: "PtHrv" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
+
+[Term]
+id: CO_331:0000305
+name: counting - number of plants harvested method
+namespace: SweetpotatoMethod
+def: "Count the number of plants harvested per net plot and record it" []
+is_a: CO_331:1000012 ! Counting
 
 [Term]
 id: CO_331:0000307
-name: marketable root yield
+name: commercial storage root yield
 namespace: SweetpotatoTrait
-def: "Marketable root yield" []
+def: "The yield of the commercial storage roots" []
 synonym: "RtCYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000308
-name: average commercial root weight
+name: average commercial storage root weight
 namespace: SweetpotatoTrait
-def: "Average commercial root weight evaluated in the harvest" []
+def: "The average commercial weight of storage roots" []
 synonym: "RtACRW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000309
-name: yield of total roots 2
+name: storage roots yield
 namespace: SweetpotatoTrait
-def: "Yield of total roots calculated after harvest" []
+def: "The yield of storage roots" []
 synonym: "RtYPP" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000310
-name: percentage of marketable roots
+name: proportion of commercial storage roots
 namespace: SweetpotatoTrait
-def: "Percentage of marketable roots after harvest" []
+def: "The proportion of commercial storage roots after harvest" []
 synonym: "RtCI" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000311
 name: biomass yield
 namespace: SweetpotatoTrait
-def: "Biomass yield" []
+def: "The yield of the biomass" []
 synonym: "BioYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
 id: CO_331:0000312
-name: foliage total yield
+name: total foliage yield
 namespace: SweetpotatoTrait
-def: "Foliage total yield" []
+def: "The yield of the total vine or foliage" []
 synonym: "VnFolYld" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: W. Grueneberg
 
 [Term]
-id: CO_331:0000326
-name: storage root surface defects
-namespace: SweetpotatoTrait
-def: "Storage Root Surface Defects" []
-synonym: "RtSDef" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+id: CO_331:0000313
+name: computation - commercial storage root yield method
+namespace: SweetpotatoMethod
+def: "Compute the yield of the commercial storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000314
+name: computation - average commercial weight of storage roots method
+namespace: SweetpotatoMethod
+def: "Compute the average commercial weight of storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000315
+name: computation - yield of storage roots per plant harvested method
+namespace: SweetpotatoMethod
+def: "Compute the yield of total storage roots per plant harvested within the net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000316
+name: computation - commercial storage roots proportion method
+namespace: SweetpotatoMethod
+def: "Compute the percentage of commercial storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000317
+name: computation - biomass yield method in kg
+namespace: SweetpotatoMethod
+def: "Computation of the biomass yield within net plot using the formula based in kg" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000318
+name: computation - yield of foliage method
+namespace: SweetpotatoMethod
+def: "Compute the yield of vines per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000321
+name: kg/plant
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000327
@@ -2753,4228 +2397,6178 @@ namespace: SweetpotatoTrait
 def: "Storage Root Cortex Thickness" []
 synonym: "RtCThk" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000328
 name: flowering habit
 namespace: SweetpotatoTrait
-def: "An behavior pattern of the plant to produce flowers" []
+def: "The habit of the flower" []
 synonym: "FrHab" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000329
 name: flower size
 namespace: SweetpotatoTrait
-def: "Flower size" []
+def: "The size of the flower" []
 synonym: "FrSiz" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000330
-name: shape of limb
+name: flower limb shape
 namespace: SweetpotatoTrait
-def: "Shape of limb" []
+def: "The shape of the flower limb" []
 synonym: "FrShL" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000331
 name: equality of sepal length
 namespace: SweetpotatoTrait
-def: "Equality of sepal length" []
+def: "The length equality of the sepal" []
 synonym: "FrSepEql" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000332
 name: number of sepal veins
 namespace: SweetpotatoTrait
-def: "Number of veins observed in the sepals" []
+def: "The number of sepal veins" []
 synonym: "FrSepNVn" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000333
 name: sepal shape
 namespace: SweetpotatoTrait
-def: "Sepal shape" []
+def: "The shape of the sepal" []
 synonym: "FrSepShp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000334
-name: sepal apex
+name: sepal apex shape
 namespace: SweetpotatoTrait
-def: "Sepal apex" []
+def: "The shape of the sepal apex" []
 synonym: "FrSepApx" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000335
 name: sepal pubescence
 namespace: SweetpotatoTrait
-def: "Degree of hairiness registered in the sepals" []
+def: "The pubescence of the sepal" []
 synonym: "FrSepPub" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000336
 name: sepal color
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the sepal" []
+def: "The color of the sepal" []
 synonym: "FrSepCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000337
-name: color of stigma
+name: stigma color
 namespace: SweetpotatoTrait
-def: "Color of stigma" []
+def: "The color of the stigma" []
 synonym: "FrStgCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000338
-name: color of style
+name: style color
 namespace: SweetpotatoTrait
-def: "Color of style" []
+def: "The color of the style" []
 synonym: "FrStyCol" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000339
 name: stigma exertion
 namespace: SweetpotatoTrait
-def: "The relative position of the stigma as compared to the highest anther." []
+def: "The exertion of the stigma" []
 synonym: "FrStgExt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000340
 name: seed capsule set
 namespace: SweetpotatoTrait
-def: "Seed capsule set" []
+def: "The capsule set of the seed" []
 synonym: "FrSdCp" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000341
 name: storage root formation
 namespace: SweetpotatoTrait
-def: "Arrangement of the storage roots on the underground stems." []
+def: "The formation of the storage root" []
 synonym: "RtFrm" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
-id: CO_331:0000343
-name: variability of storage root shape
+id: CO_331:0000342
+name: storage root stalk
 namespace: SweetpotatoTrait
-def: "Variability of storage root shape" []
-synonym: "RtShV" EXACT []
+def: "The length of the storage root stalk" []
+synonym: "RtStk" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000344
-name: variability of storage root size
+name: storage root size variability
 namespace: SweetpotatoTrait
-def: "Variability of storage root size" []
+def: "The size variability of the storage root" []
 synonym: "RtSzV" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000345
-name: keeping quality of storage roots
+name: stored storage root keeping quality
 namespace: SweetpotatoTrait
-def: "Keeping quality of storage roots" []
+def: "The keeping quality of stored storage roots" []
 synonym: "RtKQl" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+is_a: CO_331:1000007 ! Quality_trait
 
 [Term]
 id: CO_331:0000346
-name: consistency of boiled storage root
+name: boiled storage root consistency
 namespace: SweetpotatoTrait
-def: "Consistency of boiled storage root" []
+def: "The consistency of the boiled storage root" []
 synonym: "RtBlCu" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+is_a: CO_331:1000007 ! Quality_trait
 
 [Term]
 id: CO_331:0000347
-name: undesirable color of boiled storage root
+name: boiled storage root undesirable color
 namespace: SweetpotatoTrait
-def: "Undesirable color of boiled storage root" []
+def: "The undesirable color of the boiled storage root" []
 synonym: "RtBlCd" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: Z. Huaman
+is_a: CO_331:1000007 ! Quality_trait
 
 [Term]
 id: CO_331:0000348
 name: reaction to drought
 namespace: SweetpotatoTrait
-def: "Response to damage by water restriction." []
+def: "The response of the plant to water restriction" []
 synonym: "RnDrt" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000349
 name: reaction to flooding
 namespace: SweetpotatoTrait
-def: "Response of plant to inundation by water of all or part of the plant" []
+def: "The response of the plant (or plant part) to flooding" []
 synonym: "RnFld" EXACT []
-synonym: "waterlogging response" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000350
 name: reaction to heat
 namespace: SweetpotatoTrait
-def: "Response of a plant or plant part to damage by higher than normal temperatures" []
+def: "The response of the plant (or plant part) to heat" []
 synonym: "RnHeat" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000351
 name: reaction to salinity
 namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt" []
+def: "The response of the plant to salinity" []
 synonym: "RnSlt" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000352
 name: reaction to shade
 namespace: SweetpotatoTrait
-def: "Response of plant to damage by shade" []
+def: "The response of the plant to shade" []
 synonym: "RnShd" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000353
-name: reaction to soil
+name: reaction to acidic ph soil
 namespace: SweetpotatoTrait
-def: "Response of plant to damage by ph soil" []
+def: "The response of the plant to acidic pH soil" []
 synonym: "RnSph" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000354
 name: reaction to high soil temperature
 namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt" []
+def: "The response of the plant to high soil temperature" []
 synonym: "RnSTp" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000355
 name: reaction to west indian sweet potato weevil
 namespace: SweetpotatoTrait
-def: "Reaction to West Indian sweet potato weevil" []
+def: "The reaction of the plant to the West Indian sweet potato weevil" []
 synonym: "RnWISPW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000356
 name: reaction to striped sweet potato weevil
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil" []
+def: "The reaction of the plant to Striped sweet potato weevil" []
 synonym: "RnSSPW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000357
 name: reaction to sweet potato wire worms
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato wire worms" []
+def: "The reaction of the plant to Sweet potato wire worms" []
 synonym: "RnSPWW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000358
 name: reaction to wire worms
 namespace: SweetpotatoTrait
-def: "Reaction to Wire worms" []
+def: "The reaction of the plant to Wire worms" []
 synonym: "RnWW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000359
 name: reaction to sweet potato flea beetles
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato flea beetles" []
+def: "The reaction of the plant to Sweet potato flea beetles" []
 synonym: "RnSPFB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000360
 name: reaction to flea beetles
 namespace: SweetpotatoTrait
-def: "Reaction to flea beetles" []
+def: "The reaction of the plant to flea beetles" []
 synonym: "RnFB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000361
 name: reaction to sweet potato leaf beetles
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato leaf beetles" []
+def: "The reaction of the plant to Sweet potato leaf beetles" []
 synonym: "RnSPLB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000362
 name: reaction to beetles
 namespace: SweetpotatoTrait
-def: "Reaction to Beetles" []
+def: "The reaction of the plant to Beetles" []
 synonym: "RnBTL" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000363
 name: reaction to grubworm
 namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Grub worm" []
+def: "The reaction of the storage root to Grub worm" []
 synonym: "RnGrbW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000364
 name: reaction to hornworm
 namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Hornworm" []
+def: "The reaction of the storage root to Hornworm" []
 synonym: "RnHrnw" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000365
 name: reaction to aphids
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Aphis" []
+def: "The reaction of the plant to Aphids" []
 synonym: "RnAph" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000366
-name: reaction to sweet potato white fly
+name: reaction to sweet potato whitefly
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly" []
+def: "The reaction of the plant to Sweet potato whitefly" []
 synonym: "RnSPWF" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000367
 name: reaction to sweet potato moth
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato moth" []
+def: "The reaction of the plant to Sweet potato moth" []
 synonym: "RnSPMth" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000368
 name: reaction to moth
 namespace: SweetpotatoTrait
-def: "Reaction to Moth" []
+def: "The reaction of the plant to Moth" []
 synonym: "RnMth" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000369
 name: reaction to sweet potato stem borer
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato stem borer" []
+def: "The reaction of the plant to Sweet potato stem borer" []
 synonym: "RnSPSB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000370
 name: reaction to other insects
 namespace: SweetpotatoTrait
-def: "Reaction to Other insects" []
+def: "The reaction of the plant to Other insects" []
 synonym: "RnIns" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000371
 name: reaction to reniform nematode
 namespace: SweetpotatoTrait
-def: "Reaction to Reniform nematode" []
+def: "The reaction of the plant to Reniform nematode" []
 synonym: "RnRFN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000372
 name: reaction to sting nematode
 namespace: SweetpotatoTrait
-def: "Reaction to Sting nematode" []
+def: "The reaction of the plant to Sting nematode" []
 synonym: "RnStN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000373
 name: reaction to brown ring rot
 namespace: SweetpotatoTrait
-def: "Reaction to Brown ring rot" []
+def: "The reaction of the plant to Brown ring rot" []
 synonym: "RnBRR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000374
 name: reaction to root lesion nematode
 namespace: SweetpotatoTrait
-def: "Reaction to Root lesion nematode" []
+def: "The reaction of the plant to Root lesion nematode" []
 synonym: "RnRLN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000375
 name: reaction to other nematodes
 namespace: SweetpotatoTrait
-def: "Reaction to other nematodes" []
+def: "The reaction of the plant to other nematodes" []
 synonym: "RnON" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000376
 name: reaction to wilt rot
 namespace: SweetpotatoTrait
-def: "Reaction to Wilt rot" []
+def: "The reaction of the plant to Wilt rot" []
 synonym: "RnWR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000377
 name: reaction to fusarium surface rot
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium surface rot" []
+def: "The reaction of the plant to Fusarium surface rot" []
 synonym: "RnFRS" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000378
 name: reaction to fusarium root rot
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium root rot" []
+def: "The reaction of the plant to Fusarium root rot" []
 synonym: "RnFRR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000379
 name: reaction to sclerotial blight and circular spot
 namespace: SweetpotatoTrait
-def: "Reaction to Sclerotial blight and circular spot" []
+def: "The reaction of the plant to Sclerotial blight and circular spot" []
 synonym: "RnSBC" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000380
 name: reaction to black rot
 namespace: SweetpotatoTrait
-def: "Reaction to Black rot" []
+def: "The reaction of the plant to Black rot" []
 synonym: "RnBR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000381
 name: reaction to scurf
 namespace: SweetpotatoTrait
-def: "Reaction to Scurf" []
+def: "The reaction of the plant to Scurf" []
 synonym: "RnScrf" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000382
 name: reaction to soft rot
 namespace: SweetpotatoTrait
-def: "Reaction to Soft rot" []
+def: "The reaction of the plant to Soft rot" []
 synonym: "RnSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000383
 name: reaction to java black rot
 namespace: SweetpotatoTrait
-def: "Reaction to Java black rot" []
+def: "The reaction of the plant to Java black rot" []
 synonym: "RnJBR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000384
 name: reaction to diaporthe dry rot
 namespace: SweetpotatoTrait
-def: "Reaction to Diaporthe dry rot" []
+def: "The reaction of the plant to Diaporthe dry rot" []
 synonym: "RnDDR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000385
 name: reaction to scab
 namespace: SweetpotatoTrait
-def: "Reaction to Scab" []
+def: "The reaction of the plant to Scab" []
 synonym: "RnScb" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000386
 name: reaction to leaf spot
 namespace: SweetpotatoTrait
-def: "Reaction to leaf spot" []
+def: "The reaction of the plant to leaf spot" []
 synonym: "RnLS" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000387
 name: reaction to white rust
 namespace: SweetpotatoTrait
-def: "Reaction to White rust" []
+def: "The reaction of the plant to White rust" []
 synonym: "RnWR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000388
 name: reaction to foot rot
 namespace: SweetpotatoTrait
-def: "Reaction to Foot rot" []
+def: "The reaction of the plant to Foot rot" []
 synonym: "RnFR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000389
 name: reaction to charcoal rot
 namespace: SweetpotatoTrait
-def: "Reaction to Charcoal rot" []
+def: "The reaction of the plant to Charcoal rot" []
 synonym: "RnCR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000390
 name: reaction to other fungi
 namespace: SweetpotatoTrait
-def: "Reaction to Other fungi" []
+def: "The reaction of the plant to Other fungi" []
 synonym: "RnOF" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000391
 name: reaction to pox or soil rot
 namespace: SweetpotatoTrait
-def: "Reaction to Pox or soil rot" []
+def: "The reaction of the plant to Pox or soil rot" []
 synonym: "RnPSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000392
 name: reaction to bacterial stem and root rot
 namespace: SweetpotatoTrait
-def: "Reaction to Bacterial stem and root rot" []
+def: "The reaction of the plant to Bacterial stem and root rot" []
 synonym: "RnBSRt" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000393
 name: reaction to bacterial wilt
 namespace: SweetpotatoTrait
-def: "Reaction to Bacterial wilt" []
+def: "The reaction of the plant to Bacterial wilt" []
 synonym: "RnBW" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000394
 name: reaction to other bacteria
 namespace: SweetpotatoTrait
-def: "Reaction to Other bacteria" []
+def: "The reaction of the plant to Other bacteria" []
 synonym: "RnOB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000395
-name: reaction to sweet potato feathery mottle virus (spmv)
+name: reaction to sweet potato feathery mottle virus
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato feathery mottle virus (SPMV)" []
+def: "The reaction of the plant to Sweet potato feathery mottle virus (SPMV)" []
 synonym: "RnSPMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000396
-name: reaction to sweet potato mild mottle virus (spmmv)
+name: reaction to sweet potato mild mottle virus
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato mild mottle virus (SPMMV)" []
+def: "The reaction of the plant to Sweet potato mild mottle virus (SPMMV)" []
 synonym: "RnSPMMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000397
-name: reaction to sweet potato vein mottle virus (spvmv)
+name: reaction to sweet potato vein mottle virus
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato vein mottle virus (SPVMV)" []
+def: "The reaction of the plant to Sweet potato vein mottle virus (SPVMV)" []
 synonym: "RnSPVMV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000398
-name: reaction to sweet potato virus disease complex (spvd complex)
+name: reaction to sweet potato virus disease complex
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato virus disease complex (SPVD complex)" []
+def: "The reaction of the plant to Sweet potato virus disease complex (SPVD complex)" []
 synonym: "RnSPVD" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000399
 name: reaction to other virus
 namespace: SweetpotatoTrait
-def: "Reaction to Other virus" []
+def: "The reaction of the plant to Other virus" []
 synonym: "RnOV" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000400
 name: reaction to witches broom
 namespace: SweetpotatoTrait
-def: "Reaction to Witches broom" []
+def: "The reaction of the plant to Witches broom" []
 synonym: "RnWB" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000401
 name: reaction to other mycoplasma
 namespace: SweetpotatoTrait
-def: "Reaction to Other mycoplasma" []
+def: "The reaction of the plant to Other mycoplasma" []
 synonym: "RnOM" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: Z. Huaman
 
 [Term]
 id: CO_331:0000402
-name: total sugar content
+name: storage root total sugar content
 namespace: SweetpotatoTrait
-def: "Total sugar content" []
-synonym: "RtTSgC" EXACT []
+def: "The total sugar content of the storage root" []
+synonym: "RwRtTSg" EXACT []
 is_a: CO_331:1000007 ! Quality_trait
-created_by: Z. Huaman
-
-[Term]
-id: CO_331:0000403
-name: appearance of plant
-namespace: SweetpotatoTrait
-def: "Appearance of plant" []
-synonym: "PtHbt" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000404
-name: appearance of flower
-namespace: SweetpotatoTrait
-def: "Appearance of flower" []
-synonym: "FrCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000405
-name: appearance of roots
-namespace: SweetpotatoTrait
-def: "Appearance of roots" []
-synonym: "RtCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000406
-name: appearance of seeds
-namespace: SweetpotatoTrait
-def: "Appearance of seeds" []
-synonym: "FrSds" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000407
-name: appearance of leaves
-namespace: SweetpotatoTrait
-def: "Appearance of leaves" []
-synonym: "Lf" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
-
-[Term]
-id: CO_331:0000408
-name: appearance of hearbarium
-namespace: SweetpotatoTrait
-def: "Appearance of hearbarium" []
-synonym: "PtHrb" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: G. Rossel
 
 [Term]
 id: CO_331:0000409
 name: storage root shape uniformity
 namespace: SweetpotatoTrait
-def: "Storage Root Shape uniformity within a single plant or plot" []
+def: "The shape uniformity of the storage root" []
 synonym: "RtShpU" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000410
-name: storage root stalk length
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems" []
-synonym: "RtStlk" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000411
-name: storage root attachment
+name: storage root attachment ability
 namespace: SweetpotatoTrait
-def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off" []
+def: "The attachment ability of the storage root" []
 synonym: "RtAtt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000412
-name: length to diameter ratio of roots
+name: length to diameter ratio of storage roots
 namespace: SweetpotatoTrait
-def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
+def: "The length to diameter ratio of the storage root" []
 synonym: "RtLDR" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000413
-name: skin color of roots
-namespace: SweetpotatoTrait
-def: "The most representative skin color observed is recorded" []
-synonym: "RtSknCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000414
-name: skin texture of roots
+name: storage root skin texture
 namespace: SweetpotatoTrait
-def: "Storage root skin feel, appearance, or consistency by visual observation and touch" []
+def: "The texture of the storage root skin" []
 synonym: "RtSknTxt" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000415
-name: flesh color (carotenoids)
+name: storage root flesh color (carotenoids)
 namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtFlsColC" EXACT []
+def: "The predominant color of Carotenoids in the storage root flesh" []
+synonym: "RtFlsColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000416
-name: flesh color (anthocyanins)
+name: storage root flesh color (anthocyanins)
 namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots" []
-synonym: "RtFlsColA" EXACT []
+def: "The predominant color of Anthocyanins in the storage root flesh" []
+synonym: "RtFlsColP" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000417
-name: deep of eyes of roots
+name: storage root adventitious buds depth
 namespace: SweetpotatoTrait
-def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface" []
+def: "The depth of the adventitious buds" []
 synonym: "RtAdvB" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000418
 name: number of lenticels
 namespace: SweetpotatoTrait
-def: "Overall assessment of visible lenticels at the storage root interface" []
+def: "The number of the lenticels" []
 synonym: "RtLtcl" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000419
 name: reaction to streptomyces soil rot
 namespace: SweetpotatoTrait
-def: "Streptomyces ipomoeae symptom evaluation" []
+def: "The reaction of the storage root to streptomyces soil rot" []
 synonym: "RnPSR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000420
 name: reaction to root knot nematode meloidogyne spp
 namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation" []
+def: "The reaction of the storage root to Root Knot Nematode Meloidogyne spp" []
 synonym: "RnMgRKN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000421
 name: reaction to root knot nematode meloidogyne incognita
 namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation" []
+def: "The reaction of the storage root to Root Knot Nematode Meloidogyne incognita" []
 synonym: "RnMgIRKN" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: A.Gonzales
 
 [Term]
 id: CO_331:0000422
 name: reaction to fusarium oxysporum
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium oxysporum batatas symptom evaluation" []
+def: "The reaction of the storage root to Fusarium oxysporum batatas" []
 synonym: "RnFR" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000423
-name: storage root defects (primary)
+name: storage root surface primary defects
 namespace: SweetpotatoTrait
-def: "Type and/or name of primary visible storage root defect" []
-synonym: "RtDam" EXACT []
-synonym: "RtDefP" EXACT []
+def: "Storage root surface primary defects" []
+synonym: "RtSPDef" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000424
 name: relative storage root yield
 namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield" []
+def: "The overall visual estimation of storage root yield" []
 synonym: "RtYldR" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000425
 name: storage root yield relative to check
 namespace: SweetpotatoTrait
-def: "Overall calculation of relative root yield" []
+def: "The overall computation of relative storage root yield" []
 synonym: "RtYldChk" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
-
-[Term]
-id: CO_331:0000426
-name: storage root appearance
-namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield appearance" []
-synonym: "RtApr" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000427
 name: growing season
 namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season" []
+def: "The overall visual assessment of storage root size relative to harvest date and/or total growing season" []
 synonym: "PtMtSs" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000428
-name: amylose content
+name: storage root amylose concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Amylose content in sweetpotato" []
+def: "The amylose content in dry weight basis of the storage root" []
 synonym: "RtFlsAmy" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000429
-name: asparagine content
+name: storage root asparagine concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "peonidin content of purple flesh sweetpotato" []
+def: "The asparagine content in dry weight basis of the storage root" []
 synonym: "RtFlsAsp" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000430
-name: cyanidin content
+name: storage root cyanidin concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
+def: "The cyanidin content in dry weight basis of the storage root" []
 synonym: "RtFlsCya" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000431
-name: total monomeric anthocyanin content
+name: storage root total monomeric anthocyanin concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
+def: "The total monomeric anthocyanin content in dry weight basis of the storage root" []
 synonym: "RtFlsAntM" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000432
-name: peonidin content
+name: storage root peonidin concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Peonidin content of purple flesh sweetpotato" []
+def: "The peonidin content in dry weight basis of the storage root" []
 synonym: "RtFlsPeo" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000433
-name: anthocyanin content
+name: storage root anthocyanin concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Anthocyanin content of purple flesh sweetpotato" []
+def: "The anthocyanin content in dry weight basis of the storage root" []
 synonym: "RtFlsAnt" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000434
-name: phenol content
+name: storage root phenol concentration in dry weight basis
 namespace: SweetpotatoTrait
-def: "Phenol content of purple flesh sweetpotato" []
+def: "The phenol content in dry weight basis of the storage root" []
 synonym: "RtFlsPhe" EXACT []
 is_a: CO_331:1000009 ! Biochemical_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000435
-name: nodes per vine
+name: node number per vine
 namespace: SweetpotatoTrait
-def: "Nodes per vine" []
+def: "The number per vine of the nodes" []
 synonym: "VnNds" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
 
 [Term]
 id: CO_331:0000436
-name: leaves per plant
+name: leaf number per plant
 namespace: SweetpotatoTrait
-def: "Leaves per plant" []
+def: "The number per plant of the leafs" []
 synonym: "PtLvs" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
-
-[Term]
-id: CO_331:0000437
-name: color of leave
-namespace: SweetpotatoTrait
-def: "Color of leave" []
-synonym: "LfCol" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-created_by: D. Gemenet
 
 [Term]
 id: CO_331:0000438
 name: millipede damage
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by Millipede in roots" []
+def: "The reaction of the storage root to Millipede" []
 synonym: "RtMillDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
 
 [Term]
 id: CO_331:0000439
 name: alcidodes sp. damage
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by Alcidodes sp,  causes crown enlargement/galling or death by girdling" []
+def: "The reaction of the storage root to Alcidodes sp." []
 synonym: "RtAlcDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
 
 [Term]
 id: CO_331:0000440
 name: soil insect damage
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by soil insect" []
+def: "The reaction of the storage root to soil insects" []
 synonym: "RtSInsDam" EXACT []
 is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: T.Carey
 
 [Term]
 id: CO_331:0000441
-name: storage root shape (secondary)
+name: storage root secondary shape
 namespace: SweetpotatoTrait
-def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots" []
+def: "The secondary shape of the storage root" []
 synonym: "RtShpS" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
-created_by: C. Yencho
+
+[Term]
+id: CO_331:0000442
+name: visual estimation - storage root surface defects
+namespace: SweetpotatoMethod
+def: "Observe storage root surface defects and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000443
+name: estimation - observation of storage root cortex thickness method
+namespace: SweetpotatoMethod
+def: "Measure storage root cortex thickness and estimated it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000444
+name: visual estimation - flowering habit
+namespace: SweetpotatoMethod
+def: "Observe the habit of the flower and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000445
+name: measurement - flower size
+namespace: SweetpotatoMethod
+def: "Measure flower size and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0000446
+name: visual observation - flower limb shape
+namespace: SweetpotatoMethod
+def: "Observe the flower limb shape and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000447
+name: measurement - sepal length equality
+namespace: SweetpotatoMethod
+def: "Measure sepal length equality and rate it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0000448
+name: observation - sepal vein number
+namespace: SweetpotatoMethod
+def: "Count the number of sepal veins and record it. Record the most frequent number in ten typical flowers" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0000449
+name: visual estimation - sepal shape
+namespace: SweetpotatoMethod
+def: "Observe the sepal shape and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000450
+name: visual estimation - sepal apex shape
+namespace: SweetpotatoMethod
+def: "Observe the shape of the sepal apex and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000451
+name: visual estimation - sepal pubescence
+namespace: SweetpotatoMethod
+def: "Observe the pubescence of the sepal and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000452
+name: visual estimation - sepal color
+namespace: SweetpotatoMethod
+def: "Observe the sepal color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000453
+name: visual estimation - stigma color
+namespace: SweetpotatoMethod
+def: "Observe the stigma color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000454
+name: visual estimation - style color
+namespace: SweetpotatoMethod
+def: "Observe the style color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000455
+name: visual estimation - stigma exertion
+namespace: SweetpotatoMethod
+def: "Observe the stigma exertion and rate it. The relative position of the stigma as compared to the highest anther" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000456
+name: visual estimation - seed capsule set
+namespace: SweetpotatoMethod
+def: "Observe the seed capsule set and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000457
+name: visual estimation - storage root formation
+namespace: SweetpotatoMethod
+def: "Observe the storage root formation and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000458
+name: measurement - storage root stalk length
+namespace: SweetpotatoMethod
+def: "Measure storage root stalk and rate it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0000460
+name: visual estimation - storage root size variability
+namespace: SweetpotatoMethod
+def: "Observe the size variability of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000461
+name: visual estimation - keeping quality method
+namespace: SweetpotatoMethod
+def: "Observe the keeping quality of stored storage roots and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000462
+name: estimation - boiled storage root consistency method
+namespace: SweetpotatoMethod
+def: "Taste boiled storage root consistency and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000463
+name: visual estimation - boiled storage root undesirable color method
+namespace: SweetpotatoMethod
+def: "Observe the boiled storage root undesirable color and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000464
+name: visual estimation - reaction of the plant to drought
+namespace: SweetpotatoMethod
+def: "Observe the reaction to drought and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000465
+name: visual estimation - reaction of the plant to flooding
+namespace: SweetpotatoMethod
+def: "Observe the reaction to flooding and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000466
+name: visual estimation - reaction of the plant to heat
+namespace: SweetpotatoMethod
+def: "Observe the reaction to heat and rate it. The reaction is estimated by observing the appearance of plants in response to a hot season with night temperatures of more than 22°C" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000467
+name: visual estimation - reaction of the plant to salinity
+namespace: SweetpotatoMethod
+def: "Observe the reaction to salinity and rate it. The reaction is estimated by observing the appearance of plants in response to soil with salinity levels of more 8 mm/cm" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000468
+name: visual estimation - reaction of the plant to shade
+namespace: SweetpotatoMethod
+def: "Observe the reaction to shade and rate it. The reaction is estimated by observing the appearance of plants in response to shade" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000469
+name: visual estimation - reaction of the plant to soil
+namespace: SweetpotatoMethod
+def: "Observe the reaction to pH soil and rate it. The reaction is estimated by observing the appearance of plants in response to acid and heavy soils with pH below 5.0" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000470
+name: visual estimation - reaction of the plant to high soil temperature
+namespace: SweetpotatoMethod
+def: "Observe the reaction to high soil temperature and rate it. The reaction is estimated by observing the appearance of plants during a hoy season with day temperatures with peaks of more than 40°C" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000471
+name: visual estimation - reaction of the plant to west indian sweet potato weevil
+namespace: SweetpotatoMethod
+def: "Observe the reaction to West Indian sweet potato weevil and rate" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000472
+name: visual estimation - reaction of the plant to striped sweet potato weevil
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Striped sweet potato weevil and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000473
+name: visual estimation - reaction of the plant to sweet potato wire worms
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato wire worms and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000474
+name: visual estimation - reaction of the plant to wire worms
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Wire worms and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000475
+name: visual estimation - reaction of the plant to sweet potato flea beetles
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato flea beetles and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000476
+name: visual estimation - reaction of the plant to flea beetles
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Flea beetles and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000477
+name: visual estimation - reaction of the plant to sweet potato leaf beetles
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato leaf beetles and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000478
+name: visual estimation - reaction of the plant to beetles
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Beetles or rootworms and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000479
+name: visual estimation - reaction to grubworm
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Grubworm and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000480
+name: visual estimation - reaction to hornworm
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Hornworm and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000481
+name: visual estimation - reaction of the plant to aphids
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Aphids and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000482
+name: visual estimation - reaction of the plant to sweet potato whitefly
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato whitefly and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000483
+name: visual estimation - reaction of the plant to sweet potato moth
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato moth and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000484
+name: visual estimation - reaction of the plant to moth
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Moth and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000485
+name: visual estimation - reaction of the plant to sweet potato stem borer
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato stem borer and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000486
+name: visual estimation - response of the plant to other insects
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other insects and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000487
+name: visual estimation - reaction of the plant to reniform nematode
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Reniform nematode and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000488
+name: visual estimation - reaction of the plant to sting nematode
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sting nematode and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000489
+name: visual estimation - reaction of the plant to brown ring rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Brown ring rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000490
+name: visual estimation - reaction of the plant to root lesion nematode
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Root lesion nematode and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000491
+name: visual estimation - reaction of the plant to other nematodes
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other nematodes and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000492
+name: visual estimation - reaction of the plant to wilt rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Wilt rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000493
+name: visual estimation - reaction of the plant to fusarium surface rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Fusarium surface rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000494
+name: visual estimation - reaction of the plant to fusarium root rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Fusarium root rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000495
+name: visual estimation - reaction of the plant to sclerotial blight and circular spot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sclerotial blight and circular spot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000496
+name: visual estimation - reaction of the plant to black rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Black rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000497
+name: visual estimation - reaction of the plant to scurf
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Scurf and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000498
+name: visual estimation - reaction of the plant to soft rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Soft rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000499
+name: visual estimation - reaction of the plant to java black rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Java black rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000500
+name: visual estimation - reaction of the plant to diaporthe dry rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Diaporthe dry rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000501
+name: visual estimation - reaction of the plant to scab
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Scab and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000502
+name: visual estimation - reaction of the plant to leaf spot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Leaf spot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000503
+name: visual estimation - reaction of the plant to white rust
+namespace: SweetpotatoMethod
+def: "Observe the reaction to White rust and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000504
+name: visual estimation - reaction of the plant to foot rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Foot rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000505
+name: visual estimation - reaction of the plant to charcoal rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Charcoal rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000506
+name: visual estimation - reaction of the plant to other fungi
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other fungi and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000507
+name: visual estimation - reaction of the plant to pox or soil rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Pox or soil rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000508
+name: visual estimation - reaction of the plant to bacterial stem and root rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Bacterial stem and root rot and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000509
+name: visual estimation - reaction of the plant to bacterial wilt
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Bacterial wilt and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000510
+name: visual estimation - reaction of the plant to other bacteria
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other bacteria and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000511
+name: visual estimation - reaction of the plant to sweet potato feathery mottle virus (spmv)
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato feathery mottle virus (SPMV) and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000512
+name: visual estimation - reaction of the plant to sweet potato mild mottle virus (spmmv)
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato mild mottle virus (SPMMV) and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000513
+name: visual estimation - reaction of the plant to sweet potato vein mottle virus (spvmv)
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato vein mottle virus (SPVMV) and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000514
+name: visual estimation - reaction of the plant to sweet potato virus disease complex (spvd complex)
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Sweet potato virus disease complex (SPVD complex) and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000515
+name: visual estimation - reaction of the plant to other virus
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other virus and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000516
+name: visual estimation - reaction of the plant to witches broom
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Witches broom and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000517
+name: visual estimation - reaction of the plant to other mycoplasma
+namespace: SweetpotatoMethod
+def: "Observe the reaction to Other mycoplasma and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000526
+name: visual estimation - storage root primary shape
+namespace: SweetpotatoMethod
+def: "Observe the primary shape of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000527
+name: visual estimation - storage root secondary shape
+namespace: SweetpotatoMethod
+def: "Observe the secondary shape of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000528
+name: visual estimation - storage root shape uniformity
+namespace: SweetpotatoMethod
+def: "Observe the shape uniformity of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000530
+name: visual estimation - storage root attachment ability
+namespace: SweetpotatoMethod
+def: "Observe the attachment ability of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000531
+name: computation - length to diameter ratio of storage roots method
+namespace: SweetpotatoMethod
+def: "Compute the ratio of the length and diameter of the storage roots using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000532
+name: visual estimation - storage root skin color method ncsu
+namespace: SweetpotatoMethod
+def: "Observe the predominant color of the storage root skin and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000533
+name: visual estimation - storage root skin texture
+namespace: SweetpotatoMethod
+def: "Observe the texture of the storage root skin and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000534
+name: visual estimation - storage root flesh color (carotenoids)
+namespace: SweetpotatoMethod
+def: "Observe the flesh color (carotenoids) of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000535
+name: visual estimation - storage root flesh color (anthocyanins)
+namespace: SweetpotatoMethod
+def: "Observe the flesh color (anthocyanins) of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000536
+name: visual estimation - storage root adventitious buds depth
+namespace: SweetpotatoMethod
+def: "Observe the depth of the adventitious buds in the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000537
+name: visual estimation - lenticel number
+namespace: SweetpotatoMethod
+def: "Observe the number of lenticels and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000538
+name: visual estimation - reaction to streptomyces soil rot
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Streptomyces Soil Rot and rate it. Observe an average or all storage roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000539
+name: visual estimation - reaction to root knot nematode meloidogyne spp
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Root Knot Nematode Meloidogyne spp and rate it. Observe the appearance of an average or all fibrous roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000540
+name: visual estimation - reaction to root knot nematode meloidogyne incognita
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Root Knot Nematode Meloidogyne incognita and rate it. Observe the degree of necrosis and the number of galls in fibrous roots in 5 to 10 plant" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000541
+name: visual estimation - reaction to fusarium oxysporum
+namespace: SweetpotatoMethod
+def: "Observe the reaction of the storage root to Fusarium oxysporum and rate it. Observe an average or all fibrous roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000542
+name: visual estimation - storage root defects
+namespace: SweetpotatoMethod
+def: "Observation of an average or all storage roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000543
+name: estimation - relative storage root yield method
+namespace: SweetpotatoMethod
+def: "Observe the relative storage root yield and rate it. Observe an average or all storage roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000544
+name: computation - relative check of storage root yield method
+namespace: SweetpotatoMethod
+def: "Compute the storage root yield relative to check using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0000546
+name: estimation - growing season method
+namespace: SweetpotatoMethod
+def: "Observe the growing season and rate it. Observe an average or all storage roots within a single plant or plot" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000554
+name: counting - nodes number per vine
+namespace: SweetpotatoMethod
+def: "Count node number per vine and record it" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0000555
+name: counting - leaf number per plant
+namespace: SweetpotatoMethod
+def: "Count leaf number per plant and record it" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0000557
+name: visual estimation - millipede damage
+namespace: SweetpotatoMethod
+def: "Observe the Millipede damage and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000558
+name: visual estimation - alcidodes sp. damage
+namespace: SweetpotatoMethod
+def: "Observe the Alcidodes sp. damage in the storage root and rate it. Observe the damage caused by Alcidodes sp, it causes crown enlargement/galling or death by girdling" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000559
+name: visual estimation - soil insect damage
+namespace: SweetpotatoMethod
+def: "Observe the Soil insect damage and rate it Overall assessment of soil insect damage based on inspection of the harvested roots" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0000560
+name: RtSDef 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000561
+name: RtsCthi 5 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000562
+name: FrHab 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000564
+name: FrShL 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000565
+name: FrSepEql 2 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000566
+name: FrSepNVn
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000567
+name: FrSepShp 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000568
+name: FrSepApx 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000569
+name: FrSepPub 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000570
+name: FrSepCol 7 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000571
+name: FrStgCol 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000572
+name: FrStyCol 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000573
+name: FrStgExt 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000574
+name: FrSdCp 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000575
+name: RtFrm 4 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000576
+name: RtStk 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000578
+name: RtSzV 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000579
+name: RtKQl 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000580
+name: RtBlCu 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000581
+name: RtBlCd 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000582
+name: RnDrt 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000583
+name: RnFld 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000584
+name: RnHeat 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000585
+name: RnSlt 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000586
+name: RnShd 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000587
+name: RnSph 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000588
+name: RnSTp 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000589
+name: RnWISPW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000590
+name: RnSSPW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000591
+name: RnSPWW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000592
+name: RnWW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000593
+name: RnSPFB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000594
+name: RnFB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000595
+name: RnSPLB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000596
+name: RnBTL 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000597
+name: RnGrbW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000598
+name: RnHrnw 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000599
+name: RnAph 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000600
 name: Overall storage root disease symptoms estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall storage root disease symptoms evaluation. 1=Very poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = No disease" []
+def: "The overall storage root disease symptoms estimating 1-9" []
 synonym: "DISEASE" EXACT []
 synonym: "RtDSm_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000815 ! pltcov 4 pt. scale
-created_by: C. Yencho
-creation_date: 2016-12-01T04:02:09Z
+relationship: variable_of CO_331:0000815 ! RtDSm 5 pt. scale
+relationship: variable_of CO_331:0002024 ! vistual estimation - overall storage root disease symptoms
+relationship: variable_of CO_331:0002056 ! overall disease symptoms of the storage root
 
 [Term]
 id: CO_331:0000601
-name: weight of total US no. 1 storage roots
+name: weight of total storage roots
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects." []
+def: "The weight of total US no. 1 storage roots" []
 synonym: "RtUS1W" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000602
 name: weight of canner storage roots
 namespace: SweetpotatoTrait
-def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length." []
+def: "The weight of canner storage roots" []
 synonym: "RtCanW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000603
 name: weight of jumbo storage roots
 namespace: SweetpotatoTrait
-def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality." []
+def: "The roots that exceed the diameter, length and weight requirements of US. No 1 and canner storage roots, but are of marketable quality" []
 synonym: "RtJumW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000604
 name: weight of cull storage roots
 namespace: SweetpotatoTrait
-def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades" []
+def: "The roots must be 1 or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades" []
 synonym: "RtCulW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000605
-name: weight of 90 count US no. 1 storage roots
+name: weight of 90 count us no. 1 storage roots
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box." []
 synonym: "Rt90ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000606
-name: weight of 55 count US no. 1 storage roots
+name: weight of 55 count us no. 1 storage roots
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box" []
 synonym: "Rt55ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000607
-name: weight of 40 count US no. 1 storage roots
+name: weight of 40 count us no. 1 storage roots
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box" []
 synonym: "Rt40ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000608
-name: weight of 32 count US no. 1 storage roots
+name: weight of 32 count us no. 1 storage roots
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box" []
 synonym: "Rt32ctW" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
-created_by: C. Yencho
 
 [Term]
 id: CO_331:0000609
-name: weight of total US no. 1 storage roots measuring kg per plot
+name: Weight of total US no. 1 storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects. Measured in kilograms per plot." []
+def: "The weight of total US no. 1 storage roots" []
 synonym: "RtUS1W_Ms_kgplot" EXACT []
 synonym: "US1" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000601 ! weight of total US no. 1 storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000601 ! weight of total storage roots
+relationship: variable_of CO_331:0000892 ! measurement - weight of total us no. 1 storage roots
 relationship: variable_of CO_331:0000893 ! kg/plot
 
 [Term]
 id: CO_331:0000610
-name: weight of canner storage roots measuring kg per plot
+name: Weight of canner storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 1\" to 2\" diameter, 2\" to 7\" in length. Measured in kilograms per plot." []
+def: "The weight of canner storage roots measuring kg per plot" []
 synonym: "CAN" EXACT []
 synonym: "RtCanW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000602 ! weight of canner storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002019 ! measurement - weight of canner storage roots
 
 [Term]
 id: CO_331:0000611
-name: weight of jumbo storage roots measuring kg per plot
+name: Weight of jumbo storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots that exceed the diameter, length and weight requirements of the above two grades, but are of marketable quality. Measured in kilograms per plot." []
+def: "The roots that exceed the diameter, length and weight requirements of US. No 1 and canner storage roots, but are of marketable quality" []
 synonym: "JUM" EXACT []
 synonym: "RtJumW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000603 ! weight of jumbo storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002021 ! measurement - weight of jumbo storage roots
 
 [Term]
 id: CO_331:0000612
-name: weight of cull storage roots measuring kg per plot
+name: Weight of cull storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots must be 1\" or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades. Measured in kilograms per plot." []
+def: "The roots must be 1 or larger in diameter and so misshapen or unattractive that they can not fit as marketable roots in the no. 1, Canner, or Jumbo grades" []
 synonym: "CUL" EXACT []
 synonym: "RtCulW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000604 ! weight of cull storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002020 ! measurement - weight of cull storage roots
 
 [Term]
 id: CO_331:0000613
-name: weight of 90 count US no. 1 storage roots measuring kg per plot
+name: Weight of 90 count US no. 1 storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box. Measured in kilograms per plot." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 5.0 - 9.4 oz. Should take roughly 90 to fill a 40lb box." []
 synonym: "90CT" EXACT []
 synonym: "Rt90ctW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000605 ! weight of 90 count US no. 1 storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000605 ! weight of 90 count us no. 1 storage roots
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002018 ! measurement - weight of 90 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0000614
-name: weight of 55 count US no. 1 storage roots measuring kg per plot
+name: Weight of 55 count US no. 1 storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box. Measured in kilograms per plot." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 9.5 - 14 oz. Should take roughly 55 to fill a 40lb box" []
 synonym: "55CT" EXACT []
 synonym: "Rt55ctW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000606 ! weight of 55 count US no. 1 storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000606 ! weight of 55 count us no. 1 storage roots
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002017 ! measurement - weight of 55 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0000615
-name: weight of 40 count US no. 1 storage roots measuring kg per plot
+name: Weight of 40 count US no. 1 storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box. Measured in kilograms per plot." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 14.1 - 18 oz. Should take roughly 40 to fill a 40lb box" []
 synonym: "40CT" EXACT []
 synonym: "Rt40ctW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000607 ! weight of 40 count US no. 1 storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000607 ! weight of 40 count us no. 1 storage roots
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002016 ! measurement - weight of 40 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0000616
-name: weight of 32 count US no. 1 storage roots measuring kg per plot
+name: Weight of 32 count US no. 1 storage roots measuring kg per plot
 namespace: SweetpotatoTrait
-def: "Roots 2\" to 3 1/2\" diameter, length of 3\" to 9\", must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box. Measured in kilograms per plot." []
+def: "The roots 2 to 3 1/2 diameter, length of 3 to 9, must be well shaped and free of defects that weigh between 18.1 - 22 oz. Should take roughly 32 to fill a 40lb box" []
 synonym: "32CT" EXACT []
 synonym: "Rt32ctW_Ms_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000608 ! weight of 32 count US no. 1 storage roots
-relationship: variable_of CO_331:0000892 ! measurements of root mass
+relationship: variable_of CO_331:0000608 ! weight of 32 count us no. 1 storage roots
 relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002015 ! measurement - weight of 32 count us no. 1 storage roots
+
+[Term]
+id: CO_331:0000617
+name: RnJBR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000618
+name: RnDDR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000619
+name: RnScb 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000620
+name: RnLS 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000622
+name: RnFR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000623
+name: RnCR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000624
+name: RnOF 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000625
+name: RnPSR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000626
+name: RnBSRt 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000627
+name: RnBW 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000628
+name: RnOB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000629
+name: RnSPMV 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000630
+name: RnSPMMV 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000631
+name: RnSPVMV 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000632
+name: RnSPVD 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000633
+name: RnOV 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000634
+name: RnWB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000635
+name: RnOM 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000644
+name: RtShpP 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000645
+name: RtShpS 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000646
+name: RtShpU 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000648
+name: RtAtt 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000649
+name: RtLDR
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000650
+name: RtSknCol 10 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000651
+name: RtSknTxt 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000652
+name: RtFlsColC 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000653
+name: RtFlsColA 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000654
+name: RtAdvB 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000655
+name: RtLtcl 9 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000656
+name: RnPSR 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000657
+name: RnMgRKN 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000658
+name: RnMgIRKN 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000659
+name: RnFR 6 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000660
+name: RtSPDef 14 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000661
+name: RtYldR
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000662
+name: RtYldChk
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000663
+name: RtApr 8 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000664
+name: PtMtSs
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000665
+name: mg/g
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000672
+name: VnNds
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000673
+name: PtLvs
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0000675
+name: RtMillDam 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000676
+name: RtAlcDam 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0000677
+name: RtSInsDam 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
 
 [Term]
 id: CO_331:0000678
-name: Plants planted counting number per plot
+name: Number of plants planted per NET plot
 namespace: SweetpotatoTrait
-def: "Number of plants planted" []
+def: "Evaluation of the number of plants planted per NET plot" []
 synonym: "NOPS" EXACT []
 synonym: "PltPld_Ct_plplot" EXACT []
 is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000190 ! counting - number of plants planted method
 relationship: variable_of CO_331:0000303 ! number of plants planted
 relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000872 ! recording planting materials
 
 [Term]
 id: CO_331:0000679
-name: Plants harvested counting number per plot
+name: Number of plants harvested per NET plot
 namespace: SweetpotatoTrait
-def: "Number of plants harvested" []
+def: "Evaluation of the number of plants harvested per NET plot" []
 synonym: "NOPH" EXACT []
 synonym: "PtHrv_Ct_plplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000304 ! number of plants harvested
+relationship: variable_of CO_331:0000305 ! counting - number of plants harvested method
 relationship: variable_of CO_331:0000871 ! plants/plot
-relationship: variable_of CO_331:0000885 ! evaluation of plants
 
 [Term]
 id: CO_331:0000680
-name: Storage root marketable yield weight computation tons per ha
+name: Average commercial storage root weight computation kg
 namespace: SweetpotatoTrait
-def: "Average commercial root weight evaluated in the harvest" []
+def: "The average commercial weight of storage roots in kg" []
 synonym: "ACRW" EXACT []
-synonym: "RtACRW_Cp_g" EXACT []
+synonym: "RtACRW_Cp_kg" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000308 ! average commercial root weight
-relationship: variable_of CO_331:0000896 ! estimated marketable yield per hectare - method
-relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0000308 ! average commercial storage root weight
+relationship: variable_of CO_331:0000314 ! computation - average commercial weight of storage roots method
+relationship: variable_of CO_331:0000893 ! kg/plot
 
 [Term]
 id: CO_331:0000681
-name: Storage root total yield computation tons per ha
+name: Storage roots yield in kg per plant harvested
 namespace: SweetpotatoTrait
-def: "Yield of total roots calculated after harvest" []
-synonym: "RtYPP_Cp_kpl" EXACT []
+def: "The yield of storage roots in kg per plant harvested" []
+synonym: "RtYPPh_Cp_kgplant" EXACT []
 synonym: "YPP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000309 ! yield of total roots 2
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000898 ! estimated yield of total roots per hectare - method
+relationship: variable_of CO_331:0000309 ! storage roots yield
+relationship: variable_of CO_331:0000315 ! computation - yield of storage roots per plant harvested method
+relationship: variable_of CO_331:0000321 ! kg/plant
 
 [Term]
 id: CO_331:0000682
-name: Storage root marketable yield fraction computation percent
+name: Percentage of commercial storage root
 namespace: SweetpotatoTrait
-def: "Percentage of marketable roots after harvest" []
+def: "The percentage of commercial storage roots after harvest" []
 synonym: "CI" EXACT []
-synonym: "RtCI_Cp_Pct" EXACT []
+synonym: "RtCI_Cp_pct" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000310 ! percentage of marketable roots
-relationship: variable_of CO_331:0000899 ! percentage of marketable - method
+relationship: variable_of CO_331:0000310 ! proportion of commercial storage roots
+relationship: variable_of CO_331:0000316 ! computation - commercial storage roots proportion method
 relationship: variable_of CO_331:0000900 ! %
 
 [Term]
 id: CO_331:0000683
-name: Biomass yield weight computation tons per ha
+name: Biomass yield in kg per plot
 namespace: SweetpotatoTrait
-def: "Biomass yield" []
+def: "The yield of the biomass in kg per plot" []
 synonym: "BIOM" EXACT []
-synonym: "BioYld_Cp" EXACT []
+synonym: "BioYld_Cp_kgplot" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000311 ! biomass yield
-relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
+relationship: variable_of CO_331:0000317 ! computation - biomass yield method in kg
+relationship: variable_of CO_331:0000893 ! kg/plot
 
 [Term]
 id: CO_331:0000684
-name: Foliage total yield computation tons per hectare
+name: Total foliage yield in tons per ha
 namespace: SweetpotatoTrait
-def: "Foliage total yield" []
+def: "The yield of the total vine or foliage in tons per ha" []
 synonym: "FYTHA" EXACT []
 synonym: "VnFolYld_Cp_tha" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000312 ! foliage total yield
+relationship: variable_of CO_331:0000312 ! total foliage yield
+relationship: variable_of CO_331:0000318 ! computation - yield of foliage method
 relationship: variable_of CO_331:0000897 ! t/ha
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
 
 [Term]
 id: CO_331:0000685
-name: Content of iron on dry weight basis measuring mg per kg
+name: Content of iron in dry weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
+def: "The iron concentration in dry weight basis of the storage root measuring mg per 100g by ICP" []
 synonym: "FeDW" EXACT []
-synonym: "RtFlsFe_Ms_mgkgDW" EXACT []
+synonym: "RtFlsFe_Ms_ICP_mg100gDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000103 ! iron content
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: variable_of CO_331:0000926 ! mg/kg
+relationship: variable_of CO_331:0000103 ! storage root iron concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002100 ! measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
 
 [Term]
 id: CO_331:0000686
-name: Content of zinc on dry weight basis measuring mg per kg
+name: Content of zinc in dry weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
-synonym: "FeDW" EXACT []
-synonym: "RtFlsZn_Ms_mgkgDW" EXACT []
+def: "The zinc concentration in dry weight basis of the storage root measuring mg per 100g by ICP" []
+synonym: "RtFlsZn_Ms_ICP_mg100gDW" EXACT []
+synonym: "ZnDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000106 ! zinc content
-relationship: variable_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: variable_of CO_331:0000926 ! mg/kg
+relationship: variable_of CO_331:0000106 ! storage root zinc concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002142 ! measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
 
 [Term]
 id: CO_331:0000687
-name: Content of calcium on dry weight basis measuring mg per kg
+name: Content of calcium in dry weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of iron on dry weight basis of the root" []
+def: "The calcium concentration in dry weight basis of the storage root measuring mg per 100g by ICP" []
 synonym: "CaDW" EXACT []
-synonym: "RtFlsCa_Ms_mgkgDW" EXACT []
+synonym: "RtFlsCa_Ms_ICP_mg100gDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000281 ! calcium content
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000928 ! content of calcium in dry weight basis - method
+relationship: variable_of CO_331:0000281 ! storage root calcium concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002083 ! measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
 
 [Term]
 id: CO_331:0000688
-name: Content of magnesium on dry weight basis measuring mg per kg
+name: Content of magnesium in dry weight basis measuring mg per 100g by ICP
 namespace: SweetpotatoTrait
-def: "Content of magnesium on dry weight basis of the root" []
+def: "The magnesium content in dry weight basis of the storage root measuring mg per 100g by ICP" []
 synonym: "MgDW" EXACT []
-synonym: "RtFlsMg_Ms_mgkgDW" EXACT []
+synonym: "RtFlsMg_Ms_ICP_mg100gDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000285 ! magnesium content
-relationship: variable_of CO_331:0000926 ! mg/kg
-relationship: variable_of CO_331:0000929 ! content of magnesium in dry weight basis - method
+relationship: variable_of CO_331:0000285 ! storage root magnesium concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002125 ! measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
 
 [Term]
 id: CO_331:0000689
 name: Color of boiled roots estimating 0-3
 namespace: SweetpotatoTrait
-def: "Color of boiled roots. O = Orange, IO = Intermediate orange, DO = Deep orange" []
+def: "Flesh color of boiled storage roots estimating 0-3" []
 synonym: "COLBR" EXACT []
-synonym: "RtCb_Et_0to3" EXACT []
+synonym: "RtCb_Et_1to3" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000133 ! color of boiled roots
-relationship: variable_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
-relationship: variable_of CO_331:0000942 ! rtscb 3 pt. scale
+relationship: variable_of CO_331:0000133 ! flesh color of boiled storage roots
+relationship: variable_of CO_331:0000134 ! visual estimation - flesh color of boiled storage roots method
+relationship: variable_of CO_331:0000135 ! RtCb 3pt scale
 
 [Term]
 id: CO_331:0000690
-name: Storage Root Surface Defects estimating 1-9
+name: Storage root primary defects estimating 1-9 by Huaman
 namespace: SweetpotatoTrait
-def: "Storage Root Surface Defects. 0 = Absent, 1 = Alligator-like skin, 2 = Veins, 3 = Shallow horizontal constrictions, 4 = Deep horizontal constrictions, 5 =Shallow longitudinal grooves, 6 = Deep longitudinal grooves, 7 = Deep constrictions and deep grooves, 8 = Other" []
+def: "Storage root primary defects estimating 1-9 by Huaman" []
 synonym: "RtSDef_Et_1to9" EXACT []
 synonym: "RTSUR" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000326 ! storage root surface defects
-relationship: variable_of CO_331:0000943 ! observation of storage root surface defects
-relationship: variable_of CO_331:0000944 ! rtssdef 9 pt. scale
+relationship: variable_of CO_331:0000423 ! storage root surface primary defects
+relationship: variable_of CO_331:0000442 ! visual estimation - storage root surface defects
+relationship: variable_of CO_331:0000560 ! RtSDef 9 pt. scale
 
 [Term]
 id: CO_331:0000691
-name: Storage Root Cortex Thickness estimating 1-9
+name: Storage root cortex thickness estimating 1-9
 namespace: SweetpotatoTrait
-def: "Storage Root Cortex Thickness. 1 = Very thin (1 mm), 3 = Thin (1-2 mm), 5 = Intermediate (2-3 mm), 7 = Thick (3-4 mm), 9 = Very thick (>4 mm)" []
+def: "Storage root cortex thickness estimating 1-9" []
+synonym: "RCORTEX" EXACT []
 synonym: "RTCOR" EXACT []
 synonym: "RtCThk_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000327 ! storage root cortex thickness
-relationship: variable_of CO_331:0000945 ! observation of storage root cortex thickness
-relationship: variable_of CO_331:0000946 ! rtscthi 5 pt. scale
+relationship: variable_of CO_331:0000443 ! estimation - observation of storage root cortex thickness method
+relationship: variable_of CO_331:0000561 ! RtsCthi 5 pt. Scale
 
 [Term]
 id: CO_331:0000692
 name: Flowering habit estimating 0-7
 namespace: SweetpotatoTrait
-def: "An behavior pattern of the plant to produce flowers. 0 = None, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
+def: "The habit of the flower estimating 0-7" []
 synonym: "FLWHAB" EXACT []
 synonym: "FrHab_Et_0to7" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000328 ! flowering habit
-relationship: variable_of CO_331:0000947 ! observation of number flowers in the inflorescence
-relationship: variable_of CO_331:0000948 ! flrhab 4 pt. scale
+relationship: variable_of CO_331:0000444 ! visual estimation - flowering habit
+relationship: variable_of CO_331:0000562 ! FrHab 4 pt. scale
 
 [Term]
 id: CO_331:0000693
 name: Flower size measuring cm
 namespace: SweetpotatoTrait
-def: "Flower size" []
+def: "The size of the flower measuring cm" []
 synonym: "FLESIZ" EXACT []
 synonym: "FrSiz_Ms_cm" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000329 ! flower size
-relationship: variable_of CO_331:0000949 ! measurement of flower length and width in cm
+relationship: variable_of CO_331:0000445 ! measurement - flower size
 relationship: variable_of CO_331:0000950 ! cm
 
 [Term]
 id: CO_331:0000694
 name: Shape of limb estimating 3-7
 namespace: SweetpotatoTrait
-def: "Shape of limb. 3 = Semi-stellate, 5= Pentagonal, 7 = Rounded" []
+def: "The shape of the flower limb estimating 3-7" []
 synonym: "FLLMB" EXACT []
 synonym: "FrShL_Et_3to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000330 ! shape of limb
-relationship: variable_of CO_331:0000951 ! observation of shape limb in the flowers in the inflorescence
-relationship: variable_of CO_331:0000952 ! flrshl 3 pt. scale
+relationship: variable_of CO_331:0000330 ! flower limb shape
+relationship: variable_of CO_331:0000446 ! visual observation - flower limb shape
+relationship: variable_of CO_331:0000564 ! FrShL 3 pt. scale
 
 [Term]
 id: CO_331:0000695
 name: Equality of sepal length estimating 1-2
 namespace: SweetpotatoTrait
-def: "Equality of sepal length. 1 = Outer two shorter, 2 = Equal" []
+def: "The length equality of the sepal estimating 1-2" []
 synonym: "FrSepEql_Et_1to2" EXACT []
 synonym: "SEPLEQ" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000331 ! equality of sepal length
-relationship: variable_of CO_331:0000953 ! equality of sepal length
-relationship: variable_of CO_331:0000954 ! sepeql 2 pt. scale
+relationship: variable_of CO_331:0000447 ! measurement - sepal length equality
+relationship: variable_of CO_331:0000565 ! FrSepEql 2 pt. scale
 
 [Term]
 id: CO_331:0000696
 name: Sepal veins counting number
 namespace: SweetpotatoTrait
-def: "Number of veins observed in the sepals" []
-synonym: "FrSepNVn_Ct_perSpl" EXACT []
+def: "The number of sepal veins" []
+synonym: "FrSepNVn_Ct_no" EXACT []
 synonym: "SEPVNM" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000332 ! number of sepal veins
-relationship: variable_of CO_331:0000955 ! record the most frequent number in ten typical flowers
-relationship: variable_of CO_331:0000956 ! number
+relationship: variable_of CO_331:0000448 ! observation - sepal vein number
+relationship: variable_of CO_331:0000566 ! FrSepNVn
 
 [Term]
 id: CO_331:0000697
 name: Sepal shape estimating 1-9
 namespace: SweetpotatoTrait
-def: "Sepal shape. 1 = Ovate, 3 = Elliptic, 5 = Obovate, 7 = Oblong, 9 = Lanceolate" []
+def: "The shape of the sepal estimating 1-9" []
 synonym: "FrSepShp_Et_1to9" EXACT []
 synonym: "SEPSHP" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000333 ! sepal shape
-relationship: variable_of CO_331:0000957 ! observation of  sepal shape
-relationship: variable_of CO_331:0000958 ! sepshp 5 pt. scale
+relationship: variable_of CO_331:0000449 ! visual estimation - sepal shape
+relationship: variable_of CO_331:0000567 ! FrSepShp 5 pt. scale
 
 [Term]
 id: CO_331:0000698
 name: Sepal apex estimating 1-7
 namespace: SweetpotatoTrait
-def: "Sepal apex. 1 = Acute, 3 = Obtuse, 5 = Acuminate, 7 = Caudate" []
+def: "The shape of the sepal apex estimating 1-7" []
 synonym: "FrSepApx_Et_1to7" EXACT []
 synonym: "SEPAPX" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000334 ! sepal apex
-relationship: variable_of CO_331:0000959 ! observation of sepal apex
-relationship: variable_of CO_331:0000960 ! sepapx 4 pt. scale
+relationship: variable_of CO_331:0000334 ! sepal apex shape
+relationship: variable_of CO_331:0000450 ! visual estimation - sepal apex shape
+relationship: variable_of CO_331:0000568 ! FrSepApx 4 pt. scale
 
 [Term]
 id: CO_331:0000699
 name: Sepal pubescence estimating 0-7
 namespace: SweetpotatoTrait
-def: "Degree of hairiness registered in the sepals. 0 = Absent, 3 = Sparse, 5 = Moderate, 7 = Heavy" []
+def: "The pubescence of the sepal estimating 0-7" []
 synonym: "FrSepPub_Et_0to7" EXACT []
 synonym: "SEPPUB" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000335 ! sepal pubescence
-relationship: variable_of CO_331:0000961 ! observation of sepal pubescence
-relationship: variable_of CO_331:0000962 ! seppub 4 pt. scale
+relationship: variable_of CO_331:0000451 ! visual estimation - sepal pubescence
+relationship: variable_of CO_331:0000569 ! FrSepPub 4 pt. scale
 
 [Term]
 id: CO_331:0000700
 name: Sepal color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Anthocyanin (purple) pigmentation present in the sepal. 1 = Green, 2 = Green with purple edge, 3 = Green with purple spots, 5 = Green with purple areas, 6 = Sorne sepals green, others purple, 9 = Totally pigrnented - dark purple" []
+def: "The color of the sepal estimating 1-9" []
 synonym: "FrSepCol_Et_3to7" EXACT []
 synonym: "SEPCOL" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000336 ! sepal color
-relationship: variable_of CO_331:0000963 ! observation of sepal color
-relationship: variable_of CO_331:0000964 ! sepcol 7 pt. scale
+relationship: variable_of CO_331:0000452 ! visual estimation - sepal color
+relationship: variable_of CO_331:0000570 ! FrSepCol 7 pt. scale
 
 [Term]
 id: CO_331:0000701
-name: Color of stigma estimating 1-9
+name: Stigma color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Color of stigma. 1 = White, 5 = Pale purple, 9 = Purple" []
+def: "The color of the stigma estimating 1-9" []
 synonym: "FrStgCol_Et_1to9" EXACT []
 synonym: "STGCOL" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000337 ! color of stigma
-relationship: variable_of CO_331:0000965 ! observation of stigma color
-relationship: variable_of CO_331:0000966 ! stgcol 3 pt. scale
+relationship: variable_of CO_331:0000337 ! stigma color
+relationship: variable_of CO_331:0000453 ! visual estimation - stigma color
+relationship: variable_of CO_331:0000571 ! FrStgCol 3 pt. scale
 
 [Term]
 id: CO_331:0000702
-name: Color of style estimating 1-9
+name: Style color estimating 1-9
 namespace: SweetpotatoTrait
-def: "Color of style. 1 = White, 3 = White with purple at the base, 5 = White with purple at the top, 7 = White with purple spots throughout, 9 = Purple" []
+def: "The color of the style estimating 1-9" []
 synonym: "FrStyCol_Et_1to9" EXACT []
 synonym: "STYCOL" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000338 ! color of style
-relationship: variable_of CO_331:0000967 ! observation of style color
-relationship: variable_of CO_331:0000968 ! stycol 5 pt. scale
+relationship: variable_of CO_331:0000338 ! style color
+relationship: variable_of CO_331:0000454 ! visual estimation - style color
+relationship: variable_of CO_331:0000572 ! FrStyCol 5 pt. scale
 
 [Term]
 id: CO_331:0000703
 name: Stigma exertion estimating 1-7
 namespace: SweetpotatoTrait
-def: "The relative position of the stigma as compared to the highest anther.. 1 = Inserted (shorter than longest anther), 3 = Same height as highest anther, 5 = Slighty exerted, 7 = Exerted (longer than longest anther)" []
+def: "The exertion of the stigma estimating 1-7" []
 synonym: "FrStgExt_Et_1to7" EXACT []
 synonym: "STGEXT" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000339 ! stigma exertion
-relationship: variable_of CO_331:0000969 ! observation of stigma exertion
-relationship: variable_of CO_331:0000970 ! stgext 4 pt. scale
+relationship: variable_of CO_331:0000455 ! visual estimation - stigma exertion
+relationship: variable_of CO_331:0000573 ! FrStgExt 4 pt. scale
 
 [Term]
 id: CO_331:0000704
 name: Seed capsule set estimating 0-7
 namespace: SweetpotatoTrait
-def: "Seed capsule set. 0 = None, 1 = Scarce, 3 = Sparse, 5 = Moderate, 7 = Profuse" []
+def: "The capsule set of the seed estimating 0-7" []
 synonym: "FrSdCp_Et_0to7" EXACT []
 synonym: "SEDCAP" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000340 ! seed capsule set
-relationship: variable_of CO_331:0000971 ! observation of seed capsule set
-relationship: variable_of CO_331:0000972 ! sedcap 5 pt. scale
+relationship: variable_of CO_331:0000456 ! visual estimation - seed capsule set
+relationship: variable_of CO_331:0000574 ! FrSdCp 5 pt. scale
 
 [Term]
 id: CO_331:0000705
 name: Storage root formation estimating 1-7
 namespace: SweetpotatoTrait
-def: "Arrangement of the storage roots on the underground stems.. 1 = Closed cluster, 3 = Open cluster, 5 = Dispersed, 7 = Very dispersed" []
+def: "The formation of the storage root estimating 1-7" []
 synonym: "RTFORM" EXACT []
 synonym: "RtFrm_Et_1to7" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000341 ! storage root formation
-relationship: variable_of CO_331:0000973 ! observation of storage root formation
-relationship: variable_of CO_331:0000974 ! strfor 4 pt. scale
+relationship: variable_of CO_331:0000457 ! visual estimation - storage root formation
+relationship: variable_of CO_331:0000575 ! RtFrm 4 pt. scale
+
+[Term]
+id: CO_331:0000706
+name: Storage root stalk estimating 0-9
+namespace: SweetpotatoTrait
+def: "The length of the storage root stalk estimating 0-9" []
+synonym: "RTSTALK" EXACT []
+synonym: "RTSTFM" EXACT []
+synonym: "RtStk_Et_0to9" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000342 ! storage root stalk
+relationship: variable_of CO_331:0000458 ! measurement - storage root stalk length
+relationship: variable_of CO_331:0000576 ! RtStk 6 pt. scale
 
 [Term]
 id: CO_331:0000707
-name: Variability of storage root shape estimating 3-7
+name: Storage root shape estimating 3-7 by Huaman
 namespace: SweetpotatoTrait
-def: "Variability of storage root shape. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
+def: "The shape uniformity of the storage root estimating 3-7 by Huaman" []
+synonym: "RtShpU_Et_3to7_by_Huaman" EXACT []
 synonym: "RTSHPV" EXACT []
-synonym: "RtShV_Et_3to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000343 ! variability of storage root shape
-relationship: variable_of CO_331:0000977 ! observation of variability of storage root shape
-relationship: variable_of CO_331:0000978 ! vrtssh 3 pt. scale
+relationship: variable_of CO_331:0000409 ! storage root shape uniformity
+relationship: variable_of CO_331:0000528 ! visual estimation - storage root shape uniformity
+relationship: variable_of CO_331:0000978 ! RtShpU 3 pt. scale
 
 [Term]
 id: CO_331:0000708
-name: Variability of storage root size estimating 3-7
+name: Storage root size variability estimating 3-7
 namespace: SweetpotatoTrait
-def: "Variability of storage root size. 3 = Uniform, 5 = SlightIy variable, 7 = Moderately variable" []
+def: "The size variability of the storage root estimating 3-7" []
 synonym: "RTSIZV" EXACT []
 synonym: "RtSzV_Et_3to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000344 ! variability of storage root size
-relationship: variable_of CO_331:0000979 ! observation of variability of storage root size
-relationship: variable_of CO_331:0000980 ! vrtssiz 3 pt. scale
+relationship: variable_of CO_331:0000344 ! storage root size variability
+relationship: variable_of CO_331:0000460 ! visual estimation - storage root size variability
+relationship: variable_of CO_331:0000578 ! RtSzV 3 pt. scale
 
 [Term]
 id: CO_331:0000709
-name: Keeping quality of storage roots estimating 3-7
+name: Keeping quality of stored storage roots estimating 3-7
 namespace: SweetpotatoTrait
-def: "Keeping quality of storage roots. 3 = Poor, 5 = Medium, 7 = Good" []
+def: "The keeping quality of stored storage roots estimating 3-7" []
 synonym: "RTKQL" EXACT []
 synonym: "RtKQl_Et_3to7" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000345 ! keeping quality of storage roots
-relationship: variable_of CO_331:0000981 ! observation of keeping quality of storage roots
-relationship: variable_of CO_331:0000982 ! kqtyrts 3 pt. scale
+relationship: variable_of CO_331:0000345 ! stored storage root keeping quality
+relationship: variable_of CO_331:0000461 ! visual estimation - keeping quality method
+relationship: variable_of CO_331:0000579 ! RtKQl 3 pt. scale
 
 [Term]
 id: CO_331:0000710
 name: Consistency of boiled storage root estimating 1-9
 namespace: SweetpotatoTrait
-def: "Consistency of boiled storage root. 1 = Watery, 2 = Extremely soft, 3 = Very soft, 4 = Soft, 5 = Slighty hard, 6 = Moderately hard, 7 = Hard, 8 = Very hard, 9 = Very hard and non-cooked" []
+def: "The consistency of the boiled storage root estimating 1-9" []
 synonym: "RTBCOLD" EXACT []
 synonym: "RtBlCu_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000346 ! consistency of boiled storage root
-relationship: variable_of CO_331:0000983 ! observation of consistency of boiled storage root
-relationship: variable_of CO_331:0000984 ! cbolrts 9 pt. scale
+relationship: variable_of CO_331:0000346 ! boiled storage root consistency
+relationship: variable_of CO_331:0000462 ! estimation - boiled storage root consistency method
+relationship: variable_of CO_331:0000580 ! RtBlCu 9 pt. scale
 
 [Term]
 id: CO_331:0000711
 name: Undesirable color of boiled storage root estimating 0-9
 namespace: SweetpotatoTrait
-def: "Undesirable color of boiled storage root. 0 = None, 1 = Sorne beige, 2 = Much beige, 3 = Slighty green or grey, 4 = Green, 5 = Grey, 6 = Beige and green, 7 = Beige and grey, 8 = Beige and purple, 9 = Purple" []
+def: "The undesirable color of the boiled storage root estimating 0-9" []
 synonym: "RTBCOLU" EXACT []
 synonym: "RtBlCd_Et_0to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000347 ! undesirable color of boiled storage root
-relationship: variable_of CO_331:0000985 ! observation of undesirable color of boiled storage root
-relationship: variable_of CO_331:0000986 ! ucolbrts 10 pt. scale
+relationship: variable_of CO_331:0000347 ! boiled storage root undesirable color
+relationship: variable_of CO_331:0000463 ! visual estimation - boiled storage root undesirable color method
+relationship: variable_of CO_331:0000581 ! RtBlCd 10 pt. scale
 
 [Term]
 id: CO_331:0000712
 name: Reaction to drought estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response to damage by water restriction.. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to drought estimating 1-9" []
 synonym: "DROUGHT" EXACT []
 synonym: "RnDrt_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000348 ! reaction to drought
-relationship: variable_of CO_331:0000987 ! visual estimation of the plant response to  limited water availability
-relationship: variable_of CO_331:0000988 ! rctdro 5 pt. scale
+relationship: variable_of CO_331:0000464 ! visual estimation - reaction of the plant to drought
+relationship: variable_of CO_331:0000582 ! RnDrt 5 pt. scale
 
 [Term]
 id: CO_331:0000713
 name: Reaction to flooding estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of plant to inundation by water of all or part of the plant. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to flooding estimating 1-9" []
 synonym: "FLOOD" EXACT []
 synonym: "RnFld_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000349 ! reaction to flooding
-relationship: variable_of CO_331:0000989 ! visual estimation of the plant response to  flooding (watering saturated soil)
-relationship: variable_of CO_331:0000990 ! rctflo 5 pt. scale
+relationship: variable_of CO_331:0000465 ! visual estimation - reaction of the plant to flooding
+relationship: variable_of CO_331:0000583 ! RnFld 5 pt. scale
 
 [Term]
 id: CO_331:0000714
 name: Reaction to heat estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of a plant or plant part to damage by higher than normal temperatures. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to heat estimating 1-9" []
 synonym: "HEAT" EXACT []
 synonym: "RnHeat_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000350 ! reaction to heat
-relationship: variable_of CO_331:0000991 ! visual estimation of the plant response to  hot season with night temperatures of more than 22°c
-relationship: variable_of CO_331:0000992 ! rctheat 5 pt. scale
+relationship: variable_of CO_331:0000466 ! visual estimation - reaction of the plant to heat
+relationship: variable_of CO_331:0000584 ! RnHeat 5 pt. scale
 
 [Term]
 id: CO_331:0000715
 name: Reaction to salinity estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to salinity estimating 1-9" []
 synonym: "RnSlt_Et_1to9" EXACT []
 synonym: "SALINITY" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000351 ! reaction to salinity
-relationship: variable_of CO_331:0000993 ! visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
-relationship: variable_of CO_331:0000994 ! rctsty 5 pt. scale
+relationship: variable_of CO_331:0000467 ! visual estimation - reaction of the plant to salinity
+relationship: variable_of CO_331:0000585 ! RnSlt 5 pt. scale
 
 [Term]
 id: CO_331:0000716
 name: Reaction to shade estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of plant to damage by shade. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to shade estimating 1-9" []
 synonym: "RnShd_Et_1to9" EXACT []
 synonym: "SHADE" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000352 ! reaction to shade
-relationship: variable_of CO_331:0000995 ! visual estimation of the plant response to  shape
-relationship: variable_of CO_331:0000996 ! rctshd 5 pt. scale
+relationship: variable_of CO_331:0000468 ! visual estimation - reaction of the plant to shade
+relationship: variable_of CO_331:0000586 ! RnShd 5 pt. scale
 
 [Term]
 id: CO_331:0000717
 name: Reaction to soil pH estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of plant to damage by ph soil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to soil pH estimating 1-9" []
 synonym: "RnSph_Et_1to9" EXACT []
 synonym: "SOILPH" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000353 ! reaction to soil
-relationship: variable_of CO_331:0000997 ! visual estimation of the plant response to  acid and heavy ph soil below 5
-relationship: variable_of CO_331:0000998 ! rctsph 5 pt. scale
+relationship: variable_of CO_331:0000353 ! reaction to acidic ph soil
+relationship: variable_of CO_331:0000469 ! visual estimation - reaction of the plant to soil
+relationship: variable_of CO_331:0000587 ! RnSph 5 pt. scale
 
 [Term]
 id: CO_331:0000718
 name: Reaction to high soil temperature estimating 1-9
 namespace: SweetpotatoTrait
-def: "Response of a plant to damage by high concentration salt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to high soil temperature estimating 1-9" []
 synonym: "RnSTp_Et_1to9" EXACT []
 synonym: "SOILTEMP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001000 ! rctstp 5 pt. scale
 relationship: variable_of CO_331:0000354 ! reaction to high soil temperature
-relationship: variable_of CO_331:0000999 ! visual estimation of the plant response to  hight soil temperature (40 °c)
+relationship: variable_of CO_331:0000470 ! visual estimation - reaction of the plant to high soil temperature
+relationship: variable_of CO_331:0000588 ! RnSTp 5 pt. scale
 
 [Term]
 id: CO_331:0000719
 name: Reaction to West Indian sweet potato weevil estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to West Indian sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to West Indian sweet potato weevil estimating 1-9" []
 synonym: "RnWISPW_Et_1to9" EXACT []
 synonym: "WISPWV" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001001 ! visual estimation of the plant response to  west indian sweet potato weevil
-relationship: variable_of CO_331:00001002 ! rcwispw 5 pt. scale
 relationship: variable_of CO_331:0000355 ! reaction to west indian sweet potato weevil
+relationship: variable_of CO_331:0000471 ! visual estimation - reaction of the plant to west indian sweet potato weevil
+relationship: variable_of CO_331:0000589 ! RnWISPW 5 pt. scale
 
 [Term]
 id: CO_331:0000720
 name: Reaction to Striped sweet potato weevil estimating 1-9
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Striped sweet potato weevil. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Striped sweet potato weevil estimating 1-9" []
 synonym: "RnSSPW_Et_1to9" EXACT []
 synonym: "STSPWV" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001003 ! visual estimation of the plant response to  striped sweet potato weevil
-relationship: variable_of CO_331:00001004 ! rcsspw 5 pt. scale
 relationship: variable_of CO_331:0000356 ! reaction to striped sweet potato weevil
+relationship: variable_of CO_331:0000472 ! visual estimation - reaction of the plant to striped sweet potato weevil
+relationship: variable_of CO_331:0000590 ! RnSSPW 5 pt. scale
 
 [Term]
 id: CO_331:0000721
 name: Reaction to Sweet potato wire worms estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato wire worms estimating 1-9" []
 synonym: "RnSPWW_Et_1to9" EXACT []
 synonym: "SPWW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001005 ! visual estimation of the plant response to  sweet potato wire worms
-relationship: variable_of CO_331:00001006 ! rcspww 5 pt. scale
 relationship: variable_of CO_331:0000357 ! reaction to sweet potato wire worms
+relationship: variable_of CO_331:0000473 ! visual estimation - reaction of the plant to sweet potato wire worms
+relationship: variable_of CO_331:0000591 ! RnSPWW 5 pt. scale
 
 [Term]
 id: CO_331:0000722
 name: Reaction to Wire worms estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Wire worms. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Wire worms estimating 1-9" []
 synonym: "RnWW_Et_1to9" EXACT []
 synonym: "WIREWORMS" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001007 ! visual estimation of the plant response to  wire worms
-relationship: variable_of CO_331:00001008 ! rcww 5 pt. scale
 relationship: variable_of CO_331:0000358 ! reaction to wire worms
+relationship: variable_of CO_331:0000474 ! visual estimation - reaction of the plant to wire worms
+relationship: variable_of CO_331:0000592 ! RnWW 5 pt. scale
 
 [Term]
 id: CO_331:0000723
 name: Reaction to Sweet potato flea beetles estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato flea beetles estimating 1-9" []
 synonym: "RnSPFB_Et_1to9" EXACT []
 synonym: "SPFB" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001009 ! visual estimation of the plant response to  sweet potato flea beetles
-relationship: variable_of CO_331:00001010 ! rcspfb 5 pt. scale
 relationship: variable_of CO_331:0000359 ! reaction to sweet potato flea beetles
+relationship: variable_of CO_331:0000475 ! visual estimation - reaction of the plant to sweet potato flea beetles
+relationship: variable_of CO_331:0000593 ! RnSPFB 5 pt. scale
 
 [Term]
 id: CO_331:0000724
 name: Reaction to flea beetles estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to flea beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to flea beetles estimating 1-9" []
 synonym: "FLEABEETLE" EXACT []
 synonym: "RnFB_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001011 ! visual estimation of the plant response to  flea beetles
-relationship: variable_of CO_331:00001012 ! rcfb 5 pt. scale
 relationship: variable_of CO_331:0000360 ! reaction to flea beetles
+relationship: variable_of CO_331:0000476 ! visual estimation - reaction of the plant to flea beetles
+relationship: variable_of CO_331:0000594 ! RnFB 5 pt. scale
 
 [Term]
 id: CO_331:0000725
 name: Reaction to Sweet potato leaf beetles estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato leaf beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato leaf beetles estimating 1-9" []
 synonym: "RnSPLB_Et_1to9" EXACT []
 synonym: "SPFB" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001013 ! visual estimation of the plant response to  sweet potato leaf beetles
-relationship: variable_of CO_331:00001014 ! rcsplb 5 pt. scale
 relationship: variable_of CO_331:0000361 ! reaction to sweet potato leaf beetles
+relationship: variable_of CO_331:0000477 ! visual estimation - reaction of the plant to sweet potato leaf beetles
+relationship: variable_of CO_331:0000595 ! RnSPLB 5 pt. scale
 
 [Term]
 id: CO_331:0000726
 name: Reaction to Beetles estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Beetles. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Beetles estimating 1-9" []
 synonym: "BEETLES" EXACT []
 synonym: "RnBTL_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001015 ! visual estimation of the plant response to  beetles
-relationship: variable_of CO_331:00001016 ! rcbtl 5 pt. scale
 relationship: variable_of CO_331:0000362 ! reaction to beetles
+relationship: variable_of CO_331:0000478 ! visual estimation - reaction of the plant to beetles
+relationship: variable_of CO_331:0000596 ! RnBTL 5 pt. scale
 
 [Term]
 id: CO_331:0000727
 name: Reaction to Grubworm estimating 1-9
 namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Grub worm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Grubworm estimating 1-9" []
 synonym: "GRUBW" EXACT []
 synonym: "RnGrbW_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001017 ! visual estimation of the root response to  grub worm
-relationship: variable_of CO_331:00001018 ! rcgrbw 5 pt. scale
 relationship: variable_of CO_331:0000363 ! reaction to grubworm
+relationship: variable_of CO_331:0000479 ! visual estimation - reaction to grubworm
+relationship: variable_of CO_331:0000597 ! RnGrbW 5 pt. scale
 
 [Term]
 id: CO_331:0000728
 name: Reaction to Hornworm estimating 1-9
 namespace: SweetpotatoTrait
-def: "The reaction of the root to damage caused by Hornworm. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Hornworm estimating 1-9" []
 synonym: "HORNW" EXACT []
 synonym: "RnHrnw_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001019 ! visual estimation of the root response to  hornworm
-relationship: variable_of CO_331:00001020 ! rchrnw 5 pt. scale
 relationship: variable_of CO_331:0000364 ! reaction to hornworm
+relationship: variable_of CO_331:0000480 ! visual estimation - reaction to hornworm
+relationship: variable_of CO_331:0000598 ! RnHrnw 5 pt. scale
 
 [Term]
 id: CO_331:0000729
 name: Reaction to Aphids estimating 1-9
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Aphis. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Aphids estimating 1-9" []
 synonym: "APHIDS" EXACT []
 synonym: "RnAph_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001021 ! visual estimation of the plant response to  aphis
-relationship: variable_of CO_331:00001022 ! rcaph 5 pt. scale
 relationship: variable_of CO_331:0000365 ! reaction to aphids
+relationship: variable_of CO_331:0000481 ! visual estimation - reaction of the plant to aphids
+relationship: variable_of CO_331:0000599 ! RnAph 5 pt. scale
 
 [Term]
 id: CO_331:0000730
-name: Reaction to Sweet potato white fly estimating 1-9
+name: Reaction to Sweet potato whitefly estimating 1-9
 namespace: SweetpotatoTrait
-def: "The reaction of the plant or plant part to damage caused by Sweet potato white fly. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato whitefly estimating 1-9" []
 synonym: "RnSPWF_Et_1to9" EXACT []
 synonym: "SPWF" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001023 ! visual estimation of the plant response to  sweet potato white fly
-relationship: variable_of CO_331:00001024 ! rcspwf 5 pt. scale
-relationship: variable_of CO_331:0000366 ! reaction to sweet potato white fly
+relationship: variable_of CO_331:00001024 ! RnSPWF 5 pt. scale
+relationship: variable_of CO_331:0000366 ! reaction to sweet potato whitefly
+relationship: variable_of CO_331:0000482 ! visual estimation - reaction of the plant to sweet potato whitefly
 
 [Term]
 id: CO_331:0000731
 name: Reaction to Sweet potato moth estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato moth estimating 1-9" []
 synonym: "RnSPMth_Et_1to9" EXACT []
 synonym: "SPMOTH" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001025 ! visual estimation of the plant response to  sweet potato moth
-relationship: variable_of CO_331:00001026 ! rcspmth 5 pt. scale
+relationship: variable_of CO_331:00001026 ! RnSPMth 5 pt. scale
 relationship: variable_of CO_331:0000367 ! reaction to sweet potato moth
+relationship: variable_of CO_331:0000483 ! visual estimation - reaction of the plant to sweet potato moth
 
 [Term]
 id: CO_331:0000732
 name: Reaction to Moth estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Moth. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Moth estimating 1-9" []
 synonym: "MOTH" EXACT []
 synonym: "RnMth_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001027 ! visual estimation of the plant response to  moth
-relationship: variable_of CO_331:00001028 ! rcmth 5 pt. scale
+relationship: variable_of CO_331:00001028 ! RnMth 5 pt. scale
 relationship: variable_of CO_331:0000368 ! reaction to moth
+relationship: variable_of CO_331:0000484 ! visual estimation - reaction of the plant to moth
 
 [Term]
 id: CO_331:0000733
 name: Reaction to Sweet potato stem borer estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato stem borer. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato stem borer estimating 1-9" []
 synonym: "RnSPSB_Et_1to9" EXACT []
 synonym: "SPSB" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001029 ! visual estimation of the plant response to  sweet potato stem borer
-relationship: variable_of CO_331:00001030 ! rcspsb 5 pt. scale
+relationship: variable_of CO_331:00001030 ! RnSPSB 5 pt. scale
 relationship: variable_of CO_331:0000369 ! reaction to sweet potato stem borer
+relationship: variable_of CO_331:0000485 ! visual estimation - reaction of the plant to sweet potato stem borer
 
 [Term]
 id: CO_331:0000734
 name: Reaction to Other insects estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Other insects. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Other insects estimating 1-9" []
 synonym: "INSECTS" EXACT []
 synonym: "RnIns_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001031 ! visual estimation of the plant response to  other insects
-relationship: variable_of CO_331:00001032 ! rcins 5 pt. scale
+relationship: variable_of CO_331:00001032 ! RnIns 5 pt. scale
 relationship: variable_of CO_331:0000370 ! reaction to other insects
+relationship: variable_of CO_331:0000486 ! visual estimation - response of the plant to other insects
 
 [Term]
 id: CO_331:0000735
 name: Reaction to Reniform nematode estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Reniform nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Reniform nematode estimating 1-9" []
 synonym: "RENIN" EXACT []
 synonym: "RnRFN_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001033 ! visual estimation of the root response to  reniform nematode
-relationship: variable_of CO_331:00001034 ! rcrfn 5 pt. scale
+relationship: variable_of CO_331:00001034 ! RnRFN 5 pt. scale
 relationship: variable_of CO_331:0000371 ! reaction to reniform nematode
+relationship: variable_of CO_331:0000487 ! visual estimation - reaction of the plant to reniform nematode
 
 [Term]
 id: CO_331:0000736
 name: Reaction to Sting nematode estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sting nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sting nematode estimating 1-9" []
 synonym: "RnStN_Et_1to9" EXACT []
 synonym: "STINGN" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001035 ! visual estimation of the root response to  sting nematode
-relationship: variable_of CO_331:00001036 ! rcstn 5 pt. scale
+relationship: variable_of CO_331:00001036 ! RnStN 5 pt. scale
 relationship: variable_of CO_331:0000372 ! reaction to sting nematode
+relationship: variable_of CO_331:0000488 ! visual estimation - reaction of the plant to sting nematode
 
 [Term]
 id: CO_331:0000737
 name: Reaction to Brown ring rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Brown ring rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Brown ring rot estimating 1-9" []
 synonym: "BRROT" EXACT []
 synonym: "RnBRR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001037 ! visual estimation of the root response to  brown ring rot
-relationship: variable_of CO_331:00001038 ! rcbrr 5 pt. scale
+relationship: variable_of CO_331:00001038 ! RnBRR 5 pt. scale
 relationship: variable_of CO_331:0000373 ! reaction to brown ring rot
+relationship: variable_of CO_331:0000489 ! visual estimation - reaction of the plant to brown ring rot
 
 [Term]
 id: CO_331:0000738
 name: Reaction to Root lesion nematode estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Root lesion nematode. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Root lesion nematode estimating 1-9" []
 synonym: "RnRLN_Et_1to9" EXACT []
 synonym: "ROOTLN" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
-relationship: variable_of CO_331:00001040 ! rcrln 5 pt. scale
+relationship: variable_of CO_331:00001040 ! RnRLN 5 pt. scale
 relationship: variable_of CO_331:0000374 ! reaction to root lesion nematode
+relationship: variable_of CO_331:0000490 ! visual estimation - reaction of the plant to root lesion nematode
 
 [Term]
 id: CO_331:0000739
 name: Reaction to other nematodes estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to other nematodes. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to other nematodes estimating 1-9" []
 synonym: "NEMATODS" EXACT []
 synonym: "RnON_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001039 ! visual estimation of the root response to  nematode
-relationship: variable_of CO_331:00001041 ! rcon 5 pt. scale
+relationship: variable_of CO_331:00001041 ! RnON 5 pt. scale
 relationship: variable_of CO_331:0000375 ! reaction to other nematodes
+relationship: variable_of CO_331:0000491 ! visual estimation - reaction of the plant to other nematodes
 
 [Term]
 id: CO_331:0000740
 name: Reaction to Wilt rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Wilt rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Wilt rot estimating 1-9" []
 synonym: "RnWR_Et_1to9" EXACT []
 synonym: "WILT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001042 ! visual estimation of the root response to  wilt rot
-relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
+relationship: variable_of CO_331:00001043 ! RnWR 5 pt. scale
 relationship: variable_of CO_331:0000376 ! reaction to wilt rot
+relationship: variable_of CO_331:0000492 ! visual estimation - reaction of the plant to wilt rot
 
 [Term]
 id: CO_331:0000741
 name: Reaction to Fusarium surface rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium surface rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Fusarium surface rot estimating 1-9" []
 synonym: "FUSSURF" EXACT []
 synonym: "RnFRS_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001044 ! visual estimation of the root response to  fusarium surface rot
-relationship: variable_of CO_331:00001045 ! rcfrs 5 pt. scale
+relationship: variable_of CO_331:00001045 ! RnFRS 5 pt. scale
 relationship: variable_of CO_331:0000377 ! reaction to fusarium surface rot
+relationship: variable_of CO_331:0000493 ! visual estimation - reaction of the plant to fusarium surface rot
 
 [Term]
 id: CO_331:0000742
 name: Reaction to Fusarium root rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Fusarium root rot estimating 1-9" []
 synonym: "FUSROOT" EXACT []
 synonym: "RnFRR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001046 ! visual estimation of the root response to  fusarium root rot
-relationship: variable_of CO_331:00001047 ! rcfrr 5 pt. scale
+relationship: variable_of CO_331:00001047 ! RnFRR 5 pt. scale
 relationship: variable_of CO_331:0000378 ! reaction to fusarium root rot
+relationship: variable_of CO_331:0000494 ! visual estimation - reaction of the plant to fusarium root rot
 
 [Term]
 id: CO_331:0000743
 name: Reaction to Sclerotial blight and circular spot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sclerotial blight and circular spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sclerotial blight and circular spot estimating 1-9" []
 synonym: "RnSBC_Et_1to9" EXACT []
 synonym: "SCLBLT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001048 ! visual estimation of the root response to  sclerotial blight and circular spot
-relationship: variable_of CO_331:00001049 ! rcsbc 5 pt. scale
+relationship: variable_of CO_331:00001049 ! RnSBC 5 pt. scale
 relationship: variable_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
+relationship: variable_of CO_331:0000495 ! visual estimation - reaction of the plant to sclerotial blight and circular spot
 
 [Term]
 id: CO_331:0000744
 name: Reaction to Black rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Black rot estimating 1-9" []
 synonym: "BLACKROT" EXACT []
 synonym: "RnBR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001050 ! visual estimation of the root response to  black rot
-relationship: variable_of CO_331:00001051 ! rcbr 5 pt. scale
+relationship: variable_of CO_331:00001051 ! RnBR 5 pt. scale
 relationship: variable_of CO_331:0000380 ! reaction to black rot
+relationship: variable_of CO_331:0000496 ! visual estimation - reaction of the plant to black rot
 
 [Term]
 id: CO_331:0000745
 name: Reaction to Scurf estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Scurf. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Scurf estimating 1-9" []
 synonym: "RnScrf_Et_1to9" EXACT []
 synonym: "SCURF" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001052 ! visual estimation of the root response to  scurf
-relationship: variable_of CO_331:00001053 ! rcscrf 5 pt. scale
+relationship: variable_of CO_331:00001053 ! RnScrf 5 pt. scale
 relationship: variable_of CO_331:0000381 ! reaction to scurf
+relationship: variable_of CO_331:0000497 ! visual estimation - reaction of the plant to scurf
 
 [Term]
 id: CO_331:0000746
 name: Reaction to Soft rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Soft rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Soft rot estimating 1-9" []
 synonym: "RnSR_Et_1to9" EXACT []
 synonym: "SOFTROT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001054 ! appearance of roots in response soft rot
-relationship: variable_of CO_331:00001055 ! rcsr 5 pt. scale
+relationship: variable_of CO_331:00001055 ! RnSR 5 pt. scale
 relationship: variable_of CO_331:0000382 ! reaction to soft rot
+relationship: variable_of CO_331:0000498 ! visual estimation - reaction of the plant to soft rot
 
 [Term]
 id: CO_331:0000747
 name: Reaction to Java black rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Java black rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Java black rot estimating 1-9" []
 synonym: "JAVABR" EXACT []
 synonym: "RnJBR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001056 ! appearance of roots in response java black rot
-relationship: variable_of CO_331:00001057 ! rcjbr 5 pt. scale
 relationship: variable_of CO_331:0000383 ! reaction to java black rot
+relationship: variable_of CO_331:0000499 ! visual estimation - reaction of the plant to java black rot
+relationship: variable_of CO_331:0000617 ! RnJBR 5 pt. scale
 
 [Term]
 id: CO_331:0000748
 name: Reaction to Diaporthe dry rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Diaporthe dry rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Diaporthe dry rot estimating 1-9" []
 synonym: "DIAPORTHE" EXACT []
 synonym: "RnDDR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001058 ! appearance of roots in response diaporthe dry rot
-relationship: variable_of CO_331:00001059 ! rcddr 5 pt. scale
 relationship: variable_of CO_331:0000384 ! reaction to diaporthe dry rot
+relationship: variable_of CO_331:0000500 ! visual estimation - reaction of the plant to diaporthe dry rot
+relationship: variable_of CO_331:0000618 ! RnDDR 5 pt. scale
 
 [Term]
 id: CO_331:0000749
 name: Reaction to Scab estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Scab. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Scab estimating 1-9" []
 synonym: "RnScb_Et_1to9" EXACT []
 synonym: "SCAB" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001060 ! visual estimation of the plant response to  scab
-relationship: variable_of CO_331:00001061 ! rcscb 5 pt. scale
 relationship: variable_of CO_331:0000385 ! reaction to scab
+relationship: variable_of CO_331:0000501 ! visual estimation - reaction of the plant to scab
+relationship: variable_of CO_331:0000619 ! RnScb 5 pt. scale
 
 [Term]
 id: CO_331:0000750
 name: Reaction to leaf spot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to leaf spot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to leaf spot estimating 1-9" []
 synonym: "LEAFSPOT" EXACT []
 synonym: "RnLS_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001062 ! visual estimation of the plant response to  leaf spot
-relationship: variable_of CO_331:00001063 ! rcls 5 pt. scale
 relationship: variable_of CO_331:0000386 ! reaction to leaf spot
+relationship: variable_of CO_331:0000502 ! visual estimation - reaction of the plant to leaf spot
+relationship: variable_of CO_331:0000620 ! RnLS 5 pt. scale
 
 [Term]
 id: CO_331:0000751
 name: Reaction to White rust estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to White rust. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to White rust estimating 1-9" []
 synonym: "RnWR_Et_1to9" EXACT []
 synonym: "WHITERUST" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001043 ! rcwr 5 pt. scale
-relationship: variable_of CO_331:00001064 ! visual estimation of the plant response to  white rust
 relationship: variable_of CO_331:0000387 ! reaction to white rust
+relationship: variable_of CO_331:0000503 ! visual estimation - reaction of the plant to white rust
+relationship: variable_of CO_331:0002147 ! RnWR 5 pt. scale
 
 [Term]
 id: CO_331:0000752
 name: Reaction to Foot rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Foot rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Foot rot estimating 1-9" []
 synonym: "FOOTROT" EXACT []
 synonym: "RnFR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001065 ! visual estimation of the plant response to  foot rot
-relationship: variable_of CO_331:00001066 ! rcfr 5 pt. scale
 relationship: variable_of CO_331:0000388 ! reaction to foot rot
+relationship: variable_of CO_331:0000504 ! visual estimation - reaction of the plant to foot rot
+relationship: variable_of CO_331:0000622 ! RnFR 5 pt. scale
 
 [Term]
 id: CO_331:0000753
 name: Reaction to Charcoal rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Charcoal rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Charcoal rot estimating 1-9" []
 synonym: "CHARCROT" EXACT []
 synonym: "RnCR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001067 ! visual estimation of the plant response to  charcoal rot
-relationship: variable_of CO_331:00001068 ! rccr 5 pt. scale
 relationship: variable_of CO_331:0000389 ! reaction to charcoal rot
+relationship: variable_of CO_331:0000505 ! visual estimation - reaction of the plant to charcoal rot
+relationship: variable_of CO_331:0000623 ! RnCR 5 pt. scale
 
 [Term]
 id: CO_331:0000754
 name: Reaction to Other fungi estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Other fungi. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Other fungi estimating 1-9" []
 synonym: "FUNGI" EXACT []
 synonym: "RnOF_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001069 ! visual estimation of the plant response to  other fungi
-relationship: variable_of CO_331:00001070 ! rcof 5 pt. scale
 relationship: variable_of CO_331:0000390 ! reaction to other fungi
+relationship: variable_of CO_331:0000506 ! visual estimation - reaction of the plant to other fungi
+relationship: variable_of CO_331:0000624 ! RnOF 5 pt. scale
 
 [Term]
 id: CO_331:0000755
 name: Reaction to Pox or soil rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Pox or soil rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Pox or soil rot estimating 1-9" []
 synonym: "POXROT" EXACT []
 synonym: "RnPSR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001071 ! visual estimation of the plant response to  pox or soil rot
-relationship: variable_of CO_331:00001072 ! rcpsr 5 pt. scale
 relationship: variable_of CO_331:0000391 ! reaction to pox or soil rot
+relationship: variable_of CO_331:0000507 ! visual estimation - reaction of the plant to pox or soil rot
+relationship: variable_of CO_331:0000625 ! RnPSR 5 pt. scale
 
 [Term]
 id: CO_331:0000756
 name: Reaction to Bacterial stem and root rot estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Bacterial stem and root rot. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Bacterial stem and root rot estimating 1-9" []
 synonym: "RnBSRt_Et_1to9" EXACT []
 synonym: "STEMROT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001073 ! visual estimation of the plant response to  bacterial stem and root rot
-relationship: variable_of CO_331:00001074 ! rcbsrt 5 pt. scale
 relationship: variable_of CO_331:0000392 ! reaction to bacterial stem and root rot
+relationship: variable_of CO_331:0000508 ! visual estimation - reaction of the plant to bacterial stem and root rot
+relationship: variable_of CO_331:0000626 ! RnBSRt 5 pt. scale
 
 [Term]
 id: CO_331:0000757
 name: Reaction to Bacterial wilt estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Bacterial wilt. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Bacterial wilt estimating 1-9" []
 synonym: "BACWILT" EXACT []
 synonym: "RnBW_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001075 ! visual estimation of the plant response to  bacterial wilt
-relationship: variable_of CO_331:00001076 ! rcbw 5 pt. scale
 relationship: variable_of CO_331:0000393 ! reaction to bacterial wilt
+relationship: variable_of CO_331:0000509 ! visual estimation - reaction of the plant to bacterial wilt
+relationship: variable_of CO_331:0000627 ! RnBW 5 pt. scale
 
 [Term]
 id: CO_331:0000758
 name: Reaction to Other bacteria estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Other bacteria. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Other bacteria estimating 1-9" []
 synonym: "BACTERIA" EXACT []
 synonym: "RnOB_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001077 ! visual estimation of the plant response to  other bacteria
-relationship: variable_of CO_331:00001078 ! rcob 5 pt. scale
 relationship: variable_of CO_331:0000394 ! reaction to other bacteria
+relationship: variable_of CO_331:0000510 ! visual estimation - reaction of the plant to other bacteria
+relationship: variable_of CO_331:0000628 ! RnOB 5 pt. scale
 
 [Term]
 id: CO_331:0000759
 name: Reaction to Sweet potato feathery mottle virus (SPMV)
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato feathery mottle virus (SPMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato feathery mottle virus (SPMV)" []
 synonym: "RnSPMV_Et_1to9" EXACT []
 synonym: "SPMV" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001079 ! visual estimation of the plant response to  sweet potato feathery mottle virus
-relationship: variable_of CO_331:00001080 ! rcspmv 5 pt. scale
-relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus (spmv)
+relationship: variable_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus
+relationship: variable_of CO_331:0000511 ! visual estimation - reaction of the plant to sweet potato feathery mottle virus (spmv)
+relationship: variable_of CO_331:0000629 ! RnSPMV 5 pt. scale
 
 [Term]
 id: CO_331:0000760
 name: Reaction to Sweet potato mild mottle virus (SPMMV) estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato mild mottle virus (SPMMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato mild mottle virus (SPMMV) estimating 1-9" []
 synonym: "RnSPMMV_Et_1to9" EXACT []
 synonym: "SPMMV" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001081 ! visual estimation of the plant response to  sweet potato mild mottle virus
-relationship: variable_of CO_331:00001082 ! rcspmmv 5 pt. scale
-relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle virus (spmmv)
+relationship: variable_of CO_331:0000396 ! reaction to sweet potato mild mottle virus
+relationship: variable_of CO_331:0000512 ! visual estimation - reaction of the plant to sweet potato mild mottle virus (spmmv)
+relationship: variable_of CO_331:0000630 ! RnSPMMV 5 pt. scale
 
 [Term]
 id: CO_331:0000761
 name: Reaction to Sweet potato vein mottle virus (SPVMV) estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato vein mottle virus (SPVMV). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato vein mottle virus (SPVMV) estimating 1-9" []
 synonym: "RnSPVMV_Et_1to9" EXACT []
 synonym: "SPVMV" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001083 ! visual estimation of the plant response to  sweet potato vein mottle virus
-relationship: variable_of CO_331:00001084 ! rcspvmv 5 pt. scale
-relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle virus (spvmv)
+relationship: variable_of CO_331:0000397 ! reaction to sweet potato vein mottle virus
+relationship: variable_of CO_331:0000513 ! visual estimation - reaction of the plant to sweet potato vein mottle virus (spvmv)
+relationship: variable_of CO_331:0000631 ! RnSPVMV 5 pt. scale
 
 [Term]
 id: CO_331:0000762
 name: Reaction to Sweet potato virus disease complex (SPVD complex) estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Sweet potato virus disease complex (SPVD complex). 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Sweet potato virus disease complex (SPVD complex) estimating 1-9" []
 synonym: "RnSPVD_Et_1to9" EXACT []
 synonym: "SPVD" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001085 ! visual estimation of the plant response to  sweet potato virus disease complex
-relationship: variable_of CO_331:00001086 ! rcspvd 5 pt. scale
-relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus disease complex (spvd complex)
+relationship: variable_of CO_331:0000398 ! reaction to sweet potato virus disease complex
+relationship: variable_of CO_331:0000514 ! visual estimation - reaction of the plant to sweet potato virus disease complex (spvd complex)
+relationship: variable_of CO_331:0000632 ! RnSPVD 5 pt. scale
 
 [Term]
 id: CO_331:0000763
-name: Reaction to Other virus estimating 1-9
+name: Reaction to other virus estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Other virus. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Other virus estimating 1-9" []
 synonym: "RnOV_Et_1to9" EXACT []
 synonym: "VIRUS" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001087 ! visual estimation of the plant response to  other virus
-relationship: variable_of CO_331:00001088 ! rcov 5 pt. scale
 relationship: variable_of CO_331:0000399 ! reaction to other virus
+relationship: variable_of CO_331:0000515 ! visual estimation - reaction of the plant to other virus
+relationship: variable_of CO_331:0000633 ! RnOV 5 pt. scale
 
 [Term]
 id: CO_331:0000764
 name: Reaction to Witches broom estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Witches broom. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Witches broom estimating 1-9" []
 synonym: "BROOM" EXACT []
 synonym: "RnWB_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001089 ! visual estimation of the plant response to  witches broom
-relationship: variable_of CO_331:00001090 ! rcwb 5 pt. scale
 relationship: variable_of CO_331:0000400 ! reaction to witches broom
+relationship: variable_of CO_331:0000516 ! visual estimation - reaction of the plant to witches broom
+relationship: variable_of CO_331:0000634 ! RnWB 5 pt. scale
 
 [Term]
 id: CO_331:0000765
-name: Reaction to Other mycoplasma estimating 1-9
+name: Reaction to other mycoplasma estimating 1-9
 namespace: SweetpotatoTrait
-def: "Reaction to Other mycoplasma. 1 = Very low, 3 = Low, 5 = Intermediate, 7 = High, 9 = Very High" []
+def: "The reaction to Other mycoplasma estimating 1-9" []
 synonym: "MYCOPLASMA" EXACT []
 synonym: "RnOM_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001091 ! visual estimation of the plant response to  to other mycoplasma
-relationship: variable_of CO_331:00001092 ! rcom 5 pt. scale
 relationship: variable_of CO_331:0000401 ! reaction to other mycoplasma
+relationship: variable_of CO_331:0000517 ! visual estimation - reaction of the plant to other mycoplasma
+relationship: variable_of CO_331:0000635 ! RnOM 5 pt. scale
 
 [Term]
 id: CO_331:0000766
-name: Total sugar content estimating 1-9
+name: Content of total sugars estimating 1-9
 namespace: SweetpotatoTrait
-def: "Total sugar content" []
-synonym: "RtTSgC_Et_1to9" EXACT []
+def: "Total sugar content in raw storage roots estimating 1-9" []
+synonym: "RwRtTSg_Et_1to9" EXACT []
 synonym: "TOTSUG" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001094 ! rttsgc
-relationship: variable_of CO_331:0000402 ! total sugar content
-
-[Term]
-id: CO_331:0000767
-name: Habitus measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of plant" []
-synonym: "FOTHAB" EXACT []
-synonym: "PtHbt_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001095 ! plant picture
-relationship: variable_of CO_331:0000403 ! appearance of plant
-
-[Term]
-id: CO_331:0000768
-name: Flower measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of flower" []
-synonym: "FOTFLW" EXACT []
-synonym: "FrCol_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001096 ! flower picture
-relationship: variable_of CO_331:0000404 ! appearance of flower
-
-[Term]
-id: CO_331:0000769
-name: Root measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of roots" []
-synonym: "FOTROT" EXACT []
-synonym: "RtCol_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001097 ! root picture
-relationship: variable_of CO_331:0000405 ! appearance of roots
-
-[Term]
-id: CO_331:0000770
-name: Seeds measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of seeds" []
-synonym: "FOTSDS" EXACT []
-synonym: "FrSds_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001098 ! seeds picture
-relationship: variable_of CO_331:0000406 ! appearance of seeds
-
-[Term]
-id: CO_331:0000771
-name: Leaf measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of leaves" []
-synonym: "FOTLEA" EXACT []
-synonym: "Lf_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001099 ! leaf picture
-relationship: variable_of CO_331:0000407 ! appearance of leaves
-
-[Term]
-id: CO_331:0000772
-name: Herbarium measuring image
-namespace: SweetpotatoTrait
-def: "Appearance of hearbarium" []
-synonym: "FOTHRB" EXACT []
-synonym: "PtHrb_Ms_img" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001093 ! taking standardized photo
-relationship: variable_of CO_331:00001099 ! leaf picture
-relationship: variable_of CO_331:0000408 ! appearance of hearbarium
+relationship: variable_of CO_331:00001093 ! visual estimation - total sugar content
+relationship: variable_of CO_331:0000402 ! storage root total sugar content
+relationship: variable_of CO_331:0002035 ! RwRtTSg 9pt. Scale
 
 [Term]
 id: CO_331:0000774
-name: Storage Root Shape primary estimating 1-8
+name: Storage root shape primary estimating 1-8 NCSU
 namespace: SweetpotatoTrait
-def: "Storage Root Shape described from longitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
+def: "The shape of the storage root estimating 1-8 NCSU" []
 synonym: "RTSHP1" EXACT []
 synonym: "RtShpP_Et_1to8" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000069 ! storage root shape (primary)
-relationship: variable_of CO_331:00001100 ! observation of most frequennt storage root shape
-relationship: variable_of CO_331:00001101 ! rtshpp 8 pt. scale
+relationship: variable_of CO_331:0000067 ! storage root primary shape
+relationship: variable_of CO_331:0000526 ! visual estimation - storage root primary shape
+relationship: variable_of CO_331:0000644 ! RtShpP 8 pt. scale
 
 [Term]
 id: CO_331:0000775
-name: Storage Root Shape secondary estimating 1-8
+name: Storage root shape secondary estimating 1-8
 namespace: SweetpotatoTrait
-def: "Storage Root Shape described from latitudinal sections made about the middle of freshly harvested storage roots. 1 = Round, 2 = Round elliptic, 3 = Elliptic, 4 = Long elliptic, 5 = Ovoid, 6 = Blocky (Oblong), 7 = Irregular, 8 = Asymmetric (tight hill)" []
+def: "The secondary shape of the storage root estimating 1-8 NCSU" []
 synonym: "RTSHP2" EXACT []
 synonym: "RtShpS_Et_1to8" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001102 ! observation of 2nd most frequent storage root shape
-relationship: variable_of CO_331:00001103 ! rtshps 8 pt. scale
-relationship: variable_of CO_331:0000441 ! storage root shape (secondary)
+relationship: variable_of CO_331:0000441 ! storage root secondary shape
+relationship: variable_of CO_331:0000527 ! visual estimation - storage root secondary shape
+relationship: variable_of CO_331:0000645 ! RtShpS 8 pt. scale
 
 [Term]
 id: CO_331:0000776
-name: Storage Root Shape Uniformity estimating 1-9
+name: Storage root shape uniformity estimating 1-9 by NCSU
 namespace: SweetpotatoTrait
-def: "Storage Root Shape uniformity within a single plant or plot. 1 = Very Poor, 2 = Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
+def: "The shape uniformity of the storage root estimating 1-9 by NCSU" []
 synonym: "RTSHPU" EXACT []
-synonym: "RtShpU_Et_1to9" EXACT []
+synonym: "RtShpU_Et_1to9_NCSU" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001104 ! observation of an average or all storage roots within a single plant or plot (for example: if a single plant or plot presents several storage root shapes, it would be considered very poor shape uniformity and would receive a score of 1
-relationship: variable_of CO_331:00001105 ! rtshpu 9 pt. scale
 relationship: variable_of CO_331:0000409 ! storage root shape uniformity
-
-[Term]
-id: CO_331:0000777
-name: Storage Root Stalk estimating 0-9
-namespace: SweetpotatoTrait
-def: "Length of stalk joining the storage roots to the stems. 0 = Sessile or absent, 1 = Very short (<2 cm), 3 = Short (2-5 cm), 5 = Intermediate (6-8 cm), 7 = Long (9-12 cm), 9 = Very long (>12 cm)" []
-synonym: "RTSTALK" EXACT []
-synonym: "RtStlk_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001107 ! rtstlk 6 pt. scale
-relationship: variable_of CO_331:0000410 ! storage root stalk length
+relationship: variable_of CO_331:0000528 ! visual estimation - storage root shape uniformity
+relationship: variable_of CO_331:0000646 ! RtShpU 5 pt. scale
 
 [Term]
 id: CO_331:0000778
-name: Storage Root Attachement estimating 0-9
+name: Storage root attachement estimating 0-9
 namespace: SweetpotatoTrait
-def: "Ability of storage roots to remain attached to stem after digging and forcible shaking roots off. 1 = Very tight, 3 = Tight, 5 = Moderate, 6.0, 7 = Light, 8.0, 9 = Very Light" []
+def: "The attachment ability of the storage root estimating 0-9" []
 synonym: "RtAtt_Et_1to9" EXACT []
 synonym: "RTATTACH" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001108 ! rtatt 9 pt. scale
-relationship: variable_of CO_331:0000411 ! storage root attachment
+relationship: variable_of CO_331:0000411 ! storage root attachment ability
+relationship: variable_of CO_331:0000530 ! visual estimation - storage root attachment ability
+relationship: variable_of CO_331:0000648 ! RtAtt 8 pt. scale
 
 [Term]
 id: CO_331:0000779
-name: Length to Diameter Ratio computation
+name: Length to diameter ratio computation
 namespace: SweetpotatoTrait
-def: "Ratio of the length of a storage root to its diameter of the average of all storage roots in a single plant or plot" []
+def: "The length to diameter ratio of the storage root" []
 synonym: "LDR" EXACT []
 synonym: "RtLDR_Cp_ratio" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
-relationship: variable_of CO_331:0000412 ! length to diameter ratio of roots
+relationship: variable_of CO_331:0000412 ! length to diameter ratio of storage roots
+relationship: variable_of CO_331:0000531 ! computation - length to diameter ratio of storage roots method
+relationship: variable_of CO_331:0000649 ! RtLDR
 
 [Term]
 id: CO_331:0000780
-name: Skin Color estimating 1-12
+name: Storage root skin predominant color estimating 1-12 NCSU
 namespace: SweetpotatoTrait
-def: "The most representative skin color observed is recorded. 1 = White, 2 = Cream, 3 = Yellow, 4 = Tan, 5 = Orange, 6 = Rose, 7 = Pink, 8 = Red, 9 = Light Purple, 10 = Purple, 11 = Dark Purple, 12 = Brown" []
-synonym: "RtSknCol_Et_1to12" EXACT []
+def: "The predominant or the most representative color of the storage root skin observed is recorded, estimating 1-12, by NCSU" []
+synonym: "RtSknCol_Et_1to12_NCSU" EXACT []
 synonym: "SKINCOLOR" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001110 ! rtskncol 12 pt. scale
-relationship: variable_of CO_331:0000413 ! skin color of roots
+relationship: variable_of CO_331:0000049 ! storage root skin predominant color
+relationship: variable_of CO_331:0000532 ! visual estimation - storage root skin color method ncsu
+relationship: variable_of CO_331:0000650 ! RtSknCol 10 pt. scale
 
 [Term]
 id: CO_331:0000781
-name: Skin Texture estimating 1-9
+name: Skin texture estimating 1-9
 namespace: SweetpotatoTrait
-def: "Storage root skin feel, appearance, or consistency by visual observation and touch. 1 = Very Rough, 2.0, 3 = Moderately Rough, 4.0, 5 = Moderately Smooth, 6.0, 7 = Smooth, 8.0, 9 = Very Smooth" []
+def: "The texture of the storage root skin estimating 1-9" []
 synonym: "RTSKNTEX" EXACT []
 synonym: "RtSknTxt_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001111 ! rtskntxt 9 pt. scale
-relationship: variable_of CO_331:0000414 ! skin texture of roots
+relationship: variable_of CO_331:0000414 ! storage root skin texture
+relationship: variable_of CO_331:0000533 ! visual estimation - storage root skin texture
+relationship: variable_of CO_331:0000651 ! RtSknTxt 9 pt. scale
 
 [Term]
 id: CO_331:0000782
-name: Flesh Color Carotenoids estimating 0-4
+name: Storage root flesh color Carotenoids estimating 0-4
 namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = White, 0.5, 1 = Cream, 2 = Yellow, 2.5 = Yellow with orange, 2.75 = Orange with yellow, 3 = Orange, 3.5 = Dark Orange, 4 = Very Dark Orange" []
+def: "The predominant color of Carotenoids in the storage root flesh estimating 0-4" []
 synonym: "RTFLESH1" EXACT []
 synonym: "RtFlsColC_Et_0to4" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001112 ! rtflscolc 9 pt. scale
-relationship: variable_of CO_331:0000415 ! flesh color (carotenoids)
+relationship: variable_of CO_331:0000415 ! storage root flesh color (carotenoids)
+relationship: variable_of CO_331:0000534 ! visual estimation - storage root flesh color (carotenoids)
+relationship: variable_of CO_331:0000652 ! RtFlsColC 9 pt. scale
 
 [Term]
 id: CO_331:0000783
-name: Flesh Color Anthocyanins estimating 0-4
+name: Storage root flesh color Anthocyanins estimating 0-4
 namespace: SweetpotatoTrait
-def: "Observation of predominant Flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots. 0 = No Anthocyanins, 0.5, 1 = Light Purple, 1.5, 2 = Moderate Purple, 2.5, 3 = Dark Purple, 3.5, 4 = Very Dark Purple" []
+def: "The predominant color of Anthocyanins in the storage root flesh estimating 0-4" []
 synonym: "RTFLESH2" EXACT []
 synonym: "RtFlsColA_Et_0to4" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001113 ! rtflscola 9 pt. scale
-relationship: variable_of CO_331:0000416 ! flesh color (anthocyanins)
+relationship: variable_of CO_331:0000416 ! storage root flesh color (anthocyanins)
+relationship: variable_of CO_331:0000535 ! visual estimation - storage root flesh color (anthocyanins)
+relationship: variable_of CO_331:0000653 ! RtFlsColA 5 pt. scale
 
 [Term]
 id: CO_331:0000784
-name: Adventitious buds estimating 1-9
+name: Adventitious buds depth estimating 1-9
 namespace: SweetpotatoTrait
-def: "Observation of how deep or shallow predominant eyes or adventitious buds are at the storage root skin interface. 1 = Very Deep, 3 = Deep, 5 = Moderate, 7 = Shallow, 9 = Very Shallow" []
-synonym: "EYES" EXACT []
+def: "The depth of adventitious buds of the storage root estimating 1-9" []
+synonym: "BUDS" EXACT []
 synonym: "RtAdvB_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001114 ! rtadvb 5 pt. scale
-relationship: variable_of CO_331:0000417 ! deep of eyes of roots
+relationship: variable_of CO_331:0000417 ! storage root adventitious buds depth
+relationship: variable_of CO_331:0000536 ! visual estimation - storage root adventitious buds depth
+relationship: variable_of CO_331:0000654 ! RtAdvB 5 pt. scale
 
 [Term]
 id: CO_331:0000785
-name: Lenticels estimating 1-9
+name: Lenticels Number of the storage root estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall assessment of visible lenticels at the storage root interface. 1 = Very Prominent, 2.0, 3 = Prominent, 4.0, 5 = Moderate, 6.0, 7 = Few, 8.0, 9 = None" []
+def: "The number of the lenticels of the storage root estimating 1-9" []
 synonym: "LENTS" EXACT []
 synonym: "RtLtcl_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001115 ! ses 9 pt. scale
 relationship: variable_of CO_331:0000418 ! number of lenticels
+relationship: variable_of CO_331:0000537 ! visual estimation - lenticel number
+relationship: variable_of CO_331:0000655 ! RtLtcl 9 pt. scale
 
 [Term]
 id: CO_331:0000786
 name: Streptomyces Soil Rot estimating 0-5
 namespace: SweetpotatoTrait
-def: "Streptomyces ipomoeae symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+def: "Streptomyces Soil Rot estimating 0-5" []
 synonym: "RnPSR_Et_0to5" EXACT []
 synonym: "SSR" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001116 ! observation of an average or all storage roots within a single plant or plot (greenhouse screen and field screen)
-relationship: variable_of CO_331:00001117 ! ses 6 pt. scale
 relationship: variable_of CO_331:0000419 ! reaction to streptomyces soil rot
+relationship: variable_of CO_331:0000538 ! visual estimation - reaction to streptomyces soil rot
+relationship: variable_of CO_331:0000656 ! RnPSR 6 pt. scale
 
 [Term]
 id: CO_331:0000787
-name: Root Knot Nematode  Meloidogyne estimating 0-5
+name: Root Knot Nematode Meloidogyne estimating 0-5
 namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne spp. symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+def: "Root Knot Nematode Meloidogyne estimating 0-5" []
 synonym: "RKN" EXACT []
-synonym: "RnMgRKN_Et_0to5" EXACT []
+synonym: "RnMgRKN_Et_0to5_NCSU" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
-relationship: variable_of CO_331:00001119 ! rcmgrkn  6 pt. scale
 relationship: variable_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
+relationship: variable_of CO_331:0000539 ! visual estimation - reaction to root knot nematode meloidogyne spp
+relationship: variable_of CO_331:0000657 ! RnMgRKN 6 pt. scale
 
 [Term]
 id: CO_331:0000788
-name: Root Knot Nematode  Meloidogyne incognita estimating 0-7
+name: Root Knot Nematode Meloidogyne incognita estimating 0-7
 namespace: SweetpotatoTrait
-def: "Reaction to Root-knot nematode Meloidogyne incognita symptom evaluation. 1= highly resistant (HR), 2= Resistant (1-10%), 3 = Moderate resistant (MR)(11-25%), 4 = Susceptible (S) (26-75%), 5= (HS) Highly susceptible (>76%)" []
-synonym: "RKN, MELOI" EXACT []
-synonym: "RnMgIRKN_Et_0to7" EXACT []
+def: "Root Knot Nematode Meloidogyne incognita estimating 0-7" []
+synonym: " MELOI" EXACT []
+synonym: "RKN" EXACT []
+synonym: "RnMgIRKN_Et_0to7_CIP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001118 ! visual estimation of the roots response to  root-knot nematode
-relationship: variable_of CO_331:00001120 ! rcmigrkn  5 pt. scale
 relationship: variable_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
+relationship: variable_of CO_331:0000540 ! visual estimation - reaction to root knot nematode meloidogyne incognita
+relationship: variable_of CO_331:0000658 ! RnMgIRKN 5 pt. scale
 
 [Term]
 id: CO_331:0000789
 name: Reaction to Fusarium Wilt estimating 0-5
 namespace: SweetpotatoTrait
-def: "Reaction to Fusarium oxysporum batatas symptom evaluation. 0 = Highly Susceptible, 1 = Susceptible, 2 = Moderately Susceptible, 3 =Moderately Resistant, 4 = Resistant, 5 = Highly Resistant" []
+def: "The reaction to Fusarium Wilt estimating 0-5" []
 synonym: "FWILT" EXACT []
 synonym: "RnFR_Et_0to5" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001121 ! visual estimation of the roots response to  fusarium oxysporum
-relationship: variable_of CO_331:00001122 ! rnfr 6 pt. scale
 relationship: variable_of CO_331:0000422 ! reaction to fusarium oxysporum
+relationship: variable_of CO_331:0000541 ! visual estimation - reaction to fusarium oxysporum
+relationship: variable_of CO_331:0000659 ! RnFR 6 pt. scale
 
 [Term]
 id: CO_331:0000790
-name: Storage Root Defects primary estimating 1-18
+name: Storage root primary defects estimating 1-14 by NCSU
 namespace: SweetpotatoTrait
-def: "Type and/or name of primary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
-synonym: "RTDEF1" EXACT []
-synonym: "RtDefP_Et_1to18" EXACT []
+def: "Storage root primary defects estimating 1-14 by NCSU" []
+synonym: "RTDEF" EXACT []
+synonym: "RtDef_Et_1to14" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001123 ! rtdam 14 pt. scale
-relationship: variable_of CO_331:0000423 ! storage root defects (primary)
+relationship: variable_of CO_331:0000423 ! storage root surface primary defects
+relationship: variable_of CO_331:0000542 ! visual estimation - storage root defects
+relationship: variable_of CO_331:0000660 ! RtSPDef 14 pt. scale
 
 [Term]
 id: CO_331:0000791
 name: Relative Storage Root Yield estimating 1-9
 namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield. 1 = Very Poor, 3 = Poor, 5 = Moderate, 7 = Good, 9 = Excellent" []
+def: "The overall visual estimation of storage root yield estimating 1-9" []
 synonym: "RTRYIELD" EXACT []
 synonym: "RtYldR_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001124 ! rtyldr 5 pt. scale
 relationship: variable_of CO_331:0000424 ! relative storage root yield
+relationship: variable_of CO_331:0000543 ! estimation - relative storage root yield method
+relationship: variable_of CO_331:0000661 ! RtYldR
 
 [Term]
 id: CO_331:0000792
 name: Yield as percent of check
 namespace: SweetpotatoTrait
-def: "Overall calculation of relative root yield" []
+def: "The overall computation of relative storage root yield" []
 synonym: "RtYldChk_Cp_pct" EXACT []
 synonym: "RTYLDPCT" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001109 ! scale_of CO_331:00001106
 relationship: variable_of CO_331:0000425 ! storage root yield relative to check
-relationship: variable_of CO_331:0000901 ! Method of CO_331:0000311
+relationship: variable_of CO_331:0000544 ! computation - relative check of storage root yield method
+relationship: variable_of CO_331:0000662 ! RtYldChk
 
 [Term]
 id: CO_331:0000793
-name: Storage Root Appearance estimating 1-9
+name: Storage root appearance estimating 1-9 NCSU
 namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root yield appearance. 1 = Very Poor, 3 = Poor, 4.0, 5 = Moderate, 6.0, 7 = Good, 8.0, 9 = Excellent" []
+def: "The appearance of the storage root estimating 1-9 NCSU" []
 synonym: "RTAPPEAR" EXACT []
-synonym: "RtApr_Et_1to9" EXACT []
+synonym: "RtApr_Et_1to9_NCSU" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:0000426 ! storage root appearance
-relationship: variable_of CO_331:0000920 ! rtapr 9 pt. scale
+relationship: variable_of CO_331:0000199 ! storage root appearance
+relationship: variable_of CO_331:0000663 ! RtApr 8 pt. scale
+relationship: variable_of CO_331:0002146 ! visual estimation - storage root appearance -method ncsu
 
 [Term]
 id: CO_331:0000794
 name: Season maturity estimating 0-4
 namespace: SweetpotatoTrait
-def: "Overall visual assessment of storage root size relative to harvest date and/or total growing season. 0 = Late Season, 1 = Mid to Late Season, 2 = Mid Season, 3 = Early to Mid Season, 4 = Early Season" []
+def: "The overall visual assessment of storage root size relative to harvest date and/or total growing season estimating 0-4" []
 synonym: "PtMtSs_Et_0to4" EXACT []
 synonym: "SEASON" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001125 ! ptmtss 5 pt. scale
 relationship: variable_of CO_331:0000427 ! growing season
+relationship: variable_of CO_331:0000546 ! estimation - growing season method
+relationship: variable_of CO_331:0000664 ! PtMtSs
 
 [Term]
 id: CO_331:0000795
-name: Amylose content measuring  mg per g DW
+name: Content of amylose in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Amylose content in sweetpotato" []
+def: "The content of amylose in dry weight basis in storage roots measuring mg per g" []
 synonym: "AMY" EXACT []
-synonym: "RtFlsAmy_Ms_mgpergDW" EXACT []
+synonym: "RtFlsAmy_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001126 ! amylose - method
-relationship: variable_of CO_331:00001127 ! g/100 g fw
-relationship: variable_of CO_331:0000428 ! amylose content
+relationship: variable_of CO_331:0000428 ! storage root amylose concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002115 ! measurement the amylose content - near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000796
-name: Asparagine content measuring  mg per g DW
+name: Content of asparagine in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "peonidin content of purple flesh sweetpotato" []
+def: "The content of asparagine in dry weight basis in storage roots measuring mg per g" []
 synonym: "ASP" EXACT []
-synonym: "RtFlsAsp_Ms_mgpergDW" EXACT []
+synonym: "RtFlsAsp_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001128 ! asparagine - method
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:0000429 ! asparagine content
+relationship: variable_of CO_331:0000429 ! storage root asparagine concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002117 ! measurement the asparagine content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000797
-name: Cyanidin content measuring  mg per g DW
+name: Content of cyanidin in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Cyanidin content, it is a pigment found in the purple flesh sweetpotato (PFSP)." []
+def: "The content of cyanidin in dry weight basis in storage roots measuring mg per g" []
 synonym: "CYAN" EXACT []
-synonym: "RtFlsCya_Ms_mgpergDW" EXACT []
+synonym: "RtFlsCya_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001130 ! cyanidin - method
-relationship: variable_of CO_331:0000430 ! cyanidin content
+relationship: variable_of CO_331:0000430 ! storage root cyanidin concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002124 ! measurement the cyanidin content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000798
-name: Total Monomeric Anthocyanin content measuring  mg per g DW
+name: Content of total monomeric anthocyanin in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Total Monomeric Anthocyanins content of purple flesh sweetpotato" []
-synonym: "RtFlsAntM_Ms_mgpergDW" EXACT []
+def: "The content of total monomeric anthocyanin in dry weight basis in storage roots measuring mg per g" []
+synonym: "RtFlsAntM_Ms_mggDW" EXACT []
 synonym: "TMA" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001131 ! total monomeric anthocyanins - method
-relationship: variable_of CO_331:0000431 ! total monomeric anthocyanin content
+relationship: variable_of CO_331:0000431 ! storage root total monomeric anthocyanin concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002131 ! measurement the total monomeric anthocyanin content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000799
-name: Peonidin content measuring  mg per g DW
+name: Content of peonidin in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Peonidin content of purple flesh sweetpotato" []
+def: "The content of peonidin in dry weight basis in storage roots measuring mg per g" []
 synonym: "PEO" EXACT []
-synonym: "RtFlsPeo_Ms_mgpergDW" EXACT []
+synonym: "RtFlsPeo_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001132 ! peonidin - method
-relationship: variable_of CO_331:0000432 ! peonidin content
+relationship: variable_of CO_331:0000432 ! storage root peonidin concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002087 ! measurement  the peonidin content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000800
-name: Anthocyanin content measuring  mg per g DW
+name: Content of anthocyanin in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Anthocyanin content of purple flesh sweetpotato" []
+def: "The content of anthocyanin in dry weight basis in storage roots measuring mg per g" []
 synonym: "ANTHO" EXACT []
-synonym: "RtFlsAnt_Ms_mgpergDW" EXACT []
+synonym: "RtFlsAnt_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001133 ! anthocyanin - method
-relationship: variable_of CO_331:0000433 ! anthocyanin content
+relationship: variable_of CO_331:0000433 ! storage root anthocyanin concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002116 ! measurement the anthocyanin content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000801
-name: Phenol content measuring  mg per g DW
+name: Content of phenol in dry weight basis in storage roots measuring mg per g
 namespace: SweetpotatoTrait
-def: "Phenol content of purple flesh sweetpotato" []
+def: "The content of phenol in dry weight basis in storage roots measuring mg per g" []
 synonym: "PHEN" EXACT []
-synonym: "RtFlsPhe_Ms_mgpergDW" EXACT []
+synonym: "RtFlsPhe_Ms_mggDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001129 ! mg/g dw
-relationship: variable_of CO_331:00001134 ! phenol - method
-relationship: variable_of CO_331:0000434 ! phenol content
+relationship: variable_of CO_331:0000434 ! storage root phenol concentration in dry weight basis
+relationship: variable_of CO_331:0000665 ! mg/g
+relationship: variable_of CO_331:0002129 ! measurement the phenol content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000802
-name: Node number counting nodes per vine
+name: Number of nodes per vine
 namespace: SweetpotatoTrait
-def: "Nodes per vine" []
+def: "The number per vine of the nodes" []
 synonym: "VINTND" EXACT []
 synonym: "VnNds_Ct_pervine" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001135 ! nodes per vine evaluation
-relationship: variable_of CO_331:00001136 ! nodes/plant
-relationship: variable_of CO_331:0000435 ! nodes per vine
+relationship: variable_of CO_331:0000435 ! node number per vine
+relationship: variable_of CO_331:0000554 ! counting - nodes number per vine
+relationship: variable_of CO_331:0000672 ! VnNds
 
 [Term]
 id: CO_331:0000803
-name: Total number of leaves counting per plant
+name: Total number of leaves per plant
 namespace: SweetpotatoTrait
-def: "Leaves per plant" []
+def: "The number per plant of the leafs" []
 synonym: "LEFTPP" EXACT []
-synonym: "PtLvs_ct_perplant" EXACT []
+synonym: "PtLvs_Ct_perplant" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001137 ! leaves per plant evaluation
-relationship: variable_of CO_331:00001138 ! leaf/plant
-relationship: variable_of CO_331:0000436 ! leaves per plant
-
-[Term]
-id: CO_331:0000804
-name: Leaf color by picture measuring by picture using method
-namespace: SweetpotatoTrait
-def: "Color of leave" []
-synonym: "LEFCPC" EXACT []
-synonym: "LfCol_Ms_image" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001139 ! color of leave picture
-relationship: variable_of CO_331:00001140 ! picture
-relationship: variable_of CO_331:0000437 ! color of leave
+relationship: variable_of CO_331:0000436 ! leaf number per plant
+relationship: variable_of CO_331:0000555 ! counting - leaf number per plant
+relationship: variable_of CO_331:0000673 ! PtLvs
 
 [Term]
 id: CO_331:0000805
 name: Millipede damage estimating 1-9
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by Millipede in roots. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+def: "Millipede damage estimating 1-9" []
 synonym: "MILLDAM" EXACT []
 synonym: "RtsMillDam_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: variable_of CO_331:00001141 ! rtsmilldam 5 pt. scale
 relationship: variable_of CO_331:0000438 ! millipede damage
+relationship: variable_of CO_331:0000557 ! visual estimation - millipede damage
+relationship: variable_of CO_331:0000675 ! RtMillDam 5 pt. scale
 
 [Term]
 id: CO_331:0000806
 name: Alcidodes sp. damage estimating 1-9
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by Alcidodes sp, causes crown enlargement/galling or death by girdling. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+def: "Alcidodes sp. damage estimating 1-9" []
 synonym: "ALCDAM" EXACT []
 synonym: "RtAlcDam_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001142 ! rtalcdam 5 pt. scale
 relationship: variable_of CO_331:0000439 ! alcidodes sp. damage
-relationship: variable_of CO_331:0000883 ! weevil damage evaluation
+relationship: variable_of CO_331:0000558 ! visual estimation - alcidodes sp. damage
+relationship: variable_of CO_331:0000676 ! RtAlcDam 5 pt. scale
 
 [Term]
 id: CO_331:0000807
 name: Soil insect damage estimating 1-9
 namespace: SweetpotatoTrait
-def: "Observation of damage caused by soil insect. 1= No damage, 3 = Low damage, 5 = Intermediate, 7 = High, 9 = Severe infestation" []
+def: "Soil insect damage estimating 1-9" []
 synonym: "INSDAM" EXACT []
 synonym: "RtSInsDam_Et_1to9" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:00001143 ! soils insect evaluation
-relationship: variable_of CO_331:00001144 ! rtsinsdam  5 pt. scale
 relationship: variable_of CO_331:0000440 ! soil insect damage
-
-[Term]
-id: CO_331:0000808
-name: overall storage root disease symptoms
-namespace: SweetpotatoTrait
-def: "Overall storage root disease symptoms evaluation" []
-synonym: "RtDSm" EXACT []
-is_a: CO_331:1000005 ! Biotic_stress_trait
-created_by: C. Yencho
-creation_date: 2016-12-01T02:33:40Z
+relationship: variable_of CO_331:0000559 ! visual estimation - soil insect damage
+relationship: variable_of CO_331:0000677 ! RtSInsDam 5 pt. scale
 
 [Term]
 id: CO_331:0000809
-name: Storage root total marketable yield weight computation tons per ha
+name: Commercial storage root yield tons per ha
 namespace: SweetpotatoTrait
-def: "Marketable root yield" []
+def: "The yield of the commercial storage roots tons per ha" []
+synonym: "CYTHA" EXACT []
 synonym: "RtCYld_Cp_tha" EXACT []
-synonym: "RYTHA" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000307 ! marketable root yield
-created_by: W. Grueneberg
-creation_date: 2016-11-30T21:23:23Z
+relationship: variable_of CO_331:0000307 ! commercial storage root yield
+relationship: variable_of CO_331:0000313 ! computation - commercial storage root yield method
+relationship: variable_of CO_331:0000897 ! t/ha
 
 [Term]
 id: CO_331:0000810
-name: Storage Root Defects secondary estimating 1-18
+name: Storage root secondary defects estimating 1-18
 namespace: SweetpotatoTrait
-def: "Type and/or name of secondary visible storage root defect. 1 = Blisters (BLI), 2 = Tea Staining (TEA), 3 = Air Cracking (AIR), 4 = Bumpy (BUM), 5 = Cracking (CRA), 6 = Early Season Cracking (ESC), 7 = Grooves (GRV), 8 = Insect Damage (INS), 9 = Excessive Latex (LTX), 10 = Skinning (SKN), 11 = Sprouts (SPR), 12 = Striations (STR), 13 = Tails (TLS), 14 = Veins (VNS), 15 = Deep Eyes (DES), 16 = Misshapes (MIS), 17 = Secondary Roots (SRS), 18 = Tight Hills (THS)." []
+def: "Storage root secondary defects estimating 1-18" []
 synonym: "RTDEF2" EXACT []
 synonym: "RtDefS_Et_1to18" EXACT []
+synonym: "RTDSEF" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000811 ! storage root defects (secondary)
-created_by: C. Yencho
-creation_date: 2016-11-30T20:44:25Z
+relationship: variable_of CO_331:0000811 ! storage root surface secondary defects
+relationship: variable_of CO_331:0002029 ! visual estimation storage root defects
+relationship: variable_of CO_331:0002032 ! RtSSDef 14 pt. scale
 
 [Term]
 id: CO_331:0000811
-name: storage root defects (secondary)
+name: storage root surface secondary defects
 namespace: SweetpotatoTrait
-def: "Type and/or name of secondary visible storage root defect" []
-synonym: "RtDefS" EXACT []
+def: "Storage root surface secondary defects" []
+synonym: "RtSSDef" EXACT []
 is_a: CO_331:1000004 ! Abiotic_stress_trait
-created_by: C. Yencho
-creation_date: 2016-11-30T20:41:53Z
-
-[Term]
-id: CO_331:0000812
-name: observation of plant type
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000001 ! plant type
-
-[Term]
-id: CO_331:0000813
-name: plttyp 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000812 ! observation of plant type
-
-[Term]
-id: CO_331:0000814
-name: observation of ground cover
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000004 ! ground cover
 
 [Term]
 id: CO_331:0000815
-name: pltcov 4 pt. scale
+name: RtDSm 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000814 ! observation of ground cover
-
-[Term]
-id: CO_331:0000816
-name: observation of twining
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000007 ! twining
-
-[Term]
-id: CO_331:0000817
-name: plttwg 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000816 ! observation of twining
-
-[Term]
-id: CO_331:0000818
-name: observation of predominant vine color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000010 ! predominant vine color
-
-[Term]
-id: CO_331:0000819
-name: vinclp 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000818 ! observation of predominant vine color
-
-[Term]
-id: CO_331:0000820
-name: observation of secondary vine color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000013 ! secondary vine color
-
-[Term]
-id: CO_331:0000821
-name: vincls 8 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000820 ! observation of secondary vine color
-
-[Term]
-id: CO_331:0000822
-name: observation of vine tips pubescence
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000016 ! vine tips pubescence
-
-[Term]
-id: CO_331:0000823
-name: vintpp 8 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000822 ! observation of vine tips pubescence
-
-[Term]
-id: CO_331:0000824
-name: average length of at least three internodes located in the middle section of the vine
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000153 ! vine internode length
-
-[Term]
-id: CO_331:0000825
-name: vininlg 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000824 ! average length of at least three internodes located in the middle section of the vine
-
-[Term]
-id: CO_331:0000826
-name: average diameter of at least three internodes located in the middle section of the vine
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000157 ! vine internode diameter
-
-[Term]
-id: CO_331:0000827
-name: vinind 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000826 ! average diameter of at least three internodes located in the middle section of the vine
-
-[Term]
-id: CO_331:0000828
-name: observation of general outline of the leaf
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000019 ! general outline of the leaf
-
-[Term]
-id: CO_331:0000829
-name: lefout 7 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000828 ! observation of general outline of the leaf
-
-[Term]
-id: CO_331:0000830
-name: observation of leaf lobes type
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000022 ! leaf lobe type
-
-[Term]
-id: CO_331:0000831
-name: leflbt  6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000830 ! observation of leaf lobes type
-
-[Term]
-id: CO_331:0000832
-name: observation of leaf lobe number
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000025 ! leaf lobe number
-
-[Term]
-id: CO_331:0000833
-name: leflbn 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000832 ! observation of leaf lobe number
-
-[Term]
-id: CO_331:0000834
-name: observation of shape of central leaf lobe
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000028 ! shape of central leaf lobe
-
-[Term]
-id: CO_331:0000835
-name: leflcs 10 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000834 ! observation of shape of central leaf lobe
-
-[Term]
-id: CO_331:0000836
-name: observation of mature leaf size
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000031 ! mature leaf size
-
-[Term]
-id: CO_331:0000837
-name: leflms 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000836 ! observation of mature leaf size
-
-[Term]
-id: CO_331:0000838
-name: observation of abaxial leaf vein pigmentation
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000034 ! abaxial leaf vein pigmentation
-
-[Term]
-id: CO_331:0000839
-name: lefavp 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000838 ! observation of abaxial leaf vein pigmentation
-
-[Term]
-id: CO_331:0000840
-name: observation of mature leaf color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000037 ! mature leaf color
-
-[Term]
-id: CO_331:0000841
-name: lefcmt 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000840 ! observation of mature leaf color
-
-[Term]
-id: CO_331:0000842
-name: observation of immature leaf color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000040 ! immature leaf color
-
-[Term]
-id: CO_331:0000843
-name: lefcim 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000842 ! observation of immature leaf color
-
-[Term]
-id: CO_331:0000844
-name: observation of petiole pigmentation
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000043 ! petiole pigmentation
-
-[Term]
-id: CO_331:0000845
-name: flrptp 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000844 ! observation of petiole pigmentation
-
-[Term]
-id: CO_331:0000846
-name: average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000170 ! petiole length
-
-[Term]
-id: CO_331:0000847
-name: flrptl 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000846 ! average petiole length, from the base to the insertion with the blade, of at least three leaves in the middle portion of a main vine
-
-[Term]
-id: CO_331:0000848
-name: observation of newly opened flowers
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000046 ! flower color
-
-[Term]
-id: CO_331:0000849
-name: flrcol  6 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000848 ! observation of newly opened flowers
-
-[Term]
-id: CO_331:0000850
-name: observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000049 ! predominant skin color
-
-[Term]
-id: CO_331:0000851
-name: prdskncol 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000850 ! observation of predominant skin color, many freshly harvested storage roots should be washed and dried prior to evaluation.
-
-[Term]
-id: CO_331:0000852
-name: observation of intensity of predominant skin color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000052 ! intensity of predominant skin color
-
-[Term]
-id: CO_331:0000853
-name: skncpi  3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000852 ! observation of intensity of predominant skin color
-
-[Term]
-id: CO_331:0000854
-name: observation of secondary skin color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000055 ! secondary skin color
-
-[Term]
-id: CO_331:0000855
-name: skncsc  10 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000854 ! observation of secondary skin color
-
-[Term]
-id: CO_331:0000856
-name: observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000058 ! predominant flesh color
-
-[Term]
-id: CO_331:0000857
-name: prdflshcol 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000856 ! observation of predominant flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-
-[Term]
-id: CO_331:0000858
-name: observation of secondary flesh color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000061 ! secondary flesh color
-
-[Term]
-id: CO_331:0000859
-name: flscsc 10 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000858 ! observation of secondary flesh color
-
-[Term]
-id: CO_331:0000860
-name: observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000064 ! distribution of secondary flesh color
-
-[Term]
-id: CO_331:0000861
-name: flscsd 10 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000860 ! observation of distribution of secondary flesh color described from cross and longitudinal sections made about the middle of freshly harvested storage roots
-
-[Term]
-id: CO_331:0000862
-name: observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000067 ! storage root shape
 
 [Term]
 id: CO_331:0000863
-name: rtshp 9 pt. scale
+name: RtShp 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000862 ! observation of  storage root shape described from longitudinal sections made about the middle of freshly harvested storage roots
-
-[Term]
-id: CO_331:0000864
-name: observation of latex production in storage roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000070 ! latex production in storage roots
-
-[Term]
-id: CO_331:0000865
-name: rtlat 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000864 ! observation of latex production in storage roots
-
-[Term]
-id: CO_331:0000866
-name: observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000073 ! oxidation in storage roots
-
-[Term]
-id: CO_331:0000867
-name: rtoxi 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000866 ! observation of oxidation in storage roots 5-10 seconds after storage roots are cut in cross section.
-
-[Term]
-id: CO_331:0000868
-name: storage root size - method
-namespace: SweetpotatoMethod
-def: "Overall assessment of storage root size based on inspection of the harvested roots.  Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000076 ! storage root size
-
-[Term]
-id: CO_331:0000869
-name: rtsize 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000868 ! storage root size - method
-
-[Term]
-id: CO_331:0000870
-name: evaluation of plant vine establishment
-namespace: SweetpotatoMethod
-def: "Counting of established plants." []
-is_a: CO_331:1000012 ! Counting
-relationship: method_of CO_331:0000189 ! number of plants established
 
 [Term]
 id: CO_331:0000871
 name: plants/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000870 ! evaluation of plant vine establishment
-relationship: scale_of CO_331:0000872 ! recording planting materials
-relationship: scale_of CO_331:0000885 ! evaluation of plants
-
-[Term]
-id: CO_331:0000872
-name: recording planting materials
-namespace: SweetpotatoMethod
-def: "Counting plants/vines planted." []
-is_a: CO_331:1000012 ! Counting
-relationship: method_of CO_331:0000303 ! number of plants planted
-
-[Term]
-id: CO_331:0000873
-name: virus symptoms evaluation
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000094 ! virus symptoms
-
-[Term]
-id: CO_331:0000874
-name: virsym 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000873 ! virus symptoms evaluation
-
-[Term]
-id: CO_331:0000875
-name: observation of plant vigour
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000194 ! vine vigor
-
-[Term]
-id: CO_331:0000876
-name: vinvgr 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000875 ! observation of plant vigour
-
-[Term]
-id: CO_331:0000877
-name: early blight evaluation: (alternaria)
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000091 ! reaction to early blight: (alternaria spp)
-
-[Term]
-id: CO_331:0000878
-name: altsm 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000877 ! early blight evaluation: (alternaria)
-
-[Term]
-id: CO_331:0000879
-name: storage root form - method
-namespace: SweetpotatoMethod
-def: "Overall assessment of storage root form based on inspection of the harvested roots. Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000199 ! storage root form
-
-[Term]
-id: CO_331:0000880
-name: rtform 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000879 ! storage root form - method
-
-[Term]
-id: CO_331:0000881
-name: storage root damage
-namespace: SweetpotatoMethod
-def: "Overall assessment of damage based on inspection of the harvested roots. Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000203 ! number of storage root damages
-
-[Term]
-id: CO_331:0000882
-name: rtsdam 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000881 ! storage root damage
-
-[Term]
-id: CO_331:0000883
-name: weevil damage evaluation
-namespace: SweetpotatoMethod
-def: "Overall assessment of weevil damage based on inspection of the harvested roots. Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000088 ! reaction to sweet potato weevil
-relationship: method_of CO_331:0000439 ! alcidodes sp. damage
-
-[Term]
-id: CO_331:0000884
-name: rtdam 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000883 ! weevil damage evaluation
 
 [Term]
 id: CO_331:0000885
-name: evaluation of plants
+name: counting - number of plants available
 namespace: SweetpotatoMethod
-def: "Visual estimation" []
+def: "Count the plants available and record it" []
 is_a: CO_331:1000012 ! Counting
-relationship: method_of CO_331:0000208 ! number of plants with storage roots
-relationship: method_of CO_331:0000304 ! number of plants harvested
-
-[Term]
-id: CO_331:0000886
-name: evaluation of roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000012 ! Counting
-relationship: method_of CO_331:0000212 ! number of commercial storage roots
-relationship: method_of CO_331:0000215 ! number of non-commercial storage roots
 
 [Term]
 id: CO_331:0000887
-name: roots/plot
+name: storage root/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000886 ! evaluation of roots
-
-[Term]
-id: CO_331:0000888
-name: estimated number per plot - method
-namespace: SweetpotatoMethod
-def: "Number of commercial plus Number of non-commercial roots" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000079 ! total number of root
-
-[Term]
-id: CO_331:0000889
-name: roots/ plot
-namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000888 ! estimated number per plot - method
-
-[Term]
-id: CO_331:0000890
-name: total root number per plant - method
-namespace: SweetpotatoMethod
-def: "Total number of roots per plot / Number of plants harvested per plot" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000079 ! total number of root
 
 [Term]
 id: CO_331:0000891
-name: roots/ plant
+name: storage root/plant
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000890 ! total root number per plant - method
-relationship: scale_of CO_331:2000035 ! commercial root number per plant - method
 
 [Term]
 id: CO_331:0000892
-name: measurements of root mass
+name: measurement - weight of total us no. 1 storage roots
 namespace: SweetpotatoMethod
-def: "Measured using scales" []
+def: "Measure the weight of US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000218 ! weight of commercial storage roots
-relationship: method_of CO_331:0000221 ! weight of non-commercial storage roots
 
 [Term]
 id: CO_331:0000893
 name: kg/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000892 ! measurements of root mass
-relationship: scale_of CO_331:0000894 ! measurements of vine mass
-relationship: scale_of CO_331:0000895 ! estimated weight per plot - method
-
-[Term]
-id: CO_331:0000894
-name: measurements of vine mass
-namespace: SweetpotatoMethod
-def: "Measured using scales" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000224 ! weight of vines
-
-[Term]
-id: CO_331:0000895
-name: estimated weight per plot - method
-namespace: SweetpotatoMethod
-def: "Weight of commercial storage roots plus weight of non-commercial storage roots" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000234 ! total root weight
-
-[Term]
-id: CO_331:0000896
-name: estimated marketable yield per hectare - method
-namespace: SweetpotatoMethod
-def: "(Weight of commercial storage roots/ plot size)*10" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000307 ! marketable root yield
-relationship: method_of CO_331:0000308 ! average commercial root weight
 
 [Term]
 id: CO_331:0000897
 name: t/ha
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000896 ! estimated marketable yield per hectare - method
-relationship: scale_of CO_331:0000898 ! estimated yield of total roots per hectare - method
-relationship: scale_of CO_331:0000901 ! Method of CO_331:0000311
-relationship: scale_of CO_331:0000937 ! estimated yield per hectare - method
-
-[Term]
-id: CO_331:0000898
-name: estimated yield of total roots per hectare - method
-namespace: SweetpotatoMethod
-def: "(Weight of commercial storage roots/ plot size)*10" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000309 ! yield of total roots 2
-
-[Term]
-id: CO_331:0000899
-name: percentage of marketable - method
-namespace: SweetpotatoMethod
-def: "Number of non-commercial roots/Total number of root after harvest*100" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000310 ! percentage of marketable roots
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000900
 name: %
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000899 ! percentage of marketable - method
-relationship: scale_of CO_331:0000911 ! storage root fibers content  evaluated in percentage fresh weight
-relationship: scale_of CO_331:0000923 ! protein content - method
-relationship: scale_of CO_331:0000932 ! measurement of raw starch content
-relationship: scale_of CO_331:0000933 ! measurement of raw fructose content
-relationship: scale_of CO_331:0000934 ! measurement of raw glucose content
-relationship: scale_of CO_331:0000935 ! measurement of raw sucrose content
-relationship: scale_of CO_331:0000936 ! measurement of raw maltose content
-relationship: scale_of CO_331:0000938 ! storage root dry matter content - method
-relationship: scale_of CO_331:0000939 ! survival index - method
-relationship: scale_of CO_331:0000940 ! harvest index evaluation  - method
-
-[Term]
-id: CO_331:0000901
-name: Method of CO_331:0000311
-namespace: SweetpotatoMethod
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000311 ! biomass yield
-relationship: method_of CO_331:0000312 ! foliage total yield
-relationship: method_of CO_331:0000425 ! storage root yield relative to check
-
-[Term]
-id: CO_331:0000902
-name: estimation of cracking roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000097 ! storage root cracking
-
-[Term]
-id: CO_331:0000903
-name: rtscr 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000902 ! estimation of cracking roots
-
-[Term]
-id: CO_331:0000904
-name: measurements of fresh root mass
-namespace: SweetpotatoMethod
-def: "Fresh weight of storage root samples (roughly 200g recommended sample size)" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000240 ! Fresh weight of storage root
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000905
 name: g
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
-relationship: scale_of CO_331:0000904 ! measurements of fresh root mass
-relationship: scale_of CO_331:0000906 ! measurements of dry root mass
-relationship: scale_of CO_331:0000907 ! measurements of fresh vine mass
-relationship: scale_of CO_331:0000908 ! measurements of dry vine mass
-
-[Term]
-id: CO_331:0000906
-name: measurements of dry root mass
-namespace: SweetpotatoMethod
-def: "Dry weight of storage root samples" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000244 ! Dry weight of storage root
-
-[Term]
-id: CO_331:0000907
-name: measurements of fresh vine mass
-namespace: SweetpotatoMethod
-def: "Fresh weight of vines" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000248 ! Fresh weight of vines
-
-[Term]
-id: CO_331:0000908
-name: measurements of dry vine mass
-namespace: SweetpotatoMethod
-def: "Dry weight of vines" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000252 ! Dry weight of vines
-
-[Term]
-id: CO_331:0000909
-name: evaluation of cooked samples for fibers
-namespace: SweetpotatoMethod
-def: "Fibers in cooked storage root samples assessed by inspection and tasting. Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000256 ! fiber cooked
-
-[Term]
-id: CO_331:0000910
-name: rtfbr 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000909 ! evaluation of cooked samples for fibers
-
-[Term]
-id: CO_331:0000911
-name: storage root fibers content  evaluated in percentage fresh weight
-namespace: SweetpotatoMethod
-def: "Fibers in flesh root" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000130 ! fiber content
-
-[Term]
-id: CO_331:0000912
-name: evaluation of cooked samples for sweetness
-namespace: SweetpotatoMethod
-def: "Storage root sweetness in cooked samples, determined by taste test.  Use a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000139 ! sweetness of boiled storage root flesh
-
-[Term]
-id: CO_331:0000913
-name: rtswt 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000912 ! evaluation of cooked samples for sweetness
-
-[Term]
-id: CO_331:0000914
-name: evaluation of cooked samples for texture
-namespace: SweetpotatoMethod
-def: "Storage root texture in cooked samples, determined by taste test. Use a 1 to 9 scale with 5 scales." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000136 ! texture of boiled storage root flesh
-
-[Term]
-id: CO_331:0000915
-name: flstxch 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000914 ! evaluation of cooked samples for texture
-
-[Term]
-id: CO_331:0000916
-name: flstxcg 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000914 ! evaluation of cooked samples for texture
-
-[Term]
-id: CO_331:0000917
-name: evaluation of cooked samples for taste
-namespace: SweetpotatoMethod
-def: "Overall taste of cooked samples assessed using a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000266 ! overall taste of cooked sample
-
-[Term]
-id: CO_331:0000918
-name: rttst 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000917 ! evaluation of cooked samples for taste
-
-[Term]
-id: CO_331:0000919
-name: evaluation of cooked samples for appearance
-namespace: SweetpotatoMethod
-def: "Appearance of cooked samples assessed using a 1 to 9 scale." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000270 ! overall appearance of cooked sample
-
-[Term]
-id: CO_331:0000920
-name: rtapr 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:00001106 ! observation of an average or all storage roots within a single plant or plot
-relationship: scale_of CO_331:0000919 ! evaluation of cooked samples for appearance
-
-[Term]
-id: CO_331:0000921
-name: evaluation of roots for sprouting ability
-namespace: SweetpotatoMethod
-def: "Overall assessment using a scale of 1 to 9." []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000274 ! sprouting ability
-
-[Term]
-id: CO_331:0000922
-name: rtsprt 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000921 ! evaluation of roots for sprouting ability
-
-[Term]
-id: CO_331:0000923
-name: protein content - method
-namespace: SweetpotatoMethod
-def: "Protein content" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000100 ! protein content
-
-[Term]
-id: CO_331:0000924
-name: content of iron in dry weight basis - method
-namespace: SweetpotatoMethod
-def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma-optical emission spectrophotometry (ICP-OES) using a Radial View." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000103 ! iron content
-relationship: method_of CO_331:0000106 ! zinc content
 
 [Term]
 id: CO_331:0000925
 name: mg/100g
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: scale_of CO_331:0000927 ! content of zinc in dry weight basis - method
-relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
-relationship: scale_of CO_331:0000929 ! content of magnesium in dry weight basis - method
-relationship: scale_of CO_331:0000930 ! beta carotene content - method
-relationship: scale_of CO_331:0000931 ! total carotenoids - method
-
-[Term]
-id: CO_331:0000926
-name: mg/kg
-namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000924 ! content of iron in dry weight basis - method
-relationship: scale_of CO_331:0000928 ! content of calcium in dry weight basis - method
-relationship: scale_of CO_331:0000929 ! content of magnesium in dry weight basis - method
-
-[Term]
-id: CO_331:0000927
-name: content of zinc in dry weight basis - method
-namespace: SweetpotatoMethod
-def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma--optical emission spectrophotometry (ICP-OES) using a Radial View." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000106 ! zinc content
-
-[Term]
-id: CO_331:0000928
-name: content of calcium in dry weight basis - method
-namespace: SweetpotatoMethod
-def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma--optical emission spectrophotometry (ICP-OES) using a Radial View." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000281 ! calcium content
-
-[Term]
-id: CO_331:0000929
-name: content of magnesium in dry weight basis - method
-namespace: SweetpotatoMethod
-def: "The mineral concentrations (Fe, Zn, Ca, K, Na, Mg and P) are determined by inductively coupled plasma--optical emission spectrophotometry (ICP-OES) using a Radial View." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000285 ! magnesium content
-
-[Term]
-id: CO_331:0000930
-name: beta carotene content - method
-namespace: SweetpotatoMethod
-def: "For b-carotene analysis, 15 milliliters of the extract are transferred to a tube and dried with nitrogen gas. Immediately before injection, the residue is redissolved in 1 ml of HPLC grade acetone filtered through a 0.22-mm PTFE syringe filter directly into sample vials, and 10 ml is injected into the HPLC. Separation is carried out on a YMC C30 polymeric column (3 mm, 4.6 mm _ 250 mm) using as mobile phase an isocratic elution methanol: methyl-tert-butyl-eter (80:20) with a flow rate set as 0.8 ml/ min." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000109 ! beta-carotene content
-
-[Term]
-id: CO_331:0000931
-name: total carotenoids - method
-namespace: SweetpotatoMethod
-def: "The total carotenoid content is calculated using the absorbance value measured in a spectrophotometer at 450 nm and the extinction coefficient of b-carotene in petroleum ether ." []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000112 ! total carotenoids
-
-[Term]
-id: CO_331:0000932
-name: measurement of raw starch content
-namespace: SweetpotatoMethod
-def: "Pharr, D.M. Y Sox, H.N. 198" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000115 ! starch content
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000933
-name: measurement of raw fructose content
+name: measurement - fructose content of the raw storage root
 namespace: SweetpotatoMethod
-def: "Miller, Gail Lorenz (1959)" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000118 ! fructose content
+def: "Compute the fructose content of the raw storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000934
-name: measurement of raw glucose content
+name: measurement - glucose content of the raw storage root
 namespace: SweetpotatoMethod
-def: "Miller, Gail Lorenz (1959)" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000121 ! glucose content
+def: "Compute the glucose content of the raw storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000935
-name: measurement of raw sucrose content
+name: measurement - sucrose content of the raw storage root
 namespace: SweetpotatoMethod
-def: "Miller, Gail Lorenz (1959)" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000124 ! sucrose content
+def: "Compute the sucrose content of the raw storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:0000936
-name: measurement of raw maltose content
+name: measurement - maltose content of the raw storage root
 namespace: SweetpotatoMethod
-def: "Miller, Gail Lorenz (1959)" []
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000127 ! maltose content
-
-[Term]
-id: CO_331:0000937
-name: estimated yield per hectare - method
-namespace: SweetpotatoMethod
-def: "(Weight total of root/ plot size)*10" []
+def: "Compute the maltose content of the raw storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000082 ! yield of total roots
-
-[Term]
-id: CO_331:0000938
-name: storage root dry matter content - method
-namespace: SweetpotatoMethod
-def: "Fresh weight / dry weight * 100" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000142 ! storage root dry matter content
-
-[Term]
-id: CO_331:0000939
-name: survival index - method
-namespace: SweetpotatoMethod
-def: "Number of plants harvested / number of plants sown" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000298 ! survival index
-
-[Term]
-id: CO_331:0000940
-name: harvest index evaluation  - method
-namespace: SweetpotatoMethod
-def: "100*total root weight/total root weight + foliage weight" []
-is_a: CO_331:1000013 ! Computation
-relationship: method_of CO_331:0000085 ! harvest index
-
-[Term]
-id: CO_331:0000941
-name: estimation of color of cooked roots immediately after cooking
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000133 ! color of boiled roots
-
-[Term]
-id: CO_331:0000942
-name: rtscb 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000941 ! estimation of color of cooked roots immediately after cooking
-
-[Term]
-id: CO_331:0000943
-name: observation of storage root surface defects
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000326 ! storage root surface defects
-
-[Term]
-id: CO_331:0000944
-name: rtssdef 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000943 ! observation of storage root surface defects
-
-[Term]
-id: CO_331:0000945
-name: observation of storage root cortex thickness
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000327 ! storage root cortex thickness
-
-[Term]
-id: CO_331:0000946
-name: rtscthi 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000945 ! observation of storage root cortex thickness
-
-[Term]
-id: CO_331:0000947
-name: observation of number flowers in the inflorescence
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000328 ! flowering habit
-
-[Term]
-id: CO_331:0000948
-name: flrhab 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000947 ! observation of number flowers in the inflorescence
-
-[Term]
-id: CO_331:0000949
-name: measurement of flower length and width in cm
-namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000329 ! flower size
 
 [Term]
 id: CO_331:0000950
 name: cm
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000949 ! measurement of flower length and width in cm
-
-[Term]
-id: CO_331:0000951
-name: observation of shape limb in the flowers in the inflorescence
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000330 ! shape of limb
-
-[Term]
-id: CO_331:0000952
-name: flrshl 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000951 ! observation of shape limb in the flowers in the inflorescence
-
-[Term]
-id: CO_331:0000953
-name: equality of sepal length
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000331 ! equality of sepal length
-
-[Term]
-id: CO_331:0000954
-name: sepeql 2 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000953 ! equality of sepal length
-
-[Term]
-id: CO_331:0000955
-name: record the most frequent number in ten typical flowers
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000332 ! number of sepal veins
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000956
-name: number
+name: TtlVnProd
 namespace: SweetpotatoScale
-is_a: CO_331:1000002 ! Scales
-relationship: scale_of CO_331:0000955 ! record the most frequent number in ten typical flowers
-
-[Term]
-id: CO_331:0000957
-name: observation of  sepal shape
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000333 ! sepal shape
-
-[Term]
-id: CO_331:0000958
-name: sepshp 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000957 ! observation of  sepal shape
-
-[Term]
-id: CO_331:0000959
-name: observation of sepal apex
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000334 ! sepal apex
-
-[Term]
-id: CO_331:0000960
-name: sepapx 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000959 ! observation of sepal apex
-
-[Term]
-id: CO_331:0000961
-name: observation of sepal pubescence
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000335 ! sepal pubescence
-
-[Term]
-id: CO_331:0000962
-name: seppub 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000961 ! observation of sepal pubescence
-
-[Term]
-id: CO_331:0000963
-name: observation of sepal color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000336 ! sepal color
-
-[Term]
-id: CO_331:0000964
-name: sepcol 7 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000963 ! observation of sepal color
-
-[Term]
-id: CO_331:0000965
-name: observation of stigma color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000337 ! color of stigma
-
-[Term]
-id: CO_331:0000966
-name: stgcol 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000965 ! observation of stigma color
-
-[Term]
-id: CO_331:0000967
-name: observation of style color
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000338 ! color of style
-
-[Term]
-id: CO_331:0000968
-name: stycol 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000967 ! observation of style color
-
-[Term]
-id: CO_331:0000969
-name: observation of stigma exertion
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000339 ! stigma exertion
-
-[Term]
-id: CO_331:0000970
-name: stgext 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000969 ! observation of stigma exertion
-
-[Term]
-id: CO_331:0000971
-name: observation of seed capsule set
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000340 ! seed capsule set
-
-[Term]
-id: CO_331:0000972
-name: sedcap 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000971 ! observation of seed capsule set
-
-[Term]
-id: CO_331:0000973
-name: observation of storage root formation
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000341 ! storage root formation
-
-[Term]
-id: CO_331:0000974
-name: strfor 4 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000973 ! observation of storage root formation
-
-[Term]
-id: CO_331:0000977
-name: observation of variability of storage root shape
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000343 ! variability of storage root shape
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:0000978
-name: vrtssh 3 pt. scale
+name: RtShpU 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000977 ! observation of variability of storage root shape
 
 [Term]
 id: CO_331:0000979
-name: observation of variability of storage root size
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000344 ! variability of storage root size
+name: Content of fructose in fresh weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The fructose content in fresh weight basis in raw storage roots measuring g per 100g" []
+synonym: "FRUCFW" EXACT []
+synonym: "RwRtFru_Ms_g100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001068 ! storage root fructose content in fresh weight basis
+relationship: variable_of CO_331:0002095 ! measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000980
-name: vrtssiz 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000979 ! observation of variability of storage root size
+name: Content of fructose in fresh weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The fructose content in fresh weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtFru_Ms_g100gFW" EXACT []
+synonym: "BOILFRUCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001068 ! storage root fructose content in fresh weight basis
+relationship: variable_of CO_331:0002092 ! measurement fructose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
 
 [Term]
 id: CO_331:0000981
-name: observation of keeping quality of storage roots
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000345 ! keeping quality of storage roots
+name: Content of glucose in fresh weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The glucose content in fresh weight basis in raw storage roots measuring g per 100g" []
+synonym: "GLUCFW" EXACT []
+synonym: "RwRtGlu_Ms_g100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001070 ! storage root glucose content in fresh weight basis
+relationship: variable_of CO_331:0002099 ! measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000982
-name: kqtyrts 3 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000981 ! observation of keeping quality of storage roots
+name: Content of glucose in fresh weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The glucose content in fresh weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtGlu_Ms_g100gFW" EXACT []
+synonym: "BOILGLUCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001070 ! storage root glucose content in fresh weight basis
+relationship: variable_of CO_331:0002096 ! measurement glucose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
 
 [Term]
 id: CO_331:0000983
-name: observation of consistency of boiled storage root
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000346 ! consistency of boiled storage root
+name: Content of sucrose in fresh weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The sucrose content in fresh weight basis in raw storage roots measuring g per 100g" []
+synonym: "RwRtSuc_Ms_g100gFW" EXACT []
+synonym: "SUCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001075 ! storage root sucrose content in fresh weight basis
+relationship: variable_of CO_331:0002114 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000984
-name: cbolrts 9 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000983 ! observation of consistency of boiled storage root
+name: Content of sucrose in fresh weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The sucrose content in fresh weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtSuc_Ms_g100gFW" EXACT []
+synonym: "BOILSUCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001075 ! storage root sucrose content in fresh weight basis
+relationship: variable_of CO_331:0002111 ! measurement sucrose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
 
 [Term]
 id: CO_331:0000985
-name: observation of undesirable color of boiled storage root
-namespace: SweetpotatoMethod
-def: "Visual estimation" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000347 ! undesirable color of boiled storage root
+name: Content of maltose in fresh weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The maltose content in fresh weight basis of raw storage roots measuring g per 100g" []
+synonym: "MALTFW" EXACT []
+synonym: "RwRtMal_Ms_g100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001072 ! storage root maltose content in fresh weight basis
+relationship: variable_of CO_331:0002107 ! measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000986
-name: ucolbrts 10 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000985 ! observation of undesirable color of boiled storage root
+name: Content of maltose in fresh weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The maltose content in fresh weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtMal_Ms_g100gFW" EXACT []
+synonym: "BOILMALTFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001072 ! storage root maltose content in fresh weight basis
+relationship: variable_of CO_331:0002104 ! measurement maltose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
 
 [Term]
 id: CO_331:0000987
-name: visual estimation of the plant response to  limited water availability
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to limited water availability" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000348 ! reaction to drought
+name: Content of total sugars in fresh weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The total sugar content in fresh weight basis in raw storage roots measuring g per 100g" []
+synonym: "RwRtTSg_Ms_g100gFW" EXACT []
+synonym: "TOTSUGFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001077 ! storage root total sugar content in fresh weight basis
+relationship: variable_of CO_331:0002141 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000988
-name: rctdro 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000987 ! visual estimation of the plant response to  limited water availability
+name: Content of total sugars in fresh weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The total sugar content in fresh weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtTSg_Ms_g100gFW" EXACT []
+synonym: "BOILTOTSUGFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001077 ! storage root total sugar content in fresh weight basis
+relationship: variable_of CO_331:0002138 ! measurement total sugar - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
 
 [Term]
 id: CO_331:0000989
-name: visual estimation of the plant response to  flooding (watering saturated soil)
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to flooding (watering saturated soil)" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000349 ! reaction to flooding
+name: Storage roots yield in kg per plant planted
+namespace: SweetpotatoTrait
+def: "The yield of storage roots in kg per plant planted" []
+synonym: "RtYPPp_Cp_kgplant" EXACT []
+synonym: "YPSP" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000309 ! storage roots yield
+relationship: variable_of CO_331:0000321 ! kg/plant
+relationship: variable_of CO_331:0002004 ! computation - yield of storage roots per plant planted method
 
 [Term]
 id: CO_331:0000990
-name: rctflo 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000989 ! visual estimation of the plant response to  flooding (watering saturated soil)
+name: Vine weight in kg per plant harvested
+namespace: SweetpotatoTrait
+def: "The weight of the vines in kg per plant harvested" []
+synonym: "VnWh_Cp_kgplant" EXACT []
+synonym: "VPP" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000224 ! vine weight
+relationship: variable_of CO_331:0000321 ! kg/plant
+relationship: variable_of CO_331:0002022 ! measurement - weight of vines per plant harvested method
 
 [Term]
 id: CO_331:0000991
-name: visual estimation of the plant response to  hot season with night temperatures of more than 22°c
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to hot season with night temperatures of more than 22°C" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000350 ! reaction to heat
+name: Vine weight in kg per plant planted
+namespace: SweetpotatoTrait
+def: "The weight of the vines in kg per plant planted" []
+synonym: "VnWp_Cp_kgplant" EXACT []
+synonym: "VPSP" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000224 ! vine weight
+relationship: variable_of CO_331:0000321 ! kg/plant
+relationship: variable_of CO_331:0002023 ! measurement - weight of vines per plant planted method
 
 [Term]
 id: CO_331:0000992
-name: rctheat 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000991 ! visual estimation of the plant response to  hot season with night temperatures of more than 22°c
+name: Total number of storage roots per NET plot
+namespace: SweetpotatoTrait
+def: "The total number of storage roots per NET plot in kg" []
+synonym: "RtTN_Cp_rtplot" EXACT []
+synonym: "TNR" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000887 ! storage root/plot
+relationship: variable_of CO_331:0001079 ! total number of storage roots
+relationship: variable_of CO_331:0001094 ! computation - number of storage roots method
 
 [Term]
 id: CO_331:0000993
-name: visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to soil with salinity levels of more 8 mm/cm" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000351 ! reaction to salinity
+name: Number of commercial storage roots per plant planted
+namespace: SweetpotatoTrait
+def: "Evaluation of the number of all storage roots that weigh more or equal than 100 g per plant planted" []
+synonym: "NCRPSP" EXACT []
+synonym: "RtNCmp_Cp_rtplant" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000212 ! number of commercial storage roots
+relationship: variable_of CO_331:0000891 ! storage root/plant
+relationship: variable_of CO_331:0002005 ! computing - number of commercial storage roots per plant planted method
 
 [Term]
 id: CO_331:0000994
-name: rctsty 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000993 ! visual estimation of the plant response to  soil with salinity levels of more 8 mm/cm
+name: Number of storage roots-after harvest per plant planted
+namespace: SweetpotatoTrait
+def: "The number of storage roots-after harvest per plant planted" []
+synonym: "NRPSP" EXACT []
+synonym: "RtNump_Ct_rtplant" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000079 ! number of storage roots
+relationship: variable_of CO_331:0000891 ! storage root/plant
+relationship: variable_of CO_331:0001095 ! computation - number of storage roots per plant planted method
 
 [Term]
 id: CO_331:0000995
-name: visual estimation of the plant response to  shape
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to shape" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000352 ! reaction to shade
+name: Total storage root weight in dry weight basis per NET plot in kg
+namespace: SweetpotatoTrait
+def: "The total dry weight of the storage roots per NET plot in kg" []
+synonym: "RtTDWt_Cp_kgplot" EXACT []
+synonym: "TRWD" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0001080 ! total storage root dry weight
+relationship: variable_of CO_331:0001099 ! computation - total storage root dry weight per net plot method
 
 [Term]
 id: CO_331:0000996
-name: rctshd 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000995 ! visual estimation of the plant response to  shape
+name: Dry weight of vines per NET plot in kg
+namespace: SweetpotatoTrait
+def: "The dry weight of the vines per NET plot in kg" []
+synonym: "VnDW_Ms_kgplot" EXACT []
+synonym: "VWD" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0001087 ! vine dry weight
+relationship: variable_of CO_331:0002008 ! measurement - dry weight of vines method
 
 [Term]
 id: CO_331:0000997
-name: visual estimation of the plant response to  acid and heavy ph soil below 5
-namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to acid and heavy ph soil below 5" []
-is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000353 ! reaction to soil
+name: Biomass yield in dry weight basis in kg per plot
+namespace: SweetpotatoTrait
+def: "The yield of the biomass in dry weight basis in kg per plot" []
+synonym: "BIOMD" EXACT []
+synonym: "BioYldD_Cp_kgplot" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0001058 ! biomass yield in dry weight basis
+relationship: variable_of CO_331:0001091 ! computation - biomass yield in dry weight basis method in kg
 
 [Term]
 id: CO_331:0000998
-name: rctsph 5 pt. scale
-namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-relationship: scale_of CO_331:0000997 ! visual estimation of the plant response to  acid and heavy ph soil below 5
+name: Commercial storage root yield adjusted tons per ha
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the commercial storage roots tons per ha" []
+synonym: "CYTHAAJ" EXACT []
+synonym: "RtCYldA_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001059 ! commercial storage root yield adjusted
+relationship: variable_of CO_331:0001092 ! computation - commercial storage root yield adjusted method
 
 [Term]
 id: CO_331:0000999
-name: visual estimation of the plant response to  hight soil temperature (40 °c)
+name: Total storage roots yield adjusted tons per ha
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the total storage roots tons per ha" []
+synonym: "RtYldA_Cp_tha" EXACT []
+synonym: "RYTHAAJ" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001081 ! total storage roots yield adjusted
+relationship: variable_of CO_331:0002000 ! computation - total storage roots yield adjusted method
+
+[Term]
+id: CO_331:0001000
+name: Storage root dry matter yield per NET plot in tons per ha
+namespace: SweetpotatoTrait
+def: "The dry matter content of the storage root yield per NET plot in tons per ha" []
+synonym: "DMRY" EXACT []
+synonym: "RtDMCY_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001065 ! storage root dry matter content yield
+relationship: variable_of CO_331:0001097 ! computation - storage root dry matter content yield
+
+[Term]
+id: CO_331:0001001
+name: Storage root dry matter yield adjusted per NET plot in tons per ha
+namespace: SweetpotatoTrait
+def: "The dry matter content of the storage root yield adjusted per NET plot in tons per ha" []
+synonym: "DMRYAJ" EXACT []
+synonym: "RtDMCYA_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001066 ! storage root dry matter content yield adjusted
+relationship: variable_of CO_331:0001098 ! computation - storage root dry matter content yield adjusted
+
+[Term]
+id: CO_331:0001002
+name: Total foliage yield adjusted in tons per ha
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the total vine or foliage in tons per ha" []
+synonym: "FYTHAAJ" EXACT []
+synonym: "VnFolYldA_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001078 ! total foliage yield adjusted
+relationship: variable_of CO_331:0001093 ! computation - foliage yield method
+
+[Term]
+id: CO_331:0001003
+name: Biomass yield in tons per ha
+namespace: SweetpotatoTrait
+def: "The yield of the biomass in tons per ha" []
+synonym: "BioYld_Cp_tha" EXACT []
+synonym: "BYTHA" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000311 ! biomass yield
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0002082 ! computation - biomass yield method in th
+
+[Term]
+id: CO_331:0001004
+name: Biomass yield adjusted in tons per ha
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the biomass in tons per ha" []
+synonym: "BioYldA_Cp_tha" EXACT []
+synonym: "BYTHAAJ" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001056 ! biomass yield adjusted
+relationship: variable_of CO_331:0001090 ! computation - biomass yield adjusted method
+
+[Term]
+id: CO_331:0001005
+name: Vine dry matter yield per NET plot in tons per ha
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine yield per NET plot in tons per ha" []
+synonym: "DMVY" EXACT []
+synonym: "VnDMCY_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001085 ! vine dry matter content yield
+relationship: variable_of CO_331:0002002 ! computation - vine dry matter content yield
+
+[Term]
+id: CO_331:0001006
+name: Vine dry matter yield adjusted per NET plot in tons per ha
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine yield adjusted per NET plot in tons per ha" []
+synonym: "DMVYAJ" EXACT []
+synonym: "VnDMCYA_Cp_tha" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001086 ! vine dry matter content yield adjusted
+relationship: variable_of CO_331:0002003 ! computation - vine dry matter content yield adjusted
+
+[Term]
+id: CO_331:0001007
+name: Biomass yield in dry weight basis in tons per ha
+namespace: SweetpotatoTrait
+def: "The yield of the biomass in dry weight basis in tons per ha" []
+synonym: "BioYldD_Cp_tha" EXACT []
+synonym: "DMBY" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001058 ! biomass yield in dry weight basis
+relationship: variable_of CO_331:0002081 ! computation - biomass yield in dry weight basis method in tha
+
+[Term]
+id: CO_331:0001008
+name: Biomass yield adjusted in dry weight basis in tons per ha
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the biomass in dry weight basis in tons per ha" []
+synonym: "BioYldAD_Cp_tha" EXACT []
+synonym: "DMBYAJ" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000897 ! t/ha
+relationship: variable_of CO_331:0001057 ! biomass yield adjusted in dry weight basis
+relationship: variable_of CO_331:0001089 ! computation - biomass yield adjusted in dry weight basis method
+
+[Term]
+id: CO_331:0001009
+name: Content of protein in dry weight basis in boiled storage roots measuring percentage
+namespace: SweetpotatoTrait
+def: "Protein content in dry weight basis in boiled storage roots measuring percentage" []
+synonym: "BlRtPrt_Ms_%DW" EXACT []
+synonym: "BOILPRODW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000100 ! storage root protein content in dry weight basis
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0002044 ! measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001010
+name: Content of protein in fresh weight basis in raw storage roots measuring percentage
+namespace: SweetpotatoTrait
+def: "Protein content in fresh weight basis in raw storage roots measuring percentage" []
+synonym: "PROFW" EXACT []
+synonym: "RwRtPrt_Ms_%FW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0002078 ! storage root protein content in fresh weight basis
+relationship: variable_of CO_331:0002109 ! measurement protein- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+
+[Term]
+id: CO_331:0001011
+name: Content of protein in fresh weight basis in boiled storage roots measuring percentage
+namespace: SweetpotatoTrait
+def: "Protein content in fresh weight basis in boiled storage roots measuring percentage" []
+synonym: "BlRtPrt_Ms_%FW" EXACT []
+synonym: "BOILPROFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0002078 ! storage root protein content in fresh weight basis
+relationship: variable_of CO_331:0002110 ! measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+
+[Term]
+id: CO_331:0001012
+name: Content of starch in fresh weight basis in raw storage roots measuring percentage
+namespace: SweetpotatoTrait
+def: "Starch content in fresh weight basis in raw storage roots measuring percentage" []
+synonym: "RwRtSta_Ms_%FW" EXACT []
+synonym: "STARFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0002055 ! storage root starch content in fresh weight basis
+relationship: variable_of CO_331:0002130 ! measurement the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+
+[Term]
+id: CO_331:0001013
+name: Content of starch in fresh weight basis in boiled storage roots measuring percentage
+namespace: SweetpotatoTrait
+def: "Starch content in fresh weight basis in boiled storage roots measuring percentage" []
+synonym: "BlRtSta_Ms_%FW" EXACT []
+synonym: "BOILSTARFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0002055 ! storage root starch content in fresh weight basis
+relationship: variable_of CO_331:0002088 ! measurement  the starch content- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+
+[Term]
+id: CO_331:0001014
+name: Vine dry matter content computing percent
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine computing percent" []
+synonym: "DMV" EXACT []
+synonym: "VnDMC_Cp_pct" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0001084 ! vine dry matter content
+relationship: variable_of CO_331:0002001 ! computation - vine dry matter content
+
+[Term]
+id: CO_331:0001015
+name: Root foliage ratio computing percent
+namespace: SweetpotatoTrait
+def: "The ratio between root and foliage" []
+synonym: "RFR" EXACT []
+synonym: "RtFl_Cp_pct" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000900 ! %
+relationship: variable_of CO_331:0001063 ! root foliage ratio
+relationship: variable_of CO_331:0001096 ! computation - root foliage ratio method
+
+[Term]
+id: CO_331:0001016
+name: Content of iron in dry weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The iron concentration in dry weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "FeDW" EXACT []
+synonym: "RtFlsFe_Ms_NIRS_mg100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000103 ! storage root iron concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002103 ! measurement iron- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001017
+name: Content of zinc in dry weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The zinc concentration in dry weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "RtFlsZn_Ms_NIRS_mg100gDW" EXACT []
+synonym: "ZnDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000106 ! storage root zinc concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002145 ! measurement zinc- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001018
+name: Content of beta-carotene in dry weight basis in boiled storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in dry weight basis in boiled storage roots measuring mg per 100g" []
+synonym: "BlRtBC_Ms_mg100gDW" EXACT []
+synonym: "BOILBCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
+relationship: variable_of CO_331:0002118 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+
+[Term]
+id: CO_331:0001019
+name: Content of beta-carotene in dry weight basis in baked storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in dry weight basis in baked storage roots measuring mg per 100g" []
+synonym: "BAKBCDW" EXACT []
+synonym: "BkRtBC_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
+relationship: variable_of CO_331:0002123 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+
+[Term]
+id: CO_331:0001020
+name: Content of beta-carotene in fresh weight basis in raw storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in fresh weight basis in raw storage roots measuring mg per 100g" []
+synonym: "BCFW" EXACT []
+synonym: "RwRtBC_Ms_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002119 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+
+[Term]
+id: CO_331:0001021
+name: Content of beta-carotene in fresh weight basis in boiled storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in fresh weight basis in boiled storage roots measuring mg per 100g" []
+synonym: "BlRtBC_Ms_mg100gFW" EXACT []
+synonym: "BOILBCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002121 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+
+[Term]
+id: CO_331:0001022
+name: Content of beta-carotene in fresh weight basis in baked storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in fresh weight basis in baked storage roots measuring mg per 100g" []
+synonym: "BAKBCFW" EXACT []
+synonym: "BkRtBC_Ms_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002122 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in dry weight basis
+
+[Term]
+id: CO_331:0001023
+name: Content of beta-carotene in fresh weight basis in raw storage roots estimating from RHS color chart in mg per 100g
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in fresh weight basis in raw storage roots estimating from RHS color chart in mg per 100g" []
+synonym: "BCFWcc" EXACT []
+synonym: "RwRtBCcc_Et_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002006 ! estimation - royal horticultural society (rhs) color chart
+
+[Term]
+id: CO_331:0001024
+name: Content of total carotenoids in dry weight basis in boiled storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in dry weight basis in boiled storage roots measuring mg per 100g" []
+synonym: "BlRtTC_Ms_mg100gDW" EXACT []
+synonym: "BOILTCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
+relationship: variable_of CO_331:0002135 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+
+[Term]
+id: CO_331:0001025
+name: Content of total carotenoids in dry weight basis in baked storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in dry weight basis in baked storage roots measuring mg per 100g" []
+synonym: "BAKTCDW" EXACT []
+synonym: "BkRtTC_Ms_mg100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
+relationship: variable_of CO_331:0002133 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+
+[Term]
+id: CO_331:0001026
+name: Content of total carotenoids in fresh weight basis in raw storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in fresh weight basis in raw storage roots measuring mg per 100g" []
+synonym: "RwRtTC_Ms_mg100gFW" EXACT []
+synonym: "RWTCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002136 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+
+[Term]
+id: CO_331:0001027
+name: Content of total carotenoids in fresh weight basis in boiled storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in fresh weight basis in boiled storage roots measuring mg per 100g" []
+synonym: "BlRtTC_Ms_mg100gFW" EXACT []
+synonym: "BOILTCFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002132 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+
+[Term]
+id: CO_331:0001028
+name: Content of total carotenoids in fresh weight basis in baked storage roots measuring mg per 100g
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in fresh weight basis in baked storage roots measuring mg per 100g" []
+synonym: "BAKTCFW" EXACT []
+synonym: "BkRtTC_Ms_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002134 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
+
+[Term]
+id: CO_331:0001029
+name: Content of calcium in dry weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The calcium concentration in dry weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "CaDW" EXACT []
+synonym: "RtFlsCa_Ms_NIRS_mg100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000281 ! storage root calcium concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002085 ! measurement  calcium- near-infrared spectroscopy (nirs) method in dry weight
+
+[Term]
+id: CO_331:0001030
+name: Content of magnesium in dry weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The magnesium content in dry weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "MgDW" EXACT []
+synonym: "RtFlsMg_Ms_NIRS_mg100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000285 ! storage root magnesium concentration in dry weight basis
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002127 ! measurement the magnesium- near-infrared spectroscopy (nirs) method in dry weight
+
+[Term]
+id: CO_331:0001031
+name: Mature Leaf Size measuring cm
+namespace: SweetpotatoTrait
+def: "The size of the mature leaf measurement in cm" []
+synonym: "LFLMS" EXACT []
+synonym: "LfLMS_Et_3to9" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000031 ! mature leaf size
+relationship: variable_of CO_331:0000950 ! cm
+relationship: variable_of CO_331:0002014 ! measurement - mature leaf size
+
+[Term]
+id: CO_331:0001032
+name: Vine internode length measuring cm
+namespace: SweetpotatoTrait
+def: "The length of the vine internode" []
+synonym: "VnInLg_Ms_cm" EXACT []
+synonym: "VNLNLG" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000153 ! vine internode length
+relationship: variable_of CO_331:0000950 ! cm
+relationship: variable_of CO_331:0002091 ! measurement - vine internode length method
+
+[Term]
+id: CO_331:0001033
+name: Plant height measuring cm
+namespace: SweetpotatoTrait
+def: "The height of the plant" []
+synonym: "PTHEIGHT" EXACT []
+synonym: "PtTyp_Ms_cm" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000950 ! cm
+relationship: variable_of CO_331:0001062 ! plant height
+relationship: variable_of CO_331:0002013 ! measurement - main vine length method
+
+[Term]
+id: CO_331:0001034
+name: Flower length measuring cm
+namespace: SweetpotatoTrait
+def: "The length of the flower measuring cm" []
+synonym: "FLLG" EXACT []
+synonym: "FrLg_Ms_cm" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000950 ! cm
+relationship: variable_of CO_331:0001060 ! flower length
+relationship: variable_of CO_331:0002009 ! measurement - flower length
+
+[Term]
+id: CO_331:0001035
+name: Flower width measuring cm
+namespace: SweetpotatoTrait
+def: "The width of the flower measuring cm" []
+synonym: "FLWD" EXACT []
+synonym: "FrWd_Ms_cm" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000950 ! cm
+relationship: variable_of CO_331:0001061 ! flower width
+relationship: variable_of CO_331:0002012 ! measurement - flower width
+
+[Term]
+id: CO_331:0001036
+name: Content of iron in fresh weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The iron concentration in fresh weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "FeFW" EXACT []
+synonym: "RtFlsFe_Ms_NIRS_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002079 ! storage root iron concentration in fresh weight basis
+relationship: variable_of CO_331:0002102 ! measurement iron- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+
+[Term]
+id: CO_331:0001037
+name: Content of zinc in fresh weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The zinc concentration in fresh weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "RtFlsZn_Ms_NIRS_mg100gFW" EXACT []
+synonym: "ZnFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002054 ! storage root zinc concentration in fresh weight basis
+relationship: variable_of CO_331:0002144 ! measurement zinc- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+
+[Term]
+id: CO_331:0001038
+name: Fiber content in raw storage roots estimating 1-9
+namespace: SweetpotatoTrait
+def: "The fiber content of the raw storage root flesh estimating 1-9" []
+synonym: "FRAW" EXACT []
+synonym: "RwRtFlsFrC_Et_1to9" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000130 ! storage root fiber content
+relationship: variable_of CO_331:0002033 ! RtFlsFf 5 pt. Scale
+relationship: variable_of CO_331:0002043 ! estimation - fiber method in raw storage root
+
+[Term]
+id: CO_331:0001039
+name: Content of calcium in fresh weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The calcium concentration in fresh weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "CaFW" EXACT []
+synonym: "RtFlsCa_Ms_NIRS_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002053 ! storage root calcium concentration in fresh weight basis
+relationship: variable_of CO_331:0002086 ! measurement  calcium- near-infrared spectroscopy (nirs) method in fresh weight
+
+[Term]
+id: CO_331:0001040
+name: Content of magnesium in fresh weight basis measuring mg per 100g by NIRS
+namespace: SweetpotatoTrait
+def: "The magnesium content in fresh weight basis of the storage root measuring mg per 100g by NIRS" []
+synonym: "MgFW" EXACT []
+synonym: "RtFlsMg_Ms_NIRS_mg100gFW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000925 ! mg/100g
+relationship: variable_of CO_331:0002057 ! storage root magnesium concentration in fresh weight basis
+relationship: variable_of CO_331:0002128 ! measurement the magnesium- near-infrared spectroscopy (nirs) method in fresh weight
+
+[Term]
+id: CO_331:0001041
+name: Vine base color estimating 0-3
+namespace: SweetpotatoTrait
+def: "The base color of the vine estimating 0-3" []
+synonym: "VNBCOL" EXACT []
+synonym: "VnBCol_Et_0to3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0001083 ! vine base color
+relationship: variable_of CO_331:0002026 ! visual estimation - vine base color method
+relationship: variable_of CO_331:0002036 ! VnBCol 3 pt. scale
+
+[Term]
+id: CO_331:0001042
+name: Vine node color estimating 0-3
+namespace: SweetpotatoTrait
+def: "The node color of the vine estimating 0-3" []
+synonym: "VNNCOL" EXACT []
+synonym: "VnNCol_Et_0to3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0001088 ! vine node color
+relationship: variable_of CO_331:0002027 ! visual estimation - vine node color method
+relationship: variable_of CO_331:0002037 ! VnNCol 3 pt. Scale
+
+[Term]
+id: CO_331:0001043
+name: Vine apice color estimating 0-3
+namespace: SweetpotatoTrait
+def: "The apex color of the vine estimating 0-3" []
+synonym: "VNTCOL" EXACT []
+synonym: "VnTCol_Et_0to3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0001082 ! vine apex color
+relationship: variable_of CO_331:0002028 ! visual estimation - vine tip color method
+relationship: variable_of CO_331:0002038 ! VnTCol 3 pt. Scale
+
+[Term]
+id: CO_331:0001044
+name: Cooking time measuring in minutes
+namespace: SweetpotatoTrait
+def: "The cooking time of storage root measuring in minutes" []
+synonym: "COOKTIME" EXACT []
+synonym: "CooTime_Ms_min" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0001064 ! storage root cooking time
+relationship: variable_of CO_331:0002007 ! measurement - cooking time of the storage root method
+relationship: variable_of CO_331:0002030 ! minutes
+
+[Term]
+id: CO_331:0001045
+name: Content of fructose in dry weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The fructose content in dry weight basis in raw storage roots measuring g per 100g" []
+synonym: "FRUCDW" EXACT []
+synonym: "RwRtFru_Ms_g100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001067 ! storage root fructose content in dry weight basis
+relationship: variable_of CO_331:0002094 ! measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001046
+name: Content of fructose in dry weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The fructose content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtFru_Ms_g100gDW" EXACT []
+synonym: "BOILFRUCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001067 ! storage root fructose content in dry weight basis
+relationship: variable_of CO_331:0002093 ! measurement fructose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+
+[Term]
+id: CO_331:0001047
+name: Content of glucose in dry weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The glucose content in dry weight basis in raw storage roots measuring g per 100g" []
+synonym: "GLUCDW" EXACT []
+synonym: "RwRtGlu_Ms_g100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001069 ! storage root glucose content in dry weight basis
+relationship: variable_of CO_331:0002098 ! measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001048
+name: Content of glucose in dry weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The glucose content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtGlu_Ms_g100gDW" EXACT []
+synonym: "BOILGLUCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001069 ! storage root glucose content in dry weight basis
+relationship: variable_of CO_331:0002097 ! measurement glucose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+
+[Term]
+id: CO_331:0001049
+name: Content of sucrose in dry weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The sucrose content in dry weight basis in raw storage roots measuring g per 100g" []
+synonym: "RwRtSuc_Ms_g100gDW" EXACT []
+synonym: "SUCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001074 ! storage root sucrose content in dry weight basis
+relationship: variable_of CO_331:0002113 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001050
+name: Content of sucrose in dry weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The sucrose content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtSuc_Ms_g100gDW" EXACT []
+synonym: "BOILSUCDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001074 ! storage root sucrose content in dry weight basis
+relationship: variable_of CO_331:0002112 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+
+[Term]
+id: CO_331:0001051
+name: Content of maltose in dry weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The maltose content in dry weight basis in raw storage roots measuring g per 100g" []
+synonym: "MALTDW" EXACT []
+synonym: "RwRtMal_Ms_g100gDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001071 ! storage root maltose content in dry weight basis
+relationship: variable_of CO_331:0002106 ! measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001052
+name: Content of maltose in dry weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The maltose content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtMal_Ms_g100gDW" EXACT []
+synonym: "BOILMALTDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001071 ! storage root maltose content in dry weight basis
+relationship: variable_of CO_331:0002105 ! measurement maltose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+
+[Term]
+id: CO_331:0001053
+name: Content of total sugars in dry weight basis in raw storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The total sugar content in dry weight basis in raw storage roots measuring g per 100g" []
+synonym: "RwRtTSg_Ms_g100gDW" EXACT []
+synonym: "TOTSUGDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001076 ! storage root total sugar content in dry weight basis
+relationship: variable_of CO_331:0002140 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+
+[Term]
+id: CO_331:0001054
+name: Content of total sugars in dry weight basis in boiled storage roots measuring g per 100g
+namespace: SweetpotatoTrait
+def: "The total sugar content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtTSg_Ms_g100gDW" EXACT []
+synonym: "BOILTOTSUGDW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:00001127 ! g/100g
+relationship: variable_of CO_331:0001076 ! storage root total sugar content in dry weight basis
+relationship: variable_of CO_331:0002139 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+
+[Term]
+id: CO_331:0001055
+name: Content of starch in raw storage roots estimating 1-9
+namespace: SweetpotatoTrait
+def: "Starch content in raw storage roots estimating 1-9" []
+synonym: "RwRtSta_Et_1to9" EXACT []
+synonym: "STRAW" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0001073 ! storage root starch content
+relationship: variable_of CO_331:0002025 ! visual estimation - starch content
+relationship: variable_of CO_331:0002034 ! RwRtSta 5 pt. Scale
+
+[Term]
+id: CO_331:0001056
+name: biomass yield adjusted
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the biomass" []
+synonym: "BioYldA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001057
+name: biomass yield adjusted in dry weight basis
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the biomass in dry weight basis" []
+synonym: "BioYldAD" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001058
+name: biomass yield in dry weight basis
+namespace: SweetpotatoTrait
+def: "The yield of the biomass in dry weight basis" []
+synonym: "BioYldD" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001059
+name: commercial storage root yield adjusted
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the commercial storage roots" []
+synonym: "RtCYldA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001060
+name: flower length
+namespace: SweetpotatoTrait
+def: "The length of the flower" []
+synonym: "FrLg" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001061
+name: flower width
+namespace: SweetpotatoTrait
+def: "The width of the flower" []
+synonym: "FrWd" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001062
+name: plant height
+namespace: SweetpotatoTrait
+def: "The height of the plant" []
+synonym: "Ptlng" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001063
+name: root foliage ratio
+namespace: SweetpotatoTrait
+def: "The ratio between root and foliage" []
+synonym: "RtFl" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001064
+name: storage root cooking time
+namespace: SweetpotatoTrait
+def: "The cooking time of storage root" []
+synonym: "Cootime" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001065
+name: storage root dry matter content yield
+namespace: SweetpotatoTrait
+def: "The dry matter content of the storage root yield" []
+synonym: "RtDMCY" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001066
+name: storage root dry matter content yield adjusted
+namespace: SweetpotatoTrait
+def: "The dry matter content of the storage root yield adjusted" []
+synonym: "RtDMCYA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001067
+name: storage root fructose content in dry weight basis
+namespace: SweetpotatoTrait
+def: "Fructose content in dry weight basis of the storage root" []
+synonym: "RtFruDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001068
+name: storage root fructose content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Fructose content in fresh weight basis of the storage root" []
+synonym: "RtFruFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001069
+name: storage root glucose content in dry weight basis
+namespace: SweetpotatoTrait
+def: "Glucose content in dry weight basis of the storage root" []
+synonym: "RtGluDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001070
+name: storage root glucose content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Glucose content in fresh weight basis of the storage root" []
+synonym: "RtGluFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001071
+name: storage root maltose content in dry weight basis
+namespace: SweetpotatoTrait
+def: "Maltose content in dry weight basis of the storage root" []
+synonym: "RtMalDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001072
+name: storage root maltose content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Maltose content in fresh weight basis of the storage root" []
+synonym: "RtMalFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001073
+name: storage root starch content
+namespace: SweetpotatoTrait
+def: "Starch content in raw storage root" []
+synonym: "RwRtSta" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001074
+name: storage root sucrose content in dry weight basis
+namespace: SweetpotatoTrait
+def: "Sucrose content in dry weight basis of the storage root" []
+synonym: "RtSucDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001075
+name: storage root sucrose content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Sucrose content in fresh weight basis of the storage root" []
+synonym: "RtSucFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001076
+name: storage root total sugar content in dry weight basis
+namespace: SweetpotatoTrait
+def: "The total sugar content in dry weight basis of the storage root" []
+synonym: "RtTSgDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001077
+name: storage root total sugar content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "The total sugar content in fresh weight basis of the storage root" []
+synonym: "RtTSgFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001078
+name: total foliage yield adjusted
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the total vine or foliage" []
+synonym: "VnFolYldA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001079
+name: total number of storage roots
+namespace: SweetpotatoTrait
+def: "The total number of storage roots" []
+synonym: "RtTN" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001080
+name: total storage root dry weight
+namespace: SweetpotatoTrait
+def: "The total dry weight of the storage roots" []
+synonym: "RtTDWt" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001081
+name: total storage roots yield adjusted
+namespace: SweetpotatoTrait
+def: "The adjusted yield of the total storage roots" []
+synonym: "RtYldA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001082
+name: vine apex color
+namespace: SweetpotatoTrait
+def: "The apex color of the vine" []
+synonym: "VnACol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001083
+name: vine base color
+namespace: SweetpotatoTrait
+def: "The base color of the vine" []
+synonym: "VnBCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001084
+name: vine dry matter content
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine" []
+synonym: "VnDMC" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0001085
+name: vine dry matter content yield
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine yield" []
+synonym: "VnDMCY" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001086
+name: vine dry matter content yield adjusted
+namespace: SweetpotatoTrait
+def: "The dry matter content of the vine yield adjusted" []
+synonym: "VnDMCYA" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001087
+name: vine dry weight
+namespace: SweetpotatoTrait
+def: "The dry weight of the vines" []
+synonym: "VnDW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0001088
+name: vine node color
+namespace: SweetpotatoTrait
+def: "The node color of the vine" []
+synonym: "VnNCol" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
+id: CO_331:0001089
+name: computation - biomass yield adjusted in dry weight basis method
 namespace: SweetpotatoMethod
-def: "The reaction is estimated by observing visually the appearance  of plants in response to hight soil temperature (40 °C)" []
+def: "Computation of the biomass yield adjusted in dry weight basis within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001090
+name: computation - biomass yield adjusted method
+namespace: SweetpotatoMethod
+def: "Computation of the biomass yield adjusted within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001091
+name: computation - biomass yield in dry weight basis method in kg
+namespace: SweetpotatoMethod
+def: "Computation of the biomass yield in dry weight basis within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001092
+name: computation - commercial storage root yield adjusted method
+namespace: SweetpotatoMethod
+def: "Compute the adjusted yield of the commercial storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001093
+name: computation - foliage yield method
+namespace: SweetpotatoMethod
+def: "Compute the adjusted yield of vines per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001094
+name: computation - number of storage roots method
+namespace: SweetpotatoMethod
+def: "Compute the number of storage roots per net plot and record it" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001095
+name: computation - number of storage roots per plant planted method
+namespace: SweetpotatoMethod
+def: "Compute the number of storage roots per plant planted within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001096
+name: computation - root foliage ratio method
+namespace: SweetpotatoMethod
+def: "Computation of the ratio between root and foliage using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001097
+name: computation - storage root dry matter content yield
+namespace: SweetpotatoMethod
+def: "Compute the storage root dry matter yield content within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001098
+name: computation - storage root dry matter content yield adjusted
+namespace: SweetpotatoMethod
+def: "Compute the storage root dry matter content yield adjusted within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0001099
+name: computation - total storage root dry weight per net plot method
+namespace: SweetpotatoMethod
+def: "Compute the total dry weight of storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002000
+name: computation - total storage roots yield adjusted method
+namespace: SweetpotatoMethod
+def: "Compute the adjusted yield of the total storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002001
+name: computation - vine dry matter content
+namespace: SweetpotatoMethod
+def: "Compute the vine dry matter content using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002002
+name: computation - vine dry matter content yield
+namespace: SweetpotatoMethod
+def: "Compute the vine dry matter yield content within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002003
+name: computation - vine dry matter content yield adjusted
+namespace: SweetpotatoMethod
+def: "Compute the vine dry matter content yield adjusted within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002004
+name: computation - yield of storage roots per plant planted method
+namespace: SweetpotatoMethod
+def: "Compute the yield of total storage roots per plant planted within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002005
+name: computing - number of commercial storage roots per plant planted method
+namespace: SweetpotatoMethod
+def: "Compute the number of commercial storage roots per plant planted using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002006
+name: estimation - royal horticultural society (rhs) color chart
+namespace: SweetpotatoMethod
+def: "Observe the beta-carotene concentration of the raw storage root in fresh weight basis and rate it. Compare the color found and assign an estimate of the value in mg per 100g and record it" []
 is_a: CO_331:1000014 ! Estimation
-relationship: method_of CO_331:0000354 ! reaction to high soil temperature
+
+[Term]
+id: CO_331:0002007
+name: measurement - cooking time of the storage root method
+namespace: SweetpotatoMethod
+def: "Measure the cooking time of the storage roots in minutes and rate it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002008
+name: measurement - dry weight of vines method
+namespace: SweetpotatoMethod
+def: "Measure the dry weight of vines after harvest per net plot in kg and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002009
+name: measurement - flower length
+namespace: SweetpotatoMethod
+def: "Measure flower length and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002012
+name: measurement - flower width
+namespace: SweetpotatoMethod
+def: "Measure width size and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002013
+name: measurement - main vine length method
+namespace: SweetpotatoMethod
+def: "Measure the main vine length and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002014
+name: measurement - mature leaf size
+namespace: SweetpotatoMethod
+def: "Measure the mature leaf size and rate it. Described from leaves located in the middle section of the vine" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002015
+name: measurement - weight of 32 count us no. 1 storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of 32 count US no. 1 storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002016
+name: measurement - weight of 40 count us no. 1 storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of 40 count US no. 1 storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002017
+name: measurement - weight of 55 count us no. 1 storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of 55 count US no. 1 storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002018
+name: measurement - weight of 90 count us no. 1 storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of 90 count US no. 1 storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002019
+name: measurement - weight of canner storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of canner storage roots the and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002020
+name: measurement - weight of cull storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of cull storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002021
+name: measurement - weight of jumbo storage roots
+namespace: SweetpotatoMethod
+def: "Measure the weight of jumbo storage roots and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002022
+name: measurement - weight of vines per plant harvested method
+namespace: SweetpotatoMethod
+def: "Compute the weight of vines per plant harvested within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002023
+name: measurement - weight of vines per plant planted method
+namespace: SweetpotatoMethod
+def: "Compute the weight of vines per plant planted within the net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002024
+name: vistual estimation - overall storage root disease symptoms
+namespace: SweetpotatoMethod
+def: "Observe the overall storage root disease symptoms and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002025
+name: visual estimation - starch content
+namespace: SweetpotatoMethod
+def: "Observe and taste the starch content of the raw storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002026
+name: visual estimation - vine base color method
+namespace: SweetpotatoMethod
+def: "Observe the base color of the vine and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002027
+name: visual estimation - vine node color method
+namespace: SweetpotatoMethod
+def: "Observe the color of the vine node and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002028
+name: visual estimation - vine tip color method
+namespace: SweetpotatoMethod
+def: "Observe the color of the vine tip and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002029
+name: visual estimation storage root defects
+namespace: SweetpotatoMethod
+def: "Type and/or name of secondary visible storage root defect" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002030
+name: minutes
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002031
+name: mm
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002032
+name: RtSSDef 14 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002033
+name: RtFlsFf 5 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002034
+name: RwRtSta 5 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002035
+name: RwRtTSg 9pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002036
+name: VnBCol 3 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002037
+name: VnNCol 3 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002038
+name: VnTCol 3 pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002039
+name: Average non-commercial storage root weight computation kg
+namespace: SweetpotatoTrait
+def: "The average non-commercial weight of storage roots in kg" []
+synonym: "ANCRW" EXACT []
+synonym: "RtANCRW_Cp_kg" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002041 ! average non-commercial storage root weight
+relationship: variable_of CO_331:0002049 ! computation - average non-commercial weight of storage roots method
+
+[Term]
+id: CO_331:0002040
+name: Average total storage root weight computation kg
+namespace: SweetpotatoTrait
+def: "The average total weight of storage roots in kg" []
+synonym: "ATRW" EXACT []
+synonym: "RtATRW_Cp_kg" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000893 ! kg/plot
+relationship: variable_of CO_331:0002042 ! average total storage root weight
+relationship: variable_of CO_331:0002050 ! computation - average total weight of storage roots method
+
+[Term]
+id: CO_331:0002041
+name: average non-commercial storage root weight
+namespace: SweetpotatoTrait
+def: "The average non-commercial weight of storage roots" []
+synonym: "RtANCRW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0002042
+name: average total storage root weight
+namespace: SweetpotatoTrait
+def: "The average total weight of storage roots" []
+synonym: "RtATRW" EXACT []
+is_a: CO_331:1000008 ! Agronomic_trait
+
+[Term]
+id: CO_331:0002043
+name: estimation - fiber method in raw storage root
+namespace: SweetpotatoMethod
+def: "Observe and taste the raw storage root flesh and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002044
+name: measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the protein content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002045
+name: counting - number of non-commercial storage roots method
+namespace: SweetpotatoMethod
+def: "Count the number of non-commercial storage roots per net plot and record it. Evaluation of the number of all storage roots that weigh less than 100 g per NET plot" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0002046
+name: counting - number of plants established method
+namespace: SweetpotatoMethod
+def: "Count the number of plants established per net plot to be determined 3 weeks after planting and record it" []
+is_a: CO_331:1000012 ! Counting
+
+[Term]
+id: CO_331:0002047
+name: measurement - weight of non-commercial storage root within net plot method
+namespace: SweetpotatoMethod
+def: "Measure the weight of non-commercial storage roots within net plot and record it. Select those that are lighter than 100 g" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002048
+name: visual estimation - total vine production method
+namespace: SweetpotatoMethod
+def: "Observe the total vine production and record it. Total vine production in estimated number of plants" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002049
+name: computation - average non-commercial weight of storage roots method
+namespace: SweetpotatoMethod
+def: "Compute the average non-commercial weight of storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002050
+name: computation - average total weight of storage roots method
+namespace: SweetpotatoMethod
+def: "Compute the average total weight of storage roots per net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002051
+name: storage root beta-carotene concentration in dry weight basis
+namespace: SweetpotatoTrait
+def: "The beta-carotene concentration in dry weight basis of the storage root" []
+synonym: "RtBCDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002052
+name: storage root total carotenoid concentration in dry weight basis
+namespace: SweetpotatoTrait
+def: "The total carotenoid concentration in dry weight basis of the storage root" []
+synonym: "RtTCDw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002053
+name: storage root calcium concentration in fresh weight basis
+namespace: SweetpotatoTrait
+def: "The calcium concentration in fresh weight basis of the storage root" []
+synonym: "RtFlsCaFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002054
+name: storage root zinc concentration in fresh weight basis
+namespace: SweetpotatoTrait
+def: "The zinc concentration in fresh weight basis of the storage root" []
+synonym: "RtFlsZnFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002055
+name: storage root starch content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Starch content in fresh weight basis of the storage root" []
+synonym: "RtStaFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002056
+name: overall disease symptoms of the storage root
+namespace: SweetpotatoTrait
+def: "The overall disease symptoms of the storage root" []
+synonym: "RtDSm" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+
+[Term]
+id: CO_331:0002057
+name: storage root magnesium concentration in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Content of magnesium in fresh weight basis of the storage root" []
+synonym: "RtFlsMgFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002058
+name: Men Farmers preference of cooked  leaf appearance
+namespace: SweetpotatoTrait
+def: "Farmer observe the visual appearance of boiled leaves and rate it" []
+synonym: "MLfApAc_obs_1-5" EXACT []
+synonym: "MLTT_appearance" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002065 ! leaf appearance
+relationship: variable_of CO_331:0002072 ! visual estimation - appearance method
+relationship: variable_of CO_331:0002149 ! LfApAc 3pt. Scale
+
+[Term]
+id: CO_331:0002059
+name: Men Farmers preference of cooked leaf taste
+namespace: SweetpotatoTrait
+def: "Farmer taste leaves samples after cooking and rate it" []
+synonym: "MLfTsAc_obs_1-5" EXACT []
+synonym: "MLTT_taste" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002066 ! leaf flavor
+relationship: variable_of CO_331:0002073 ! tuber flavor after cooking - method
+relationship: variable_of CO_331:0002150 ! LfTsAc 3pt. Scale
+
+[Term]
+id: CO_331:0002060
+name: Men Farmer's preference at pest damage tolerant
+namespace: SweetpotatoTrait
+def: "Farmer's vote for genotype preference at pest damage tolerant" []
+synonym: "MFarPW" EXACT []
+synonym: "MPlPdt_obs_1-3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002067 ! pest damage tolerant
+relationship: variable_of CO_331:0002074 ! visual estimation farmer preference for genotype tolerant of pest- method
+relationship: variable_of CO_331:0002151 ! PlPdt 3pt. Scale
+
+[Term]
+id: CO_331:0002061
+name: Men Farmer's preference of the yielding ability
+namespace: SweetpotatoTrait
+def: "Farmer's vote for genotype preference of the yielding ability" []
+synonym: "MFarYA" EXACT []
+synonym: "MPlYlAb_obs_1-3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002068 ! yielding ability
+relationship: variable_of CO_331:0002075 ! visual estimation farmer  preference for genotype of the yielding ability
+relationship: variable_of CO_331:0002152 ! PlYlAb 3pt. Scale
+
+[Term]
+id: CO_331:0002062
+name: Men preference of the attractiveness of the root skin color.
+namespace: SweetpotatoTrait
+def: "Farmer's vote of the attractiveness of the root skin color of a variety with respect to their local variety  at harvest" []
+synonym: "MFarASrs" EXACT []
+synonym: "MSrSkACol_obs_1-3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002069 ! attractiveness of the storage-root skin color
+relationship: variable_of CO_331:0002076 ! visual estimation farmer  preference for the attractiveness of the storage-root skin color
+relationship: variable_of CO_331:0002153 ! SrSkACol 3pt. Scale
+
+[Term]
+id: CO_331:0002063
+name: Men preference of the attractiveness of the storage-root flesh color.
+namespace: SweetpotatoTrait
+def: "Farmer's vote of the attractiveness of the storage-root flesh color of a variety with respect to their local variety  at harvest" []
+synonym: "MFarASrf" EXACT []
+synonym: "MFSrFlACol_obs_1-3" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002070 ! attractiveness of the storage-root flesh color
+relationship: variable_of CO_331:0002077 ! visual estimation farmer preference for the attractiveness of the  storage-root flesh color
+relationship: variable_of CO_331:0002154 ! SrFlACol 3pt. Scale
+
+[Term]
+id: CO_331:0002064
+name: leaf texture
+namespace: SweetpotatoTrait
+def: "The texture of the leaf" []
+synonym: "BlLfTex" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002065
+name: leaf appearance
+namespace: SweetpotatoTrait
+def: "The visual aspect of leaves" []
+synonym: "BlLfAp" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002066
+name: leaf flavor
+namespace: SweetpotatoTrait
+def: "The flavor of the leaves" []
+synonym: "BlLfTs" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002067
+name: pest damage tolerant
+namespace: SweetpotatoTrait
+def: "The pest damage tolerant of the plant" []
+synonym: "PlPdt" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+
+[Term]
+id: CO_331:0002068
+name: yielding ability
+namespace: SweetpotatoTrait
+def: "Yielding ability of the plant" []
+synonym: "PlYlAb" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+
+[Term]
+id: CO_331:0002069
+name: attractiveness of the storage-root skin color
+namespace: SweetpotatoTrait
+def: "Attractiveness of the storage-root skin color  of a variety with respect to their local variety  at harvest" []
+synonym: "SrSkACol" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+
+[Term]
+id: CO_331:0002070
+name: attractiveness of the storage-root flesh color
+namespace: SweetpotatoTrait
+def: "Attractiveness of the storage-root flesh color  of a variety with respect to their local variety  at harvest" []
+synonym: "SrFlACol" EXACT []
+is_a: CO_331:1000005 ! Biotic_stress_trait
+
+[Term]
+id: CO_331:0002071
+name: visual estimation - texture method
+namespace: SweetpotatoMethod
+def: "Panelist observe the visual texture of boiled leaves and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002072
+name: visual estimation - appearance method
+namespace: SweetpotatoMethod
+def: "Panelist observe the visual appearance of boiled leaves and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002073
+name: tuber flavor after cooking - method
+namespace: SweetpotatoMethod
+def: "Panelists taste leaves samples after cooking and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002074
+name: visual estimation farmer preference for genotype tolerant of pest- method
+namespace: SweetpotatoMethod
+def: "Farmer are encouraged to select the materials and rank the ability of a variety to tolerate pests especially weevils relative to the tolerance of pests of his currently preferred variety using the colour cards system" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002075
+name: visual estimation farmer  preference for genotype of the yielding ability
+namespace: SweetpotatoMethod
+def: "Farmer are encouraged to select the materials and rank the yielding ability of his currently preferred variety using the colour cards system" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002076
+name: visual estimation farmer  preference for the attractiveness of the storage-root skin color
+namespace: SweetpotatoMethod
+def: "Farmer are encouraged to select the materials and rank  for the attractiveness of the storage-root skin color of his currently preferred variety using the colour cards system" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002077
+name: visual estimation farmer preference for the attractiveness of the  storage-root flesh color
+namespace: SweetpotatoMethod
+def: "The farmer is encouraged to rank the attractiveness of the root flesh color of a variety  relative to the root flesh color of their currently preferred variety using the colour cards system" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002078
+name: storage root protein content in fresh weight basis
+namespace: SweetpotatoTrait
+def: "Protein content in fresh weight basis of the storage root" []
+synonym: "RtPrtFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002079
+name: storage root iron concentration in fresh weight basis
+namespace: SweetpotatoTrait
+def: "The iron concentration in fresh weight basis of the storage root" []
+synonym: "RtFlsFeFw" EXACT []
+is_a: CO_331:1000007 ! Quality_trait
+
+[Term]
+id: CO_331:0002080
+name: visual estimation - storage root skin color
+namespace: SweetpotatoMethod
+def: "Observe the predominant color of the storage root skin and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002081
+name: computation - biomass yield in dry weight basis method in tha
+namespace: SweetpotatoMethod
+def: "Computation of the biomass yield in dry weight basis within net plot using the formula" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002082
+name: computation - biomass yield method in th
+namespace: SweetpotatoMethod
+def: "Computation of the biomass yield within net plot using the formula based in tha" []
+is_a: CO_331:1000013 ! Computation
+
+[Term]
+id: CO_331:0002083
+name: measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the calcium concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002084
+name: measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the calcium concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002085
+name: measurement  calcium- near-infrared spectroscopy (nirs) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the calcium concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002086
+name: measurement  calcium- near-infrared spectroscopy (nirs) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the calcium concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002087
+name: measurement  the peonidin content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the peonidin content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002088
+name: measurement  the starch content- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the starch content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002089
+name: measurement  the starch content- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the starch content of the boiled storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002090
+name: measurement  the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the starch content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002091
+name: measurement - vine internode length method
+namespace: SweetpotatoMethod
+def: "Measure vine internode length and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002092
+name: measurement fructose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the fructose content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002093
+name: measurement fructose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the fructose content of the boiled storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002094
+name: measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the fructose content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002095
+name: measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the fructose content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002096
+name: measurement glucose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the glucose content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002097
+name: measurement glucose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the glucose content of the boiled storage root in dry weight and record it." []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002098
+name: measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the glucose content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002099
+name: measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the glucose content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002100
+name: measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the iron concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002101
+name: measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the iron concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002102
+name: measurement iron- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the iron concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002103
+name: measurement iron- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the iron concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002104
+name: measurement maltose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the maltose content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002105
+name: measurement maltose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the maltose content of the boiled storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002106
+name: measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the maltose content of the raw storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002107
+name: measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the maltose content of the raw storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002108
+name: measurement protein - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the protein content of the boiled storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002109
+name: measurement protein- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the protein content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002110
+name: measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the protein content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002111
+name: measurement sucrose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the sucrose content of the boiled storage root in fresh weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002112
+name: measurement sucrose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the sucrose content of the boiled storage root in dry weight and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002113
+name: measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the sucrose content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002114
+name: measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the sucrose content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002115
+name: measurement the amylose content - near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the amylose content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002116
+name: measurement the anthocyanin content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the anthocyanin content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002117
+name: measurement the asparagine content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the asparagine content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002118
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the boiled storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002119
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the baked storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002120
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the baked storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002121
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the boiled storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002122
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in dry weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002123
+name: measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the beta-carotene concentration of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002124
+name: measurement the cyanidin content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the cyanidin content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002125
+name: measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the magnesium concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002126
+name: measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the magnesium concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002127
+name: measurement the magnesium- near-infrared spectroscopy (nirs) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the magnesium concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002128
+name: measurement the magnesium- near-infrared spectroscopy (nirs) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the magnesium concentration in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002129
+name: measurement the phenol content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the phenol content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002130
+name: measurement the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the starch content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002131
+name: measurement the total monomeric anthocyanin content- near-infrared spectroscopy (nirs) method
+namespace: SweetpotatoMethod
+def: "Measure the total monomeric anthocyanin content of the storage root and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002132
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the boiled storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002133
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the baked storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002134
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the baked storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002135
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the boiled storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002136
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002137
+name: measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+namespace: SweetpotatoMethod
+def: "Measure the total beta-carotene concentration of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002138
+name: measurement total sugar - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the total sugar content of the boiled storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002139
+name: measurement total sugar - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the total sugar content of the boiled storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002140
+name: measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the total sugar content of the raw storage root in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002141
+name: measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the total sugar content of the raw storage root in fresh weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002142
+name: measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the zinc concentration in dry weight basis and record it" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002143
+name: measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the zinc concentration in fresh weight basis and record it with ICP" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002144
+name: measurement zinc- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+namespace: SweetpotatoMethod
+def: "Measure the zinc concentration in fresh weight basis and record it  with NIRS" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002145
+name: measurement zinc- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+namespace: SweetpotatoMethod
+def: "Measure the zinc concentration in dry weight basis and record it with NIRS" []
+is_a: CO_331:1000011 ! Measurement
+
+[Term]
+id: CO_331:0002146
+name: visual estimation - storage root appearance -method ncsu
+namespace: SweetpotatoMethod
+def: "Observe the appearance of the storage root and rate it" []
+is_a: CO_331:1000014 ! Estimation
+
+[Term]
+id: CO_331:0002147
+name: RnWR 5 pt. scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000015 ! Ordinal
+
+[Term]
+id: CO_331:0002148
+name: LfTexAc 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002149
+name: LfApAc 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002150
+name: LfTsAc 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002151
+name: PlPdt 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002152
+name: PlYlAb 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002153
+name: SrSkACol 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002154
+name: SrFlACol 3pt. Scale
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
+
+[Term]
+id: CO_331:0002155
+name: PltsAvail
+namespace: SweetpotatoScale
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:1000001
@@ -7063,102 +8657,107 @@ namespace: SweetpotatoScale
 is_a: CO_331:1000002 ! Scales
 
 [Term]
+id: CO_331:1000030
+name: Nominal
+namespace: SweetpotatoScale
+is_a: CO_331:1000002 ! Scales
+
+[Term]
+id: CO_331:20000
+name: Men Farmers preference of cooked leaf texture test
+namespace: SweetpotatoTrait
+def: "Farmers preference of cooked leaf texture test" []
+synonym: "MLfTexAc_obs_1-5" EXACT []
+synonym: "MLTT_texture" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0002064 ! leaf texture
+relationship: variable_of CO_331:0002071 ! visual estimation - texture method
+relationship: variable_of CO_331:0002148 ! LfTexAc 3pt. Scale
+
+[Term]
 id: CO_331:2000001
 name: plant uniformity
 namespace: SweetpotatoTrait
-def: "Uniformity of height of newly emerging vines" []
+def: "The uniformity of the plant. Estimation of height uniformity of newly emerging vines" []
 synonym: "PltUni" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
 [Term]
 id: CO_331:2000002
-name: estimation of plant uniformity
+name: visual estimation - plant uniformity
 namespace: SweetpotatoMethod
-def: "visual estimation" []
+def: "Observe the plant uniformity and rate it. Estimation of height uniformity of newly emerging vines" []
 is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:2000003
-name: pltuni 10 pt. scale
+name: PltUni 6 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
-
-[Term]
-id: CO_331:2000004
-name: Virus symptoms 2 estimating 1-9
-namespace: SweetpotatoTrait
-def: "Virus symptoms 2." [Grueneberg2010:Def_14]
-comment: | Context of use:  Evaluation in Trials | Growth stage: W13 | Variable status: Recommended | Scientist: W. Grueneberg | Institution: CIP, SASHA | Language of submission: EN | Date of submission: 2015-10-22.
-synonym: "VIR2" EXACT []
-synonym: "VirSm2_Et_1to9" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000094 ! virus symptoms
-relationship: variable_of CO_331:0000873 ! virus symptoms evaluation
-relationship: variable_of CO_331:0000874 ! virsym 9 pt. scale
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:2000005
 name: Plant uniformity estimating 0-9
 namespace: SweetpotatoTrait
-def: "Estimation of height uniformity of newly emerging vines. 0=Highly Variable, 9=Uniform" []
+def: "The uniformity of the plant. Estimation of height uniformity of newly emerging vines estimating 0-9" []
 synonym: "PltUni_Et_0to9" EXACT []
 synonym: "UNIFORM" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:2000001 ! plant uniformity
-relationship: variable_of CO_331:2000002 ! estimation of plant uniformity
-relationship: variable_of CO_331:2000003 ! pltuni 10 pt. scale
+relationship: variable_of CO_331:2000002 ! visual estimation - plant uniformity
+relationship: variable_of CO_331:2000003 ! PltUni 6 pt. scale
 
 [Term]
 id: CO_331:2000006
 name: plant production
 namespace: SweetpotatoTrait
-def: "Intensity of new vine production" []
+def: "The production of the plant" []
 synonym: "PltProd" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
 [Term]
 id: CO_331:2000007
-name: estimation of plant production
+name: visual estimation - plant production
 namespace: SweetpotatoMethod
-def: "visual estimation" []
+def: "Observe the plant production the and rate it. Estimation of intensity of new vine production" []
 is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:2000008
-name: pltprod 10 pt. scale
+name: PltProd 6 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000019 ! Numerical
 
 [Term]
 id: CO_331:2000009
 name: Plant production estimating 0-9
 namespace: SweetpotatoTrait
-def: "Estimation of intensity of new vine production. 0=None, 9=Profuse" []
+def: "The production of the plant estimating 0-9" []
 synonym: "PltProd_Et_0to9" EXACT []
 synonym: "PRODUCTION" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:2000006 ! plant production
-relationship: variable_of CO_331:2000007 ! estimation of plant production
-relationship: variable_of CO_331:2000008 ! pltprod 10 pt. scale
+relationship: variable_of CO_331:2000007 ! visual estimation - plant production
+relationship: variable_of CO_331:2000008 ! PltProd 6 pt. scale
 
 [Term]
 id: CO_331:2000010
 name: plant earliness
 namespace: SweetpotatoTrait
-def: "Earliness of new vine production " []
+def: "The earliness of the plant" []
 synonym: "PltEar" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
 [Term]
 id: CO_331:2000011
-name: observation of plant earliness
+name: visual estimation - plant earliness
 namespace: SweetpotatoMethod
-def: "visual estimation" []
+def: "Observe the plant earliness and rate it. Estimation of earliness of new vine production" []
 is_a: CO_331:1000014 ! Estimation
 
 [Term]
 id: CO_331:2000012
-name: pltear 3 pt. scale
+name: PltEar 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
 
@@ -7166,19 +8765,19 @@ is_a: CO_331:1000015 ! Ordinal
 id: CO_331:2000013
 name: Plant earliness estimating 1-3
 namespace: SweetpotatoTrait
-def: "Estimation of earliness of new vine production. 1=Late, 2=Mid, 3=Early" []
+def: "The earliness of the plant estimating 0-9" []
 synonym: "EARLINESS" EXACT []
 synonym: "PltEar_Et_1to3" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:2000010 ! plant earliness
-relationship: variable_of CO_331:2000011 ! observation of plant earliness
-relationship: variable_of CO_331:2000012 ! pltear 3 pt. scale
+relationship: variable_of CO_331:2000011 ! visual estimation - plant earliness
+relationship: variable_of CO_331:2000012 ! PltEar 3 pt. scale
 
 [Term]
 id: CO_331:2000014
 name: total vine production
 namespace: SweetpotatoTrait
-def: "Total Vine Production" []
+def: "The total vine production of the plant. Total vine production in estimated number of plants" []
 synonym: "TtlVnProd" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
@@ -7188,17 +8787,18 @@ name: Total vine production estimating number
 namespace: SweetpotatoTrait
 def: "Total vine production in estimated number of plants" []
 synonym: "TOTALPROD" EXACT []
+synonym: "TtlBedProd_Et_no" EXACT []
 synonym: "TtlVnProd_Et_no" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000956 ! number
-relationship: variable_of CO_331:2000007 ! estimation of plant production
+relationship: variable_of CO_331:0000956 ! TtlVnProd
+relationship: variable_of CO_331:0002048 ! visual estimation - total vine production method
 relationship: variable_of CO_331:2000014 ! total vine production
 
 [Term]
 id: CO_331:2000016
-name: plants available
+name: plants available counting number
 namespace: SweetpotatoTrait
-def: "Plants Available for planting" []
+def: "Plants available for planting measured in number of plants counted" []
 synonym: "PltsAvail" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
@@ -7206,123 +8806,120 @@ is_a: CO_331:1000008 ! Agronomic_trait
 id: CO_331:2000017
 name: Plants available counting number
 namespace: SweetpotatoTrait
-def: "Plants Available for planting measured in number of plants counted" []
+def: "Plants available for planting measured in number of plants counted" []
 synonym: "AVAILABLE" EXACT []
-synonym: "PltsAvail_Ct_No" EXACT []
+synonym: "PltsAvail_Ct_no" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000885 ! evaluation of plants
-relationship: variable_of CO_331:0000956 ! number
-relationship: variable_of CO_331:2000016 ! plants available
+relationship: variable_of CO_331:0000885 ! counting - number of plants available
+relationship: variable_of CO_331:0002155 ! PltsAvail
+relationship: variable_of CO_331:2000016 ! plants available counting number
 
 [Term]
 id: CO_331:2000022
-name: measurement of cooked fructose content
+name: measurement - fructose content of the boiled storage root
 namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
+def: "Compute the fructose content of the boiled storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:2000023
-name: measurement of cooked glucose content
+name: measurement - glucose content of the boiled storage root
 namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
+def: "Compute the glucose content of the boiled storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:2000024
-name: measurement of cooked sucrose content
+name: measurement - sucrose content of the boiled storage root
 namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
+def: "Compute the sucrose content of the boiled storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:2000025
-name: measurement of cooked maltose content
+name: measurement - maltose content of the boiled storage root
 namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
-
-[Term]
-id: CO_331:2000026
-name: measurement of cooked starch content
-namespace: SweetpotatoMethod
-is_a: CO_331:1000011 ! Measurement
+def: "Compute the maltose content of the boiled storage root in percentage using the formula" []
+is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:2000027
-name: Starch content of cooked storage roots percent
+name: Content of starch in dry weight basis in boiled storage roots measuring percentage
 namespace: SweetpotatoTrait
-def: "Starch content of the cooked storage root expressed as percent dry weight" []
-synonym: "CkRtSta_Ms_pct" EXACT []
-synonym: "COOKSTAR" EXACT []
+def: "Starch content in dry weight basis in boiled storage roots measuring g per 100g" []
+synonym: "BlRtSta_Ms_%DW" EXACT []
+synonym: "BOILSTARDW" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000115 ! starch content
+relationship: variable_of CO_331:0000115 ! storage root starch content in dry weight basis
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:2000026 ! measurement of cooked starch content
+relationship: variable_of CO_331:0002089 ! measurement  the starch content- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
 
 [Term]
 id: CO_331:2000028
-name: Sucrose content of cooked storage roots percent
+name: Content of sucrose in boiled storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Sucrose content of the raw storage root expressed as percent" []
-synonym: "CkRtSuc_Ms_pct" EXACT []
-synonym: "COOKSUCR" EXACT []
+def: "The sucrose content of the boiled storage root computing percent" []
+synonym: "BlRtSuc_Ms_pct" EXACT []
+synonym: "BOILSUCRP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000124 ! sucrose content
+relationship: variable_of CO_331:0000124 ! storage root sucrose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:2000024 ! measurement of cooked sucrose content
+relationship: variable_of CO_331:2000024 ! measurement - sucrose content of the boiled storage root
 
 [Term]
 id: CO_331:2000029
-name: Maltose content of cooked storage roots percent
+name: Content of maltose in boiled storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Maltose content of the raw storage root expressed as percent" []
-synonym: "CkRtMal_Ms_pct" EXACT []
-synonym: "COOKMALT" EXACT []
+def: "The maltose content of the boiled storage root computing percent" []
+synonym: "BlRtMal_Ms_pct" EXACT []
+synonym: "BOILMALTP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000127 ! maltose content
+relationship: variable_of CO_331:0000127 ! storage root maltose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:2000025 ! measurement of cooked maltose content
+relationship: variable_of CO_331:2000025 ! measurement - maltose content of the boiled storage root
 
 [Term]
 id: CO_331:2000030
-name: Glucose content of cooked storage roots percent
+name: Content of glucose in boiled storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Glucose content of the raw storage root expressed as percent" []
-synonym: "CkRtGlu_Ms_pct" EXACT []
-synonym: "COOKGLUC" EXACT []
+def: "The glucose content of the boiled storage root computing percent" []
+synonym: "BlRtGlu_Ms_pct" EXACT []
+synonym: "BOILGLUCP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000121 ! glucose content
+relationship: variable_of CO_331:0000121 ! storage root glucose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:2000023 ! measurement of cooked glucose content
+relationship: variable_of CO_331:2000023 ! measurement - glucose content of the boiled storage root
 
 [Term]
 id: CO_331:2000031
-name: Fructose content of cooked storage roots percent
+name: Content of fructose in boiled storage roots computing percent
 namespace: SweetpotatoTrait
-def: "Fructose content of the raw storage root expressed as percent" []
-synonym: "CkRtFru_Ms_pct" EXACT []
-synonym: "COOKFRUC" EXACT []
+def: "The fructose content of the boiled storage root computing percent" []
+synonym: "BlRtFru_Ms_pct" EXACT []
+synonym: "BOILFRUCP" EXACT []
 is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000118 ! fructose content
+relationship: variable_of CO_331:0000118 ! storage root fructose content
 relationship: variable_of CO_331:0000900 ! %
-relationship: variable_of CO_331:2000022 ! measurement of cooked fructose content
+relationship: variable_of CO_331:2000022 ! measurement - fructose content of the boiled storage root
 
 [Term]
 id: CO_331:2000035
-name: commercial root number per plant - method
+name: computing - number of commercial storage roots per plant harvested method
 namespace: SweetpotatoMethod
-def: "Number of commercial roots per plot / Number of plants harvested per plot" []
+def: "Compute the number of commercial storage roots per plant harvested using the formula" []
 is_a: CO_331:1000013 ! Computation
 
 [Term]
 id: CO_331:2000036
-name: Number of commercial storage roots harvested per plant
+name: Number of commercial storage roots per plant harvested
 namespace: SweetpotatoTrait
-def: "Number of commercial roots per plot / Number of plants harvested per plot" []
-synonym: "CMNROOT" EXACT []
-synonym: "CMRPP" EXACT []
-synonym: "RtCmN_Ct_rtplant" EXACT []
+def: "Evaluation of the number of all storage roots that weigh more or equal than 100 g per plant harvested" []
+synonym: "NCRPP" EXACT []
+synonym: "RtNCmh_Cp_rtplant" EXACT []
 is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000212 ! number of commercial storage roots
-relationship: variable_of CO_331:0000891 ! roots/ plant
-relationship: variable_of CO_331:2000035 ! commercial root number per plant - method
+relationship: variable_of CO_331:0000891 ! storage root/plant
+relationship: variable_of CO_331:2000035 ! computing - number of commercial storage roots per plant harvested method
 
 [Typedef]
 id: method_of

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -3,7 +3,6 @@ date: 12:02:2018 19:35
 saved-by: vagrant
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: SweetpotatoDefault
-ontology: TEMP
 
 [Term]
 id: CO_331:0000000
@@ -25,12 +24,14 @@ name: visual estimation - plant type method
 namespace: SweetpotatoMethod
 def: "Observe the plant type and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000001 ! plant type
 
 [Term]
 id: CO_331:0000003
 name: PtTyp 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000002 ! visual estimation - plant type method
 
 [Term]
 id: CO_331:0000004
@@ -46,12 +47,14 @@ name: visual estimation - ground cover method
 namespace: SweetpotatoMethod
 def: "Observe the ground cover and rate it. Estimated percentage of ground cover recorded 35-40 days after planting" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000004 ! ground cover
 
 [Term]
 id: CO_331:0000006
 name: VnFolGRnv 4pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000005 ! visual estimation - ground cover method
 
 [Term]
 id: CO_331:0000007
@@ -67,12 +70,14 @@ name: visual estimation - twining method
 namespace: SweetpotatoMethod
 def: "Observe the twining and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000007 ! twining
 
 [Term]
 id: CO_331:0000009
 name: PtTwg 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000008 ! visual estimation - twining method
 
 [Term]
 id: CO_331:0000010
@@ -88,12 +93,14 @@ name: visual estimation - vine predominant color method
 namespace: SweetpotatoMethod
 def: "Observe the predominant color of the vine and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000010 ! vine predominant color
 
 [Term]
 id: CO_331:0000012
 name: VnColP 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000011 ! visual estimation - vine predominant color method
 
 [Term]
 id: CO_331:0000013
@@ -109,12 +116,14 @@ name: visual estimation - vine secondary color method
 namespace: SweetpotatoMethod
 def: "Observe the secondary color of the vine and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000013 ! vine secondary color
 
 [Term]
 id: CO_331:0000015
 name: VnColS 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000014 ! visual estimation - vine secondary color method
 
 [Term]
 id: CO_331:0000016
@@ -130,12 +139,14 @@ name: visual estimation - vine apex pubescence method
 namespace: SweetpotatoMethod
 def: "Observe the pubescence of the vine apex and rate it. Degree of hairiness of immature leaves recorded at the apex of the vines" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000016 ! vine tips pubescence
 
 [Term]
 id: CO_331:0000018
 name: VnTipP 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000017 ! visual estimation - vine apex pubescence method
 
 [Term]
 id: CO_331:0000019
@@ -151,12 +162,14 @@ name: visual estimation - leaf general outline method
 namespace: SweetpotatoMethod
 def: "Observe the leaf general outline and rate it. Described from leaves located in the middle section of the vine" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000019 ! leaf general outline
 
 [Term]
 id: CO_331:0000021
 name: LfOut 7 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000020 ! visual estimation - leaf general outline method
 
 [Term]
 id: CO_331:0000022
@@ -172,12 +185,14 @@ name: visual estimation - leaf lobe type
 namespace: SweetpotatoMethod
 def: "Observe the leaf lobe type and rate it. Described from leaves located in the middle section of the vine" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000022 ! leaf lobe type
 
 [Term]
 id: CO_331:0000024
 name: LfLbT 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000023 ! visual estimation - leaf lobe type
 
 [Term]
 id: CO_331:0000025
@@ -193,12 +208,14 @@ name: counting - leaf lobe number
 namespace: SweetpotatoMethod
 def: "Count the number of leaf lobes and rate it. Described from leaves located in the middle section of the vine" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000025 ! leaf lobe number
 
 [Term]
 id: CO_331:0000027
 name: LfLbN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000026 ! counting - leaf lobe number
 
 [Term]
 id: CO_331:0000028
@@ -214,12 +231,14 @@ name: visual estimation - leaf central lobe shape
 namespace: SweetpotatoMethod
 def: "Observe the leaf central lobe shape and rate it. Described from leaves located in the middle section of the vine" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000028 ! leaf central lobe shape
 
 [Term]
 id: CO_331:0000030
 name: LfLCS 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000029 ! visual estimation - leaf central lobe shape
 
 [Term]
 id: CO_331:0000031
@@ -235,12 +254,14 @@ name: visual estimation - mature leaf size
 namespace: SweetpotatoMethod
 def: "Observe the mature leaf size and rate it. Length from the basal lobes to the tip of the leaves. Record the average expression of at least 3 leaves located in the middle section of the vine" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000031 ! mature leaf size
 
 [Term]
 id: CO_331:0000033
 name: LfLMS 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000032 ! visual estimation - mature leaf size
 
 [Term]
 id: CO_331:0000034
@@ -256,12 +277,14 @@ name: visual estimation - abaxial leaf vein pigmentation
 namespace: SweetpotatoMethod
 def: "Observe the pigmentation of the abaxial leaf vein and rate it. Describe the most frequent expression of the distribution of the anthocyanin (purple) pigmentation shown in the veins of the lower surface of leaves" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000034 ! abaxial leaf vein pigmentation
 
 [Term]
 id: CO_331:0000036
 name: LfAVP 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000035 ! visual estimation - abaxial leaf vein pigmentation
 
 [Term]
 id: CO_331:0000037
@@ -277,12 +300,14 @@ name: visual estimation - mature leaf color
 namespace: SweetpotatoMethod
 def: "Observe the mature leaf color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000037 ! mature leaf color
 
 [Term]
 id: CO_331:0000039
 name: LfCMt 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000038 ! visual estimation - mature leaf color
 
 [Term]
 id: CO_331:0000040
@@ -298,12 +323,14 @@ name: visual estimation - inmature leaf color
 namespace: SweetpotatoMethod
 def: "Observe the immature leaf color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000040 ! immature leaf color
 
 [Term]
 id: CO_331:0000042
 name: LfColI 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000041 ! visual estimation - inmature leaf color
 
 [Term]
 id: CO_331:0000043
@@ -319,12 +346,14 @@ name: visual estimation -petiole pigmentation
 namespace: SweetpotatoMethod
 def: "Observe the petiole pigmentation and rate it. Distribution of anthocyanin (purple) pigmentation in the petioles of leaves" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000043 ! petiole pigmentation
 
 [Term]
 id: CO_331:0000045
 name: FrPtP 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000044 ! visual estimation -petiole pigmentation
 
 [Term]
 id: CO_331:0000046
@@ -340,12 +369,14 @@ name: visual estimation - flower color
 namespace: SweetpotatoMethod
 def: "Observe the flower color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000046 ! flower color
 
 [Term]
 id: CO_331:0000048
 name: Frnol 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000047 ! visual estimation - flower color
 
 [Term]
 id: CO_331:0000049
@@ -360,6 +391,7 @@ id: CO_331:0000051
 name: RtSknColP 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002080 ! visual estimation - storage root skin color
 
 [Term]
 id: CO_331:0000052
@@ -375,12 +407,14 @@ name: visual estimation - storage root skin intensity of predominant color
 namespace: SweetpotatoMethod
 def: "Observe the predominant color intensity of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000052 ! storage root skin intensity of predominant color
 
 [Term]
 id: CO_331:0000054
 name: RtSknColPI 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000053 ! visual estimation - storage root skin intensity of predominant color
 
 [Term]
 id: CO_331:0000055
@@ -396,12 +430,14 @@ name: visual estimation - storage root skin secondary color
 namespace: SweetpotatoMethod
 def: "Observe the secondary skin color of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000055 ! storage root skin secondary skin color
 
 [Term]
 id: CO_331:0000057
 name: RtSknColS 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000056 ! visual estimation - storage root skin secondary color
 
 [Term]
 id: CO_331:0000058
@@ -417,12 +453,14 @@ name: visual estimation - storage root flesh predominant color
 namespace: SweetpotatoMethod
 def: "Observe the predominant color of the storage root flesh and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000058 ! storage root predominant flesh color
 
 [Term]
 id: CO_331:0000060
 name: RtFlsColP 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000059 ! visual estimation - storage root flesh predominant color
 
 [Term]
 id: CO_331:0000061
@@ -438,12 +476,14 @@ name: visual estimation - storage root flesh secondary color
 namespace: SweetpotatoMethod
 def: "Observe the secondary color of the storage root flesh and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000061 ! storage root flesh secondary color
 
 [Term]
 id: CO_331:0000063
 name: RtFlsColS 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000062 ! visual estimation - storage root flesh secondary color
 
 [Term]
 id: CO_331:0000064
@@ -459,12 +499,14 @@ name: visual estimation - storage root flesh distribution of secondary color
 namespace: SweetpotatoMethod
 def: "Observe the distribution of secondary color of the storage root flesh and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000064 ! storage root flesh distribution of secondary color
 
 [Term]
 id: CO_331:0000066
 name: RtFlsColSD 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000065 ! visual estimation - storage root flesh distribution of secondary color
 
 [Term]
 id: CO_331:0000067
@@ -480,6 +522,7 @@ name: visual estimation - storage root shape
 namespace: SweetpotatoMethod
 def: "Observe the shape of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000067 ! storage root primary shape
 
 [Term]
 id: CO_331:0000070
@@ -495,12 +538,14 @@ name: visual estimation - storage root latex production. amount of latex observe
 namespace: SweetpotatoMethod
 def: "Observe the latex production of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000070 ! storage root latex production
 
 [Term]
 id: CO_331:0000072
 name: RtLxP 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000071 ! visual estimation - storage root latex production. amount of latex observed after cross sectioning medium-sized storage roots
 
 [Term]
 id: CO_331:0000073
@@ -516,12 +561,14 @@ name: visual estimation - storage root oxidation
 namespace: SweetpotatoMethod
 def: "Observe the oxidation of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000073 ! storage root oxidation
 
 [Term]
 id: CO_331:0000075
 name: RtOxi 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000074 ! visual estimation - storage root oxidation
 
 [Term]
 id: CO_331:0000076
@@ -537,12 +584,14 @@ name: visual estimation - storage root size
 namespace: SweetpotatoMethod
 def: "Observe the storage root size and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000076 ! storage root size
 
 [Term]
 id: CO_331:0000078
 name: RtSiz 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000077 ! visual estimation - storage root size
 
 [Term]
 id: CO_331:0000079
@@ -566,6 +615,7 @@ name: computation - total storage roots yield method
 namespace: SweetpotatoMethod
 def: "Compute the yield of the total storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000082 ! total storage roots yield
 
 [Term]
 id: CO_331:0000085
@@ -581,6 +631,7 @@ name: computation - harvest index evaluation method
 namespace: SweetpotatoMethod
 def: "Compute the total weight of commercial tubers per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000085 ! harvest index
 
 [Term]
 id: CO_331:0000088
@@ -596,12 +647,14 @@ name: visual estimation - reaction to sweet potato weevil
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to sweet potato weevil and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000088 ! reaction to sweet potato weevil
 
 [Term]
 id: CO_331:0000090
 name: RnWvl 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000089 ! visual estimation - reaction to sweet potato weevil
 
 [Term]
 id: CO_331:0000091
@@ -617,12 +670,14 @@ name: visual estimation - reaction of the plant to alternaria spp
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Early Blight: Alternaria spp and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000091 ! reaction to alternaria spp
 
 [Term]
 id: CO_331:0000093
 name: RnAlt 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000092 ! visual estimation - reaction of the plant to alternaria spp
 
 [Term]
 id: CO_331:0000094
@@ -638,12 +693,14 @@ name: visual estimation - virus symptoms
 namespace: SweetpotatoMethod
 def: "Observe the virus symptoms and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000094 ! virus symptoms
 
 [Term]
 id: CO_331:0000096
 name: RnVir 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000095 ! visual estimation - virus symptoms
 
 [Term]
 id: CO_331:0000097
@@ -658,6 +715,7 @@ id: CO_331:0000099
 name: RtCrk 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000238 ! estimation - storage root cracking method
 
 [Term]
 id: CO_331:0000100
@@ -672,18 +730,21 @@ id: CO_331:00001024
 name: RnSPWF 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000482 ! visual estimation - reaction of the plant to sweet potato whitefly
 
 [Term]
 id: CO_331:00001026
 name: RnSPMth 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000483 ! visual estimation - reaction of the plant to sweet potato moth
 
 [Term]
 id: CO_331:00001028
 name: RnMth 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000484 ! visual estimation - reaction of the plant to moth
 
 [Term]
 id: CO_331:0000103
@@ -698,84 +759,98 @@ id: CO_331:00001030
 name: RnSPSB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000485 ! visual estimation - reaction of the plant to sweet potato stem borer
 
 [Term]
 id: CO_331:00001032
 name: RnIns 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000486 ! visual estimation - response of the plant to other insects
 
 [Term]
 id: CO_331:00001034
 name: RnRFN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000487 ! visual estimation - reaction of the plant to reniform nematode
 
 [Term]
 id: CO_331:00001036
 name: RnStN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000488 ! visual estimation - reaction of the plant to sting nematode
 
 [Term]
 id: CO_331:00001038
 name: RnBRR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000489 ! visual estimation - reaction of the plant to brown ring rot
 
 [Term]
 id: CO_331:00001040
 name: RnRLN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000490 ! visual estimation - reaction of the plant to root lesion nematode
 
 [Term]
 id: CO_331:00001041
 name: RnON 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000491 ! visual estimation - reaction of the plant to other nematodes
 
 [Term]
 id: CO_331:00001043
 name: RnWR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000492 ! visual estimation - reaction of the plant to wilt rot
 
 [Term]
 id: CO_331:00001045
 name: RnFRS 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000493 ! visual estimation - reaction of the plant to fusarium surface rot
 
 [Term]
 id: CO_331:00001047
 name: RnFRR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000494 ! visual estimation - reaction of the plant to fusarium root rot
 
 [Term]
 id: CO_331:00001049
 name: RnSBC 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000495 ! visual estimation - reaction of the plant to sclerotial blight and circular spot
 
 [Term]
 id: CO_331:00001051
 name: RnBR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000496 ! visual estimation - reaction of the plant to black rot
 
 [Term]
 id: CO_331:00001053
 name: RnScrf 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000497 ! visual estimation - reaction of the plant to scurf
 
 [Term]
 id: CO_331:00001055
 name: RnSR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000498 ! visual estimation - reaction of the plant to soft rot
 
 [Term]
 id: CO_331:0000106
@@ -799,6 +874,7 @@ name: visual estimation - total sugar content
 namespace: SweetpotatoMethod
 def: "Observe the total sugar content of the raw storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000402 ! storage root total sugar content
 
 [Term]
 id: CO_331:0000112
@@ -813,6 +889,26 @@ id: CO_331:00001127
 name: g/100g
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002092 ! measurement fructose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002093 ! measurement fructose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002094 ! measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002095 ! measurement fructose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002096 ! measurement glucose- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002097 ! measurement glucose- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002098 ! measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002099 ! measurement glucose- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002104 ! measurement maltose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002105 ! measurement maltose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002106 ! measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002107 ! measurement maltose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002111 ! measurement sucrose - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002112 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002113 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002114 ! measurement sucrose - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002138 ! measurement total sugar - near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002139 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002140 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002141 ! measurement total sugar - near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
 
 [Term]
 id: CO_331:0000115
@@ -868,6 +964,7 @@ name: estimation - fiber content
 namespace: SweetpotatoMethod
 def: "Observe the fiber content of storage roots evaluated in percentage fresh weight" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000130 ! storage root fiber content
 
 [Term]
 id: CO_331:0000133
@@ -883,12 +980,14 @@ name: visual estimation - flesh color of boiled storage roots method
 namespace: SweetpotatoMethod
 def: "Visual estimation- Observe the flesh color of boiled storage roots of flesh color of cooked roots immediately after cooking" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000133 ! flesh color of boiled storage roots
 
 [Term]
 id: CO_331:0000135
 name: RtCb 3pt scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000134 ! visual estimation - flesh color of boiled storage roots method
 
 [Term]
 id: CO_331:0000136
@@ -904,6 +1003,7 @@ name: estimation - texture method
 namespace: SweetpotatoMethod
 def: "Taste the boiled storage root flesh texture and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000136 ! storage root flesh texture
 
 [Term]
 id: CO_331:0000139
@@ -919,12 +1019,14 @@ name: estimation - sweetness method
 namespace: SweetpotatoMethod
 def: "Taste the boiled storage root flesh sweetness and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000139 ! boiled storage root flesh sweetness
 
 [Term]
 id: CO_331:0000141
 name: RtFlsSwt 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000140 ! estimation - sweetness method
 
 [Term]
 id: CO_331:0000142
@@ -940,6 +1042,7 @@ name: computation - storage root dry matter content
 namespace: SweetpotatoMethod
 def: "Compute the storage root dry matter content using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000142 ! storage root dry matter content
 
 [Term]
 id: CO_331:0000145
@@ -947,6 +1050,7 @@ name: counting - number of commercial storage roots method
 namespace: SweetpotatoMethod
 def: "Count the number of commercial storage roots per net plot and record it. Evaluation of the number of all storage roots that weigh more or equal than 100 g per NET plot" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000212 ! number of commercial storage roots
 
 [Term]
 id: CO_331:0000146
@@ -954,6 +1058,7 @@ name: measurement - weight of commercial storage root within net plot method
 namespace: SweetpotatoMethod
 def: "Measure the weight of commercial storage roots within net plot and record it. Select those that are heavier or equal than 100 g" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000218 ! weight of commercial storage roots
 
 [Term]
 id: CO_331:0000147
@@ -1041,12 +1146,14 @@ name: estimation - vine internode length method
 namespace: SweetpotatoMethod
 def: "Measure vine internode length and rate it. Average expression of at least three internodes located in the middle section of the vine" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000153 ! vine internode length
 
 [Term]
 id: CO_331:0000155
 name: VnInLg 5pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000154 ! estimation - vine internode length method
 
 [Term]
 id: CO_331:0000156
@@ -1074,6 +1181,7 @@ name: measurement - vine internode diameter
 namespace: SweetpotatoMethod
 def: "Measure vine internode diameter and rate it. Average expression of at least three internodes located in the middle section of the vine" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000157 ! vine internode diameter
 
 [Term]
 id: CO_331:0000160
@@ -1209,12 +1317,14 @@ name: measurement - petiole length
 namespace: SweetpotatoMethod
 def: "Measure petiole length and rate it. Average petiole length from the base to the insertion with the blade of at least 3 leaves in the middle portion of a main vine" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000170 ! petiole length
 
 [Term]
 id: CO_331:0000172
 name: FrPtL 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000171 ! measurement - petiole length
 
 [Term]
 id: CO_331:0000173
@@ -1376,6 +1486,7 @@ name: counting - number of plants planted method
 namespace: SweetpotatoMethod
 def: "Count the number of plants planted per net plot and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000303 ! number of plants planted
 
 [Term]
 id: CO_331:0000192
@@ -1415,12 +1526,14 @@ name: estimation - observation of plant vigor method
 namespace: SweetpotatoMethod
 def: "Observe the vigor of the vine and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000194 ! vine vigor
 
 [Term]
 id: CO_331:0000196
 name: VnVg 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000195 ! estimation - observation of plant vigor method
 
 [Term]
 id: CO_331:0000197
@@ -1461,12 +1574,14 @@ name: visual estimation - storage root appearance
 namespace: SweetpotatoMethod
 def: "Observe the appearance of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000199 ! storage root appearance
 
 [Term]
 id: CO_331:0000201
 name: RtFrm 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000200 ! visual estimation - storage root appearance
 
 [Term]
 id: CO_331:0000202
@@ -1494,12 +1609,14 @@ name: visual estimation - storage root damage
 namespace: SweetpotatoMethod
 def: "Observe the storage root damage and rate it. Observe storage root defects: prominent, including cracks, veins, constrictions and grooves, or a predominance of pencil roots" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000203 ! storage root damage
 
 [Term]
 id: CO_331:0000205
 name: RtDam 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000204 ! visual estimation - storage root damage
 
 [Term]
 id: CO_331:0000206
@@ -1540,6 +1657,7 @@ name: counting - number of plants with storage roots method
 namespace: SweetpotatoMethod
 def: "Count the number of plants with storage roots within net plot and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000208 ! number of plants with storage roots
 
 [Term]
 id: CO_331:0000211
@@ -1647,6 +1765,7 @@ name: measurement - weight of vines method
 namespace: SweetpotatoMethod
 def: "Measure the weight of vines after harvest per net plot in kg and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000224 ! vine weight
 
 [Term]
 id: CO_331:0000227
@@ -1666,6 +1785,7 @@ name: computation - number of storage roots per plant harvested method
 namespace: SweetpotatoMethod
 def: "Compute the number of storage roots per plant harvested within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000079 ! number of storage roots
 
 [Term]
 id: CO_331:0000230
@@ -1685,6 +1805,7 @@ name: computation - number of storage roots per plot method
 namespace: SweetpotatoMethod
 def: "Compute the number of storage roots per plot in net plot after harvest using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000079 ! number of storage roots
 
 [Term]
 id: CO_331:0000233
@@ -1712,6 +1833,7 @@ name: computation - total storage root weight per net plot method
 namespace: SweetpotatoMethod
 def: "Compute the total weight of storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000234 ! total storage root weight
 
 [Term]
 id: CO_331:0000237
@@ -1731,6 +1853,7 @@ name: estimation - storage root cracking method
 namespace: SweetpotatoMethod
 def: "Observe the cracking of the storage root and rate it. Average cracking shown in ten plants" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000097 ! storage root cracking
 
 [Term]
 id: CO_331:0000239
@@ -1758,6 +1881,7 @@ name: measurement - fresh weight of the storage root
 namespace: SweetpotatoMethod
 def: "Measure the fresh weight of the storage root sample and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000240 ! fresh weight of the storage root
 
 [Term]
 id: CO_331:0000243
@@ -1785,6 +1909,7 @@ name: measurement - dry weight of the storage root
 namespace: SweetpotatoMethod
 def: "Measure the dry weight of the storage root sample and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000244 ! dry weight of the storage root
 
 [Term]
 id: CO_331:0000247
@@ -1812,6 +1937,7 @@ name: measurement - fresh weight of the vine
 namespace: SweetpotatoMethod
 def: "Measure the fresh weight of vines sample and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000248 ! fresh weight of vines
 
 [Term]
 id: CO_331:0000251
@@ -1840,6 +1966,7 @@ name: measurement - dry weight of vines
 namespace: SweetpotatoMethod
 def: "Measure the dry weight of vines sample and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000252 ! dry weight of vines
 
 [Term]
 id: CO_331:0000255
@@ -1868,12 +1995,14 @@ name: estimation - fiber method in boiled storage root
 namespace: SweetpotatoMethod
 def: "Observe and taste the boiled storage root fiber and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000256 ! boiled storage root fiber content
 
 [Term]
 id: CO_331:0000258
 name: BlRtFlsFbC 5 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000257 ! estimation - fiber method in boiled storage root
 
 [Term]
 id: CO_331:0000259
@@ -1917,6 +2046,7 @@ id: CO_331:0000262
 name: RtFlsTxH 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000137 ! estimation - texture method
 
 [Term]
 id: CO_331:0000263
@@ -1935,6 +2065,7 @@ id: CO_331:0000264
 name: RtFlsTxG 9 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000137 ! estimation - texture method
 
 [Term]
 id: CO_331:0000265
@@ -1963,12 +2094,14 @@ name: estimation - taste method
 namespace: SweetpotatoMethod
 def: "Taste the boiled storage root flesh and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000266 ! boiled storage root flesh taste
 
 [Term]
 id: CO_331:0000268
 name: RtFlsTs 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000267 ! estimation - taste method
 
 [Term]
 id: CO_331:0000269
@@ -1996,12 +2129,14 @@ name: estimation - appearance method
 namespace: SweetpotatoMethod
 def: "Visual estimation of the storage root flesh appearance and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000270 ! boiled storage root appearance
 
 [Term]
 id: CO_331:0000272
 name: RtFlsAp 9 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000271 ! estimation - appearance method
 
 [Term]
 id: CO_331:0000273
@@ -2029,12 +2164,14 @@ name: evaluation of roots for sprouting ability
 namespace: SweetpotatoMethod
 def: "Overall assessment using a scale of 1 to 9." []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000274 ! sprouting ability
 
 [Term]
 id: CO_331:0000276
 name: RtSprt 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000275 ! evaluation of roots for sprouting ability
 
 [Term]
 id: CO_331:0000277
@@ -2246,6 +2383,7 @@ name: computation - survival index method
 namespace: SweetpotatoMethod
 def: "Compute the survival index at harvest per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000298 ! survival index
 
 [Term]
 id: CO_331:0000301
@@ -2293,6 +2431,7 @@ name: counting - number of plants harvested method
 namespace: SweetpotatoMethod
 def: "Count the number of plants harvested per net plot and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000304 ! number of plants harvested
 
 [Term]
 id: CO_331:0000307
@@ -2348,6 +2487,7 @@ name: computation - commercial storage root yield method
 namespace: SweetpotatoMethod
 def: "Compute the yield of the commercial storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000307 ! commercial storage root yield
 
 [Term]
 id: CO_331:0000314
@@ -2355,6 +2495,7 @@ name: computation - average commercial weight of storage roots method
 namespace: SweetpotatoMethod
 def: "Compute the average commercial weight of storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000308 ! average commercial storage root weight
 
 [Term]
 id: CO_331:0000315
@@ -2362,6 +2503,7 @@ name: computation - yield of storage roots per plant harvested method
 namespace: SweetpotatoMethod
 def: "Compute the yield of total storage roots per plant harvested within the net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000309 ! storage roots yield
 
 [Term]
 id: CO_331:0000316
@@ -2369,6 +2511,7 @@ name: computation - commercial storage roots proportion method
 namespace: SweetpotatoMethod
 def: "Compute the percentage of commercial storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000310 ! proportion of commercial storage roots
 
 [Term]
 id: CO_331:0000317
@@ -2376,6 +2519,7 @@ name: computation - biomass yield method in kg
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield within net plot using the formula based in kg" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000311 ! biomass yield
 
 [Term]
 id: CO_331:0000318
@@ -2383,12 +2527,17 @@ name: computation - yield of foliage method
 namespace: SweetpotatoMethod
 def: "Compute the yield of vines per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000312 ! total foliage yield
 
 [Term]
 id: CO_331:0000321
 name: kg/plant
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000315 ! computation - yield of storage roots per plant harvested method
+relationship: scale_of CO_331:0002004 ! computation - yield of storage roots per plant planted method
+relationship: scale_of CO_331:0002022 ! measurement - weight of vines per plant harvested method
+relationship: scale_of CO_331:0002023 ! measurement - weight of vines per plant planted method
 
 [Term]
 id: CO_331:0000327
@@ -3228,6 +3377,7 @@ name: visual estimation - storage root surface defects
 namespace: SweetpotatoMethod
 def: "Observe storage root surface defects and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000423 ! storage root surface primary defects
 
 [Term]
 id: CO_331:0000443
@@ -3235,6 +3385,7 @@ name: estimation - observation of storage root cortex thickness method
 namespace: SweetpotatoMethod
 def: "Measure storage root cortex thickness and estimated it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000327 ! storage root cortex thickness
 
 [Term]
 id: CO_331:0000444
@@ -3242,6 +3393,7 @@ name: visual estimation - flowering habit
 namespace: SweetpotatoMethod
 def: "Observe the habit of the flower and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000328 ! flowering habit
 
 [Term]
 id: CO_331:0000445
@@ -3249,6 +3401,7 @@ name: measurement - flower size
 namespace: SweetpotatoMethod
 def: "Measure flower size and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000329 ! flower size
 
 [Term]
 id: CO_331:0000446
@@ -3256,6 +3409,7 @@ name: visual observation - flower limb shape
 namespace: SweetpotatoMethod
 def: "Observe the flower limb shape and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000330 ! flower limb shape
 
 [Term]
 id: CO_331:0000447
@@ -3263,6 +3417,7 @@ name: measurement - sepal length equality
 namespace: SweetpotatoMethod
 def: "Measure sepal length equality and rate it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000331 ! equality of sepal length
 
 [Term]
 id: CO_331:0000448
@@ -3270,6 +3425,7 @@ name: observation - sepal vein number
 namespace: SweetpotatoMethod
 def: "Count the number of sepal veins and record it. Record the most frequent number in ten typical flowers" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000332 ! number of sepal veins
 
 [Term]
 id: CO_331:0000449
@@ -3277,6 +3433,7 @@ name: visual estimation - sepal shape
 namespace: SweetpotatoMethod
 def: "Observe the sepal shape and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000333 ! sepal shape
 
 [Term]
 id: CO_331:0000450
@@ -3284,6 +3441,7 @@ name: visual estimation - sepal apex shape
 namespace: SweetpotatoMethod
 def: "Observe the shape of the sepal apex and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000334 ! sepal apex shape
 
 [Term]
 id: CO_331:0000451
@@ -3291,6 +3449,7 @@ name: visual estimation - sepal pubescence
 namespace: SweetpotatoMethod
 def: "Observe the pubescence of the sepal and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000335 ! sepal pubescence
 
 [Term]
 id: CO_331:0000452
@@ -3298,6 +3457,7 @@ name: visual estimation - sepal color
 namespace: SweetpotatoMethod
 def: "Observe the sepal color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000336 ! sepal color
 
 [Term]
 id: CO_331:0000453
@@ -3305,6 +3465,7 @@ name: visual estimation - stigma color
 namespace: SweetpotatoMethod
 def: "Observe the stigma color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000337 ! stigma color
 
 [Term]
 id: CO_331:0000454
@@ -3312,6 +3473,7 @@ name: visual estimation - style color
 namespace: SweetpotatoMethod
 def: "Observe the style color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000338 ! style color
 
 [Term]
 id: CO_331:0000455
@@ -3319,6 +3481,7 @@ name: visual estimation - stigma exertion
 namespace: SweetpotatoMethod
 def: "Observe the stigma exertion and rate it. The relative position of the stigma as compared to the highest anther" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000339 ! stigma exertion
 
 [Term]
 id: CO_331:0000456
@@ -3326,6 +3489,7 @@ name: visual estimation - seed capsule set
 namespace: SweetpotatoMethod
 def: "Observe the seed capsule set and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000340 ! seed capsule set
 
 [Term]
 id: CO_331:0000457
@@ -3333,6 +3497,7 @@ name: visual estimation - storage root formation
 namespace: SweetpotatoMethod
 def: "Observe the storage root formation and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000341 ! storage root formation
 
 [Term]
 id: CO_331:0000458
@@ -3340,6 +3505,7 @@ name: measurement - storage root stalk length
 namespace: SweetpotatoMethod
 def: "Measure storage root stalk and rate it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000342 ! storage root stalk
 
 [Term]
 id: CO_331:0000460
@@ -3347,6 +3513,7 @@ name: visual estimation - storage root size variability
 namespace: SweetpotatoMethod
 def: "Observe the size variability of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000344 ! storage root size variability
 
 [Term]
 id: CO_331:0000461
@@ -3354,6 +3521,7 @@ name: visual estimation - keeping quality method
 namespace: SweetpotatoMethod
 def: "Observe the keeping quality of stored storage roots and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000345 ! stored storage root keeping quality
 
 [Term]
 id: CO_331:0000462
@@ -3361,6 +3529,7 @@ name: estimation - boiled storage root consistency method
 namespace: SweetpotatoMethod
 def: "Taste boiled storage root consistency and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000346 ! boiled storage root consistency
 
 [Term]
 id: CO_331:0000463
@@ -3368,6 +3537,7 @@ name: visual estimation - boiled storage root undesirable color method
 namespace: SweetpotatoMethod
 def: "Observe the boiled storage root undesirable color and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000347 ! boiled storage root undesirable color
 
 [Term]
 id: CO_331:0000464
@@ -3375,6 +3545,7 @@ name: visual estimation - reaction of the plant to drought
 namespace: SweetpotatoMethod
 def: "Observe the reaction to drought and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000348 ! reaction to drought
 
 [Term]
 id: CO_331:0000465
@@ -3382,6 +3553,7 @@ name: visual estimation - reaction of the plant to flooding
 namespace: SweetpotatoMethod
 def: "Observe the reaction to flooding and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000349 ! reaction to flooding
 
 [Term]
 id: CO_331:0000466
@@ -3389,6 +3561,7 @@ name: visual estimation - reaction of the plant to heat
 namespace: SweetpotatoMethod
 def: "Observe the reaction to heat and rate it. The reaction is estimated by observing the appearance of plants in response to a hot season with night temperatures of more than 22°C" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000350 ! reaction to heat
 
 [Term]
 id: CO_331:0000467
@@ -3396,6 +3569,7 @@ name: visual estimation - reaction of the plant to salinity
 namespace: SweetpotatoMethod
 def: "Observe the reaction to salinity and rate it. The reaction is estimated by observing the appearance of plants in response to soil with salinity levels of more 8 mm/cm" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000351 ! reaction to salinity
 
 [Term]
 id: CO_331:0000468
@@ -3403,6 +3577,7 @@ name: visual estimation - reaction of the plant to shade
 namespace: SweetpotatoMethod
 def: "Observe the reaction to shade and rate it. The reaction is estimated by observing the appearance of plants in response to shade" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000352 ! reaction to shade
 
 [Term]
 id: CO_331:0000469
@@ -3410,6 +3585,7 @@ name: visual estimation - reaction of the plant to soil
 namespace: SweetpotatoMethod
 def: "Observe the reaction to pH soil and rate it. The reaction is estimated by observing the appearance of plants in response to acid and heavy soils with pH below 5.0" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000353 ! reaction to acidic ph soil
 
 [Term]
 id: CO_331:0000470
@@ -3417,6 +3593,7 @@ name: visual estimation - reaction of the plant to high soil temperature
 namespace: SweetpotatoMethod
 def: "Observe the reaction to high soil temperature and rate it. The reaction is estimated by observing the appearance of plants during a hoy season with day temperatures with peaks of more than 40°C" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000354 ! reaction to high soil temperature
 
 [Term]
 id: CO_331:0000471
@@ -3424,6 +3601,7 @@ name: visual estimation - reaction of the plant to west indian sweet potato weev
 namespace: SweetpotatoMethod
 def: "Observe the reaction to West Indian sweet potato weevil and rate" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000355 ! reaction to west indian sweet potato weevil
 
 [Term]
 id: CO_331:0000472
@@ -3431,6 +3609,7 @@ name: visual estimation - reaction of the plant to striped sweet potato weevil
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Striped sweet potato weevil and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000356 ! reaction to striped sweet potato weevil
 
 [Term]
 id: CO_331:0000473
@@ -3438,6 +3617,7 @@ name: visual estimation - reaction of the plant to sweet potato wire worms
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato wire worms and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000357 ! reaction to sweet potato wire worms
 
 [Term]
 id: CO_331:0000474
@@ -3445,6 +3625,7 @@ name: visual estimation - reaction of the plant to wire worms
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Wire worms and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000358 ! reaction to wire worms
 
 [Term]
 id: CO_331:0000475
@@ -3452,6 +3633,7 @@ name: visual estimation - reaction of the plant to sweet potato flea beetles
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato flea beetles and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000359 ! reaction to sweet potato flea beetles
 
 [Term]
 id: CO_331:0000476
@@ -3459,6 +3641,7 @@ name: visual estimation - reaction of the plant to flea beetles
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Flea beetles and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000360 ! reaction to flea beetles
 
 [Term]
 id: CO_331:0000477
@@ -3466,6 +3649,7 @@ name: visual estimation - reaction of the plant to sweet potato leaf beetles
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato leaf beetles and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000361 ! reaction to sweet potato leaf beetles
 
 [Term]
 id: CO_331:0000478
@@ -3473,6 +3657,7 @@ name: visual estimation - reaction of the plant to beetles
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Beetles or rootworms and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000362 ! reaction to beetles
 
 [Term]
 id: CO_331:0000479
@@ -3480,6 +3665,7 @@ name: visual estimation - reaction to grubworm
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Grubworm and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000363 ! reaction to grubworm
 
 [Term]
 id: CO_331:0000480
@@ -3487,6 +3673,7 @@ name: visual estimation - reaction to hornworm
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Hornworm and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000364 ! reaction to hornworm
 
 [Term]
 id: CO_331:0000481
@@ -3494,6 +3681,7 @@ name: visual estimation - reaction of the plant to aphids
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Aphids and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000365 ! reaction to aphids
 
 [Term]
 id: CO_331:0000482
@@ -3501,6 +3689,7 @@ name: visual estimation - reaction of the plant to sweet potato whitefly
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato whitefly and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000366 ! reaction to sweet potato whitefly
 
 [Term]
 id: CO_331:0000483
@@ -3508,6 +3697,7 @@ name: visual estimation - reaction of the plant to sweet potato moth
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato moth and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000367 ! reaction to sweet potato moth
 
 [Term]
 id: CO_331:0000484
@@ -3515,6 +3705,7 @@ name: visual estimation - reaction of the plant to moth
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Moth and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000368 ! reaction to moth
 
 [Term]
 id: CO_331:0000485
@@ -3522,6 +3713,7 @@ name: visual estimation - reaction of the plant to sweet potato stem borer
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato stem borer and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000369 ! reaction to sweet potato stem borer
 
 [Term]
 id: CO_331:0000486
@@ -3529,6 +3721,7 @@ name: visual estimation - response of the plant to other insects
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other insects and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000370 ! reaction to other insects
 
 [Term]
 id: CO_331:0000487
@@ -3536,6 +3729,7 @@ name: visual estimation - reaction of the plant to reniform nematode
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Reniform nematode and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000371 ! reaction to reniform nematode
 
 [Term]
 id: CO_331:0000488
@@ -3543,6 +3737,7 @@ name: visual estimation - reaction of the plant to sting nematode
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sting nematode and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000372 ! reaction to sting nematode
 
 [Term]
 id: CO_331:0000489
@@ -3550,6 +3745,7 @@ name: visual estimation - reaction of the plant to brown ring rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Brown ring rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000373 ! reaction to brown ring rot
 
 [Term]
 id: CO_331:0000490
@@ -3557,6 +3753,7 @@ name: visual estimation - reaction of the plant to root lesion nematode
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Root lesion nematode and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000374 ! reaction to root lesion nematode
 
 [Term]
 id: CO_331:0000491
@@ -3564,6 +3761,7 @@ name: visual estimation - reaction of the plant to other nematodes
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other nematodes and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000375 ! reaction to other nematodes
 
 [Term]
 id: CO_331:0000492
@@ -3571,6 +3769,7 @@ name: visual estimation - reaction of the plant to wilt rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Wilt rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000376 ! reaction to wilt rot
 
 [Term]
 id: CO_331:0000493
@@ -3578,6 +3777,7 @@ name: visual estimation - reaction of the plant to fusarium surface rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Fusarium surface rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000377 ! reaction to fusarium surface rot
 
 [Term]
 id: CO_331:0000494
@@ -3585,6 +3785,7 @@ name: visual estimation - reaction of the plant to fusarium root rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Fusarium root rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000378 ! reaction to fusarium root rot
 
 [Term]
 id: CO_331:0000495
@@ -3592,6 +3793,7 @@ name: visual estimation - reaction of the plant to sclerotial blight and circula
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sclerotial blight and circular spot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000379 ! reaction to sclerotial blight and circular spot
 
 [Term]
 id: CO_331:0000496
@@ -3599,6 +3801,7 @@ name: visual estimation - reaction of the plant to black rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Black rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000380 ! reaction to black rot
 
 [Term]
 id: CO_331:0000497
@@ -3606,6 +3809,7 @@ name: visual estimation - reaction of the plant to scurf
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Scurf and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000381 ! reaction to scurf
 
 [Term]
 id: CO_331:0000498
@@ -3613,6 +3817,7 @@ name: visual estimation - reaction of the plant to soft rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Soft rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000382 ! reaction to soft rot
 
 [Term]
 id: CO_331:0000499
@@ -3620,6 +3825,7 @@ name: visual estimation - reaction of the plant to java black rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Java black rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000383 ! reaction to java black rot
 
 [Term]
 id: CO_331:0000500
@@ -3627,6 +3833,7 @@ name: visual estimation - reaction of the plant to diaporthe dry rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Diaporthe dry rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000384 ! reaction to diaporthe dry rot
 
 [Term]
 id: CO_331:0000501
@@ -3634,6 +3841,7 @@ name: visual estimation - reaction of the plant to scab
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Scab and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000385 ! reaction to scab
 
 [Term]
 id: CO_331:0000502
@@ -3641,6 +3849,7 @@ name: visual estimation - reaction of the plant to leaf spot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Leaf spot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000386 ! reaction to leaf spot
 
 [Term]
 id: CO_331:0000503
@@ -3648,6 +3857,7 @@ name: visual estimation - reaction of the plant to white rust
 namespace: SweetpotatoMethod
 def: "Observe the reaction to White rust and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000387 ! reaction to white rust
 
 [Term]
 id: CO_331:0000504
@@ -3655,6 +3865,7 @@ name: visual estimation - reaction of the plant to foot rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Foot rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000388 ! reaction to foot rot
 
 [Term]
 id: CO_331:0000505
@@ -3662,6 +3873,7 @@ name: visual estimation - reaction of the plant to charcoal rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Charcoal rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000389 ! reaction to charcoal rot
 
 [Term]
 id: CO_331:0000506
@@ -3669,6 +3881,7 @@ name: visual estimation - reaction of the plant to other fungi
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other fungi and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000390 ! reaction to other fungi
 
 [Term]
 id: CO_331:0000507
@@ -3676,6 +3889,7 @@ name: visual estimation - reaction of the plant to pox or soil rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Pox or soil rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000391 ! reaction to pox or soil rot
 
 [Term]
 id: CO_331:0000508
@@ -3683,6 +3897,7 @@ name: visual estimation - reaction of the plant to bacterial stem and root rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Bacterial stem and root rot and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000392 ! reaction to bacterial stem and root rot
 
 [Term]
 id: CO_331:0000509
@@ -3690,6 +3905,7 @@ name: visual estimation - reaction of the plant to bacterial wilt
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Bacterial wilt and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000393 ! reaction to bacterial wilt
 
 [Term]
 id: CO_331:0000510
@@ -3697,6 +3913,7 @@ name: visual estimation - reaction of the plant to other bacteria
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other bacteria and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000394 ! reaction to other bacteria
 
 [Term]
 id: CO_331:0000511
@@ -3704,6 +3921,7 @@ name: visual estimation - reaction of the plant to sweet potato feathery mottle 
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato feathery mottle virus (SPMV) and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000395 ! reaction to sweet potato feathery mottle virus
 
 [Term]
 id: CO_331:0000512
@@ -3711,6 +3929,7 @@ name: visual estimation - reaction of the plant to sweet potato mild mottle viru
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato mild mottle virus (SPMMV) and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000396 ! reaction to sweet potato mild mottle virus
 
 [Term]
 id: CO_331:0000513
@@ -3718,6 +3937,7 @@ name: visual estimation - reaction of the plant to sweet potato vein mottle viru
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato vein mottle virus (SPVMV) and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000397 ! reaction to sweet potato vein mottle virus
 
 [Term]
 id: CO_331:0000514
@@ -3725,6 +3945,7 @@ name: visual estimation - reaction of the plant to sweet potato virus disease co
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Sweet potato virus disease complex (SPVD complex) and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000398 ! reaction to sweet potato virus disease complex
 
 [Term]
 id: CO_331:0000515
@@ -3732,6 +3953,7 @@ name: visual estimation - reaction of the plant to other virus
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other virus and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000399 ! reaction to other virus
 
 [Term]
 id: CO_331:0000516
@@ -3739,6 +3961,7 @@ name: visual estimation - reaction of the plant to witches broom
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Witches broom and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000400 ! reaction to witches broom
 
 [Term]
 id: CO_331:0000517
@@ -3746,6 +3969,7 @@ name: visual estimation - reaction of the plant to other mycoplasma
 namespace: SweetpotatoMethod
 def: "Observe the reaction to Other mycoplasma and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000401 ! reaction to other mycoplasma
 
 [Term]
 id: CO_331:0000526
@@ -3753,6 +3977,7 @@ name: visual estimation - storage root primary shape
 namespace: SweetpotatoMethod
 def: "Observe the primary shape of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000067 ! storage root primary shape
 
 [Term]
 id: CO_331:0000527
@@ -3760,6 +3985,7 @@ name: visual estimation - storage root secondary shape
 namespace: SweetpotatoMethod
 def: "Observe the secondary shape of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000441 ! storage root secondary shape
 
 [Term]
 id: CO_331:0000528
@@ -3767,6 +3993,7 @@ name: visual estimation - storage root shape uniformity
 namespace: SweetpotatoMethod
 def: "Observe the shape uniformity of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000409 ! storage root shape uniformity
 
 [Term]
 id: CO_331:0000530
@@ -3774,6 +4001,7 @@ name: visual estimation - storage root attachment ability
 namespace: SweetpotatoMethod
 def: "Observe the attachment ability of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000411 ! storage root attachment ability
 
 [Term]
 id: CO_331:0000531
@@ -3781,6 +4009,7 @@ name: computation - length to diameter ratio of storage roots method
 namespace: SweetpotatoMethod
 def: "Compute the ratio of the length and diameter of the storage roots using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000412 ! length to diameter ratio of storage roots
 
 [Term]
 id: CO_331:0000532
@@ -3788,6 +4017,7 @@ name: visual estimation - storage root skin color method ncsu
 namespace: SweetpotatoMethod
 def: "Observe the predominant color of the storage root skin and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000049 ! storage root skin predominant color
 
 [Term]
 id: CO_331:0000533
@@ -3795,6 +4025,7 @@ name: visual estimation - storage root skin texture
 namespace: SweetpotatoMethod
 def: "Observe the texture of the storage root skin and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000414 ! storage root skin texture
 
 [Term]
 id: CO_331:0000534
@@ -3802,6 +4033,7 @@ name: visual estimation - storage root flesh color (carotenoids)
 namespace: SweetpotatoMethod
 def: "Observe the flesh color (carotenoids) of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000415 ! storage root flesh color (carotenoids)
 
 [Term]
 id: CO_331:0000535
@@ -3809,6 +4041,7 @@ name: visual estimation - storage root flesh color (anthocyanins)
 namespace: SweetpotatoMethod
 def: "Observe the flesh color (anthocyanins) of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000416 ! storage root flesh color (anthocyanins)
 
 [Term]
 id: CO_331:0000536
@@ -3816,6 +4049,7 @@ name: visual estimation - storage root adventitious buds depth
 namespace: SweetpotatoMethod
 def: "Observe the depth of the adventitious buds in the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000417 ! storage root adventitious buds depth
 
 [Term]
 id: CO_331:0000537
@@ -3823,6 +4057,7 @@ name: visual estimation - lenticel number
 namespace: SweetpotatoMethod
 def: "Observe the number of lenticels and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000418 ! number of lenticels
 
 [Term]
 id: CO_331:0000538
@@ -3830,6 +4065,7 @@ name: visual estimation - reaction to streptomyces soil rot
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Streptomyces Soil Rot and rate it. Observe an average or all storage roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000419 ! reaction to streptomyces soil rot
 
 [Term]
 id: CO_331:0000539
@@ -3837,6 +4073,7 @@ name: visual estimation - reaction to root knot nematode meloidogyne spp
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Root Knot Nematode Meloidogyne spp and rate it. Observe the appearance of an average or all fibrous roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000420 ! reaction to root knot nematode meloidogyne spp
 
 [Term]
 id: CO_331:0000540
@@ -3844,6 +4081,7 @@ name: visual estimation - reaction to root knot nematode meloidogyne incognita
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Root Knot Nematode Meloidogyne incognita and rate it. Observe the degree of necrosis and the number of galls in fibrous roots in 5 to 10 plant" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000421 ! reaction to root knot nematode meloidogyne incognita
 
 [Term]
 id: CO_331:0000541
@@ -3851,6 +4089,7 @@ name: visual estimation - reaction to fusarium oxysporum
 namespace: SweetpotatoMethod
 def: "Observe the reaction of the storage root to Fusarium oxysporum and rate it. Observe an average or all fibrous roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000422 ! reaction to fusarium oxysporum
 
 [Term]
 id: CO_331:0000542
@@ -3858,6 +4097,7 @@ name: visual estimation - storage root defects
 namespace: SweetpotatoMethod
 def: "Observation of an average or all storage roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000423 ! storage root surface primary defects
 
 [Term]
 id: CO_331:0000543
@@ -3865,6 +4105,7 @@ name: estimation - relative storage root yield method
 namespace: SweetpotatoMethod
 def: "Observe the relative storage root yield and rate it. Observe an average or all storage roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000424 ! relative storage root yield
 
 [Term]
 id: CO_331:0000544
@@ -3872,6 +4113,7 @@ name: computation - relative check of storage root yield method
 namespace: SweetpotatoMethod
 def: "Compute the storage root yield relative to check using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000425 ! storage root yield relative to check
 
 [Term]
 id: CO_331:0000546
@@ -3879,6 +4121,7 @@ name: estimation - growing season method
 namespace: SweetpotatoMethod
 def: "Observe the growing season and rate it. Observe an average or all storage roots within a single plant or plot" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000427 ! growing season
 
 [Term]
 id: CO_331:0000554
@@ -3886,6 +4129,7 @@ name: counting - nodes number per vine
 namespace: SweetpotatoMethod
 def: "Count node number per vine and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000435 ! node number per vine
 
 [Term]
 id: CO_331:0000555
@@ -3893,6 +4137,7 @@ name: counting - leaf number per plant
 namespace: SweetpotatoMethod
 def: "Count leaf number per plant and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000436 ! leaf number per plant
 
 [Term]
 id: CO_331:0000557
@@ -3900,6 +4145,7 @@ name: visual estimation - millipede damage
 namespace: SweetpotatoMethod
 def: "Observe the Millipede damage and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000438 ! millipede damage
 
 [Term]
 id: CO_331:0000558
@@ -3907,6 +4153,7 @@ name: visual estimation - alcidodes sp. damage
 namespace: SweetpotatoMethod
 def: "Observe the Alcidodes sp. damage in the storage root and rate it. Observe the damage caused by Alcidodes sp, it causes crown enlargement/galling or death by girdling" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000439 ! alcidodes sp. damage
 
 [Term]
 id: CO_331:0000559
@@ -3914,234 +4161,273 @@ name: visual estimation - soil insect damage
 namespace: SweetpotatoMethod
 def: "Observe the Soil insect damage and rate it Overall assessment of soil insect damage based on inspection of the harvested roots" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000440 ! soil insect damage
 
 [Term]
 id: CO_331:0000560
 name: RtSDef 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000442 ! visual estimation - storage root surface defects
 
 [Term]
 id: CO_331:0000561
 name: RtsCthi 5 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000443 ! estimation - observation of storage root cortex thickness method
 
 [Term]
 id: CO_331:0000562
 name: FrHab 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000444 ! visual estimation - flowering habit
 
 [Term]
 id: CO_331:0000564
 name: FrShL 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000446 ! visual observation - flower limb shape
 
 [Term]
 id: CO_331:0000565
 name: FrSepEql 2 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000447 ! measurement - sepal length equality
 
 [Term]
 id: CO_331:0000566
 name: FrSepNVn
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000448 ! observation - sepal vein number
 
 [Term]
 id: CO_331:0000567
 name: FrSepShp 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000449 ! visual estimation - sepal shape
 
 [Term]
 id: CO_331:0000568
 name: FrSepApx 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000450 ! visual estimation - sepal apex shape
 
 [Term]
 id: CO_331:0000569
 name: FrSepPub 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000451 ! visual estimation - sepal pubescence
 
 [Term]
 id: CO_331:0000570
 name: FrSepCol 7 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000452 ! visual estimation - sepal color
 
 [Term]
 id: CO_331:0000571
 name: FrStgCol 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000453 ! visual estimation - stigma color
 
 [Term]
 id: CO_331:0000572
 name: FrStyCol 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000454 ! visual estimation - style color
 
 [Term]
 id: CO_331:0000573
 name: FrStgExt 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000455 ! visual estimation - stigma exertion
 
 [Term]
 id: CO_331:0000574
 name: FrSdCp 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000456 ! visual estimation - seed capsule set
 
 [Term]
 id: CO_331:0000575
 name: RtFrm 4 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000457 ! visual estimation - storage root formation
 
 [Term]
 id: CO_331:0000576
 name: RtStk 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000458 ! measurement - storage root stalk length
 
 [Term]
 id: CO_331:0000578
 name: RtSzV 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000460 ! visual estimation - storage root size variability
 
 [Term]
 id: CO_331:0000579
 name: RtKQl 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000461 ! visual estimation - keeping quality method
 
 [Term]
 id: CO_331:0000580
 name: RtBlCu 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000462 ! estimation - boiled storage root consistency method
 
 [Term]
 id: CO_331:0000581
 name: RtBlCd 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000463 ! visual estimation - boiled storage root undesirable color method
 
 [Term]
 id: CO_331:0000582
 name: RnDrt 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000464 ! visual estimation - reaction of the plant to drought
 
 [Term]
 id: CO_331:0000583
 name: RnFld 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000465 ! visual estimation - reaction of the plant to flooding
 
 [Term]
 id: CO_331:0000584
 name: RnHeat 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000466 ! visual estimation - reaction of the plant to heat
 
 [Term]
 id: CO_331:0000585
 name: RnSlt 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000467 ! visual estimation - reaction of the plant to salinity
 
 [Term]
 id: CO_331:0000586
 name: RnShd 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000468 ! visual estimation - reaction of the plant to shade
 
 [Term]
 id: CO_331:0000587
 name: RnSph 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000469 ! visual estimation - reaction of the plant to soil
 
 [Term]
 id: CO_331:0000588
 name: RnSTp 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000470 ! visual estimation - reaction of the plant to high soil temperature
 
 [Term]
 id: CO_331:0000589
 name: RnWISPW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000471 ! visual estimation - reaction of the plant to west indian sweet potato weevil
 
 [Term]
 id: CO_331:0000590
 name: RnSSPW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000472 ! visual estimation - reaction of the plant to striped sweet potato weevil
 
 [Term]
 id: CO_331:0000591
 name: RnSPWW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000473 ! visual estimation - reaction of the plant to sweet potato wire worms
 
 [Term]
 id: CO_331:0000592
 name: RnWW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000474 ! visual estimation - reaction of the plant to wire worms
 
 [Term]
 id: CO_331:0000593
 name: RnSPFB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000475 ! visual estimation - reaction of the plant to sweet potato flea beetles
 
 [Term]
 id: CO_331:0000594
 name: RnFB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000476 ! visual estimation - reaction of the plant to flea beetles
 
 [Term]
 id: CO_331:0000595
 name: RnSPLB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000477 ! visual estimation - reaction of the plant to sweet potato leaf beetles
 
 [Term]
 id: CO_331:0000596
 name: RnBTL 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000478 ! visual estimation - reaction of the plant to beetles
 
 [Term]
 id: CO_331:0000597
 name: RnGrbW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000479 ! visual estimation - reaction to grubworm
 
 [Term]
 id: CO_331:0000598
 name: RnHrnw 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000480 ! visual estimation - reaction to hornworm
 
 [Term]
 id: CO_331:0000599
 name: RnAph 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000481 ! visual estimation - reaction of the plant to aphids
 
 [Term]
 id: CO_331:0000600
@@ -4320,264 +4606,314 @@ id: CO_331:0000617
 name: RnJBR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000499 ! visual estimation - reaction of the plant to java black rot
 
 [Term]
 id: CO_331:0000618
 name: RnDDR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000500 ! visual estimation - reaction of the plant to diaporthe dry rot
 
 [Term]
 id: CO_331:0000619
 name: RnScb 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000501 ! visual estimation - reaction of the plant to scab
 
 [Term]
 id: CO_331:0000620
 name: RnLS 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000502 ! visual estimation - reaction of the plant to leaf spot
 
 [Term]
 id: CO_331:0000622
 name: RnFR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000504 ! visual estimation - reaction of the plant to foot rot
 
 [Term]
 id: CO_331:0000623
 name: RnCR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000505 ! visual estimation - reaction of the plant to charcoal rot
 
 [Term]
 id: CO_331:0000624
 name: RnOF 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000506 ! visual estimation - reaction of the plant to other fungi
 
 [Term]
 id: CO_331:0000625
 name: RnPSR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000507 ! visual estimation - reaction of the plant to pox or soil rot
 
 [Term]
 id: CO_331:0000626
 name: RnBSRt 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000508 ! visual estimation - reaction of the plant to bacterial stem and root rot
 
 [Term]
 id: CO_331:0000627
 name: RnBW 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000509 ! visual estimation - reaction of the plant to bacterial wilt
 
 [Term]
 id: CO_331:0000628
 name: RnOB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000510 ! visual estimation - reaction of the plant to other bacteria
 
 [Term]
 id: CO_331:0000629
 name: RnSPMV 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000511 ! visual estimation - reaction of the plant to sweet potato feathery mottle virus (spmv)
 
 [Term]
 id: CO_331:0000630
 name: RnSPMMV 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000512 ! visual estimation - reaction of the plant to sweet potato mild mottle virus (spmmv)
 
 [Term]
 id: CO_331:0000631
 name: RnSPVMV 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000513 ! visual estimation - reaction of the plant to sweet potato vein mottle virus (spvmv)
 
 [Term]
 id: CO_331:0000632
 name: RnSPVD 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000514 ! visual estimation - reaction of the plant to sweet potato virus disease complex (spvd complex)
 
 [Term]
 id: CO_331:0000633
 name: RnOV 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000515 ! visual estimation - reaction of the plant to other virus
 
 [Term]
 id: CO_331:0000634
 name: RnWB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000516 ! visual estimation - reaction of the plant to witches broom
 
 [Term]
 id: CO_331:0000635
 name: RnOM 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000517 ! visual estimation - reaction of the plant to other mycoplasma
 
 [Term]
 id: CO_331:0000644
 name: RtShpP 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000526 ! visual estimation - storage root primary shape
 
 [Term]
 id: CO_331:0000645
 name: RtShpS 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000527 ! visual estimation - storage root secondary shape
 
 [Term]
 id: CO_331:0000646
 name: RtShpU 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000528 ! visual estimation - storage root shape uniformity
 
 [Term]
 id: CO_331:0000648
 name: RtAtt 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000530 ! visual estimation - storage root attachment ability
 
 [Term]
 id: CO_331:0000649
 name: RtLDR
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000531 ! computation - length to diameter ratio of storage roots method
 
 [Term]
 id: CO_331:0000650
 name: RtSknCol 10 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000532 ! visual estimation - storage root skin color method ncsu
 
 [Term]
 id: CO_331:0000651
 name: RtSknTxt 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000533 ! visual estimation - storage root skin texture
 
 [Term]
 id: CO_331:0000652
 name: RtFlsColC 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000534 ! visual estimation - storage root flesh color (carotenoids)
 
 [Term]
 id: CO_331:0000653
 name: RtFlsColA 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000535 ! visual estimation - storage root flesh color (anthocyanins)
 
 [Term]
 id: CO_331:0000654
 name: RtAdvB 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000536 ! visual estimation - storage root adventitious buds depth
 
 [Term]
 id: CO_331:0000655
 name: RtLtcl 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000537 ! visual estimation - lenticel number
 
 [Term]
 id: CO_331:0000656
 name: RnPSR 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000538 ! visual estimation - reaction to streptomyces soil rot
 
 [Term]
 id: CO_331:0000657
 name: RnMgRKN 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000539 ! visual estimation - reaction to root knot nematode meloidogyne spp
 
 [Term]
 id: CO_331:0000658
 name: RnMgIRKN 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000540 ! visual estimation - reaction to root knot nematode meloidogyne incognita
 
 [Term]
 id: CO_331:0000659
 name: RnFR 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000541 ! visual estimation - reaction to fusarium oxysporum
 
 [Term]
 id: CO_331:0000660
 name: RtSPDef 14 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000542 ! visual estimation - storage root defects
 
 [Term]
 id: CO_331:0000661
 name: RtYldR
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000543 ! estimation - relative storage root yield method
 
 [Term]
 id: CO_331:0000662
 name: RtYldChk
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000544 ! computation - relative check of storage root yield method
 
 [Term]
 id: CO_331:0000663
 name: RtApr 8 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002146 ! visual estimation - storage root appearance -method ncsu
 
 [Term]
 id: CO_331:0000664
 name: PtMtSs
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000546 ! estimation - growing season method
 
 [Term]
 id: CO_331:0000665
 name: mg/g
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002087 ! measurement  the peonidin content- near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002115 ! measurement the amylose content - near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002116 ! measurement the anthocyanin content- near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002117 ! measurement the asparagine content- near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002124 ! measurement the cyanidin content- near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002129 ! measurement the phenol content- near-infrared spectroscopy (nirs) method
+relationship: scale_of CO_331:0002131 ! measurement the total monomeric anthocyanin content- near-infrared spectroscopy (nirs) method
 
 [Term]
 id: CO_331:0000672
 name: VnNds
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000554 ! counting - nodes number per vine
 
 [Term]
 id: CO_331:0000673
 name: PtLvs
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000555 ! counting - leaf number per plant
 
 [Term]
 id: CO_331:0000675
 name: RtMillDam 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000557 ! visual estimation - millipede damage
 
 [Term]
 id: CO_331:0000676
 name: RtAlcDam 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000558 ! visual estimation - alcidodes sp. damage
 
 [Term]
 id: CO_331:0000677
 name: RtSInsDam 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000559 ! visual estimation - soil insect damage
 
 [Term]
 id: CO_331:0000678
@@ -6072,18 +6408,24 @@ id: CO_331:0000815
 name: RtDSm 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002024 ! vistual estimation - overall storage root disease symptoms
 
 [Term]
 id: CO_331:0000863
 name: RtShp 9 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000068 ! visual estimation - storage root shape
 
 [Term]
 id: CO_331:0000871
 name: plants/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000190 ! counting - number of plants planted method
+relationship: scale_of CO_331:0000209 ! counting - number of plants with storage roots method
+relationship: scale_of CO_331:0000305 ! counting - number of plants harvested method
+relationship: scale_of CO_331:0002046 ! counting - number of plants established method
 
 [Term]
 id: CO_331:0000885
@@ -6091,18 +6433,27 @@ name: counting - number of plants available
 namespace: SweetpotatoMethod
 def: "Count the plants available and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:2000016 ! plants available counting number
 
 [Term]
 id: CO_331:0000887
 name: storage root/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000145 ! counting - number of commercial storage roots method
+relationship: scale_of CO_331:0000231 ! computation - number of storage roots per plot method
+relationship: scale_of CO_331:0001094 ! computation - number of storage roots method
+relationship: scale_of CO_331:0002045 ! counting - number of non-commercial storage roots method
 
 [Term]
 id: CO_331:0000891
 name: storage root/plant
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000228 ! computation - number of storage roots per plant harvested method
+relationship: scale_of CO_331:0001095 ! computation - number of storage roots per plant planted method
+relationship: scale_of CO_331:0002005 ! computing - number of commercial storage roots per plant planted method
+relationship: scale_of CO_331:2000035 ! computing - number of commercial storage roots per plant harvested method
 
 [Term]
 id: CO_331:0000892
@@ -6110,36 +6461,126 @@ name: measurement - weight of total us no. 1 storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000601 ! weight of total storage roots
 
 [Term]
 id: CO_331:0000893
 name: kg/plot
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000146 ! measurement - weight of commercial storage root within net plot method
+relationship: scale_of CO_331:0000225 ! measurement - weight of vines method
+relationship: scale_of CO_331:0000235 ! computation - total storage root weight per net plot method
+relationship: scale_of CO_331:0000314 ! computation - average commercial weight of storage roots method
+relationship: scale_of CO_331:0000317 ! computation - biomass yield method in kg
+relationship: scale_of CO_331:0000892 ! measurement - weight of total us no. 1 storage roots
+relationship: scale_of CO_331:0001091 ! computation - biomass yield in dry weight basis method in kg
+relationship: scale_of CO_331:0001099 ! computation - total storage root dry weight per net plot method
+relationship: scale_of CO_331:0002008 ! measurement - dry weight of vines method
+relationship: scale_of CO_331:0002015 ! measurement - weight of 32 count us no. 1 storage roots
+relationship: scale_of CO_331:0002016 ! measurement - weight of 40 count us no. 1 storage roots
+relationship: scale_of CO_331:0002017 ! measurement - weight of 55 count us no. 1 storage roots
+relationship: scale_of CO_331:0002018 ! measurement - weight of 90 count us no. 1 storage roots
+relationship: scale_of CO_331:0002019 ! measurement - weight of canner storage roots
+relationship: scale_of CO_331:0002020 ! measurement - weight of cull storage roots
+relationship: scale_of CO_331:0002021 ! measurement - weight of jumbo storage roots
+relationship: scale_of CO_331:0002047 ! measurement - weight of non-commercial storage root within net plot method
+relationship: scale_of CO_331:0002049 ! computation - average non-commercial weight of storage roots method
+relationship: scale_of CO_331:0002050 ! computation - average total weight of storage roots method
 
 [Term]
 id: CO_331:0000897
 name: t/ha
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000083 ! computation - total storage roots yield method
+relationship: scale_of CO_331:0000313 ! computation - commercial storage root yield method
+relationship: scale_of CO_331:0000318 ! computation - yield of foliage method
+relationship: scale_of CO_331:0001089 ! computation - biomass yield adjusted in dry weight basis method
+relationship: scale_of CO_331:0001090 ! computation - biomass yield adjusted method
+relationship: scale_of CO_331:0001092 ! computation - commercial storage root yield adjusted method
+relationship: scale_of CO_331:0001093 ! computation - foliage yield method
+relationship: scale_of CO_331:0001097 ! computation - storage root dry matter content yield
+relationship: scale_of CO_331:0001098 ! computation - storage root dry matter content yield adjusted
+relationship: scale_of CO_331:0002000 ! computation - total storage roots yield adjusted method
+relationship: scale_of CO_331:0002002 ! computation - vine dry matter content yield
+relationship: scale_of CO_331:0002003 ! computation - vine dry matter content yield adjusted
+relationship: scale_of CO_331:0002081 ! computation - biomass yield in dry weight basis method in tha
+relationship: scale_of CO_331:0002082 ! computation - biomass yield method in th
 
 [Term]
 id: CO_331:0000900
 name: %
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000086 ! computation - harvest index evaluation method
+relationship: scale_of CO_331:0000131 ! estimation - fiber content
+relationship: scale_of CO_331:0000143 ! computation - storage root dry matter content
+relationship: scale_of CO_331:0000299 ! computation - survival index method
+relationship: scale_of CO_331:0000316 ! computation - commercial storage roots proportion method
+relationship: scale_of CO_331:0000933 ! measurement - fructose content of the raw storage root
+relationship: scale_of CO_331:0000934 ! measurement - glucose content of the raw storage root
+relationship: scale_of CO_331:0000935 ! measurement - sucrose content of the raw storage root
+relationship: scale_of CO_331:0000936 ! measurement - maltose content of the raw storage root
+relationship: scale_of CO_331:0001096 ! computation - root foliage ratio method
+relationship: scale_of CO_331:0002001 ! computation - vine dry matter content
+relationship: scale_of CO_331:0002044 ! measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002088 ! measurement  the starch content- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002089 ! measurement  the starch content- near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002090 ! measurement  the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002108 ! measurement protein - near-infrared spectroscopy (nirs) method of the boiled storage root in dry weight
+relationship: scale_of CO_331:0002109 ! measurement protein- near-infrared spectroscopy (nirs) method  of the boiled storage root in fresh weight
+relationship: scale_of CO_331:0002110 ! measurement protein- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002130 ! measurement the starch content- near-infrared spectroscopy (nirs) method of the raw storage root in fresh weight
+relationship: scale_of CO_331:2000022 ! measurement - fructose content of the boiled storage root
+relationship: scale_of CO_331:2000023 ! measurement - glucose content of the boiled storage root
+relationship: scale_of CO_331:2000024 ! measurement - sucrose content of the boiled storage root
+relationship: scale_of CO_331:2000025 ! measurement - maltose content of the boiled storage root
 
 [Term]
 id: CO_331:0000905
 name: g
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000241 ! measurement - fresh weight of the storage root
+relationship: scale_of CO_331:0000245 ! measurement - dry weight of the storage root
+relationship: scale_of CO_331:0000249 ! measurement - fresh weight of the vine
+relationship: scale_of CO_331:0000253 ! measurement - dry weight of vines
 
 [Term]
 id: CO_331:0000925
 name: mg/100g
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002006 ! estimation - royal horticultural society (rhs) color chart
+relationship: scale_of CO_331:0002083 ! measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+relationship: scale_of CO_331:0002084 ! measurement  calcium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+relationship: scale_of CO_331:0002085 ! measurement  calcium- near-infrared spectroscopy (nirs) method in dry weight
+relationship: scale_of CO_331:0002086 ! measurement  calcium- near-infrared spectroscopy (nirs) method in fresh weight
+relationship: scale_of CO_331:0002100 ! measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+relationship: scale_of CO_331:0002101 ! measurement iron- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+relationship: scale_of CO_331:0002102 ! measurement iron- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002103 ! measurement iron- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
+relationship: scale_of CO_331:0002118 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+relationship: scale_of CO_331:0002119 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+relationship: scale_of CO_331:0002120 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
+relationship: scale_of CO_331:0002121 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+relationship: scale_of CO_331:0002122 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in dry weight basis
+relationship: scale_of CO_331:0002123 ! measurement the beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+relationship: scale_of CO_331:0002125 ! measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+relationship: scale_of CO_331:0002126 ! measurement the magnesium- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+relationship: scale_of CO_331:0002127 ! measurement the magnesium- near-infrared spectroscopy (nirs) method in dry weight
+relationship: scale_of CO_331:0002128 ! measurement the magnesium- near-infrared spectroscopy (nirs) method in fresh weight
+relationship: scale_of CO_331:0002132 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method  of the boiled storage root in fresh weight basis
+relationship: scale_of CO_331:0002133 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in dry weight basis
+relationship: scale_of CO_331:0002134 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the baked storage root in fresh weight basis
+relationship: scale_of CO_331:0002135 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the boiled storage root in dry weight basis
+relationship: scale_of CO_331:0002136 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+relationship: scale_of CO_331:0002137 ! measurement total beta-carotene- high-performance liquid chromatography (hplc) method of the raw storage root in fresh weight basis
+relationship: scale_of CO_331:0002142 ! measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in dry weight
+relationship: scale_of CO_331:0002143 ! measurement zinc- inductively coupled plasma atomic emission spectroscopy (icp-oes) method in fresh weight
+relationship: scale_of CO_331:0002144 ! measurement zinc- near-infrared spectroscopy (nirs) method  of the raw storage root in fresh weight
+relationship: scale_of CO_331:0002145 ! measurement zinc- near-infrared spectroscopy (nirs) method of the raw storage root in dry weight
 
 [Term]
 id: CO_331:0000933
@@ -6147,6 +6588,7 @@ name: measurement - fructose content of the raw storage root
 namespace: SweetpotatoMethod
 def: "Compute the fructose content of the raw storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000118 ! storage root fructose content
 
 [Term]
 id: CO_331:0000934
@@ -6154,6 +6596,7 @@ name: measurement - glucose content of the raw storage root
 namespace: SweetpotatoMethod
 def: "Compute the glucose content of the raw storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000121 ! storage root glucose content
 
 [Term]
 id: CO_331:0000935
@@ -6161,6 +6604,7 @@ name: measurement - sucrose content of the raw storage root
 namespace: SweetpotatoMethod
 def: "Compute the sucrose content of the raw storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000124 ! storage root sucrose content
 
 [Term]
 id: CO_331:0000936
@@ -6168,24 +6612,33 @@ name: measurement - maltose content of the raw storage root
 namespace: SweetpotatoMethod
 def: "Compute the maltose content of the raw storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000127 ! storage root maltose content
 
 [Term]
 id: CO_331:0000950
 name: cm
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000445 ! measurement - flower size
+relationship: scale_of CO_331:0002009 ! measurement - flower length
+relationship: scale_of CO_331:0002012 ! measurement - flower width
+relationship: scale_of CO_331:0002013 ! measurement - main vine length method
+relationship: scale_of CO_331:0002014 ! measurement - mature leaf size
+relationship: scale_of CO_331:0002091 ! measurement - vine internode length method
 
 [Term]
 id: CO_331:0000956
 name: TtlVnProd
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002048 ! visual estimation - total vine production method
 
 [Term]
 id: CO_331:0000978
 name: RtShpU 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000528 ! visual estimation - storage root shape uniformity
 
 [Term]
 id: CO_331:0000979
@@ -7381,6 +7834,7 @@ name: computation - biomass yield adjusted in dry weight basis method
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield adjusted in dry weight basis within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001057 ! biomass yield adjusted in dry weight basis
 
 [Term]
 id: CO_331:0001090
@@ -7388,6 +7842,7 @@ name: computation - biomass yield adjusted method
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield adjusted within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001056 ! biomass yield adjusted
 
 [Term]
 id: CO_331:0001091
@@ -7395,6 +7850,7 @@ name: computation - biomass yield in dry weight basis method in kg
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield in dry weight basis within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001058 ! biomass yield in dry weight basis
 
 [Term]
 id: CO_331:0001092
@@ -7402,6 +7858,7 @@ name: computation - commercial storage root yield adjusted method
 namespace: SweetpotatoMethod
 def: "Compute the adjusted yield of the commercial storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001059 ! commercial storage root yield adjusted
 
 [Term]
 id: CO_331:0001093
@@ -7409,6 +7866,7 @@ name: computation - foliage yield method
 namespace: SweetpotatoMethod
 def: "Compute the adjusted yield of vines per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001078 ! total foliage yield adjusted
 
 [Term]
 id: CO_331:0001094
@@ -7416,6 +7874,7 @@ name: computation - number of storage roots method
 namespace: SweetpotatoMethod
 def: "Compute the number of storage roots per net plot and record it" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001079 ! total number of storage roots
 
 [Term]
 id: CO_331:0001095
@@ -7423,6 +7882,7 @@ name: computation - number of storage roots per plant planted method
 namespace: SweetpotatoMethod
 def: "Compute the number of storage roots per plant planted within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000079 ! number of storage roots
 
 [Term]
 id: CO_331:0001096
@@ -7430,6 +7890,7 @@ name: computation - root foliage ratio method
 namespace: SweetpotatoMethod
 def: "Computation of the ratio between root and foliage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001063 ! root foliage ratio
 
 [Term]
 id: CO_331:0001097
@@ -7437,6 +7898,7 @@ name: computation - storage root dry matter content yield
 namespace: SweetpotatoMethod
 def: "Compute the storage root dry matter yield content within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001065 ! storage root dry matter content yield
 
 [Term]
 id: CO_331:0001098
@@ -7444,6 +7906,7 @@ name: computation - storage root dry matter content yield adjusted
 namespace: SweetpotatoMethod
 def: "Compute the storage root dry matter content yield adjusted within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001066 ! storage root dry matter content yield adjusted
 
 [Term]
 id: CO_331:0001099
@@ -7451,6 +7914,7 @@ name: computation - total storage root dry weight per net plot method
 namespace: SweetpotatoMethod
 def: "Compute the total dry weight of storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001080 ! total storage root dry weight
 
 [Term]
 id: CO_331:0002000
@@ -7458,6 +7922,7 @@ name: computation - total storage roots yield adjusted method
 namespace: SweetpotatoMethod
 def: "Compute the adjusted yield of the total storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001081 ! total storage roots yield adjusted
 
 [Term]
 id: CO_331:0002001
@@ -7465,6 +7930,7 @@ name: computation - vine dry matter content
 namespace: SweetpotatoMethod
 def: "Compute the vine dry matter content using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001084 ! vine dry matter content
 
 [Term]
 id: CO_331:0002002
@@ -7472,6 +7938,7 @@ name: computation - vine dry matter content yield
 namespace: SweetpotatoMethod
 def: "Compute the vine dry matter yield content within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001085 ! vine dry matter content yield
 
 [Term]
 id: CO_331:0002003
@@ -7479,6 +7946,7 @@ name: computation - vine dry matter content yield adjusted
 namespace: SweetpotatoMethod
 def: "Compute the vine dry matter content yield adjusted within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001086 ! vine dry matter content yield adjusted
 
 [Term]
 id: CO_331:0002004
@@ -7486,6 +7954,7 @@ name: computation - yield of storage roots per plant planted method
 namespace: SweetpotatoMethod
 def: "Compute the yield of total storage roots per plant planted within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000309 ! storage roots yield
 
 [Term]
 id: CO_331:0002005
@@ -7493,6 +7962,7 @@ name: computing - number of commercial storage roots per plant planted method
 namespace: SweetpotatoMethod
 def: "Compute the number of commercial storage roots per plant planted using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000212 ! number of commercial storage roots
 
 [Term]
 id: CO_331:0002006
@@ -7500,6 +7970,7 @@ name: estimation - royal horticultural society (rhs) color chart
 namespace: SweetpotatoMethod
 def: "Observe the beta-carotene concentration of the raw storage root in fresh weight basis and rate it. Compare the color found and assign an estimate of the value in mg per 100g and record it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002007
@@ -7507,6 +7978,7 @@ name: measurement - cooking time of the storage root method
 namespace: SweetpotatoMethod
 def: "Measure the cooking time of the storage roots in minutes and rate it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001064 ! storage root cooking time
 
 [Term]
 id: CO_331:0002008
@@ -7514,6 +7986,7 @@ name: measurement - dry weight of vines method
 namespace: SweetpotatoMethod
 def: "Measure the dry weight of vines after harvest per net plot in kg and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001087 ! vine dry weight
 
 [Term]
 id: CO_331:0002009
@@ -7521,6 +7994,7 @@ name: measurement - flower length
 namespace: SweetpotatoMethod
 def: "Measure flower length and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001060 ! flower length
 
 [Term]
 id: CO_331:0002012
@@ -7528,6 +8002,7 @@ name: measurement - flower width
 namespace: SweetpotatoMethod
 def: "Measure width size and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001061 ! flower width
 
 [Term]
 id: CO_331:0002013
@@ -7535,6 +8010,7 @@ name: measurement - main vine length method
 namespace: SweetpotatoMethod
 def: "Measure the main vine length and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001062 ! plant height
 
 [Term]
 id: CO_331:0002014
@@ -7542,6 +8018,7 @@ name: measurement - mature leaf size
 namespace: SweetpotatoMethod
 def: "Measure the mature leaf size and rate it. Described from leaves located in the middle section of the vine" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000031 ! mature leaf size
 
 [Term]
 id: CO_331:0002015
@@ -7549,6 +8026,7 @@ name: measurement - weight of 32 count us no. 1 storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of 32 count US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000608 ! weight of 32 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0002016
@@ -7556,6 +8034,7 @@ name: measurement - weight of 40 count us no. 1 storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of 40 count US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000607 ! weight of 40 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0002017
@@ -7563,6 +8042,7 @@ name: measurement - weight of 55 count us no. 1 storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of 55 count US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000606 ! weight of 55 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0002018
@@ -7570,6 +8050,7 @@ name: measurement - weight of 90 count us no. 1 storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of 90 count US no. 1 storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000605 ! weight of 90 count us no. 1 storage roots
 
 [Term]
 id: CO_331:0002019
@@ -7577,6 +8058,7 @@ name: measurement - weight of canner storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of canner storage roots the and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000602 ! weight of canner storage roots
 
 [Term]
 id: CO_331:0002020
@@ -7584,6 +8066,7 @@ name: measurement - weight of cull storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of cull storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000604 ! weight of cull storage roots
 
 [Term]
 id: CO_331:0002021
@@ -7591,6 +8074,7 @@ name: measurement - weight of jumbo storage roots
 namespace: SweetpotatoMethod
 def: "Measure the weight of jumbo storage roots and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000603 ! weight of jumbo storage roots
 
 [Term]
 id: CO_331:0002022
@@ -7598,6 +8082,7 @@ name: measurement - weight of vines per plant harvested method
 namespace: SweetpotatoMethod
 def: "Compute the weight of vines per plant harvested within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000224 ! vine weight
 
 [Term]
 id: CO_331:0002023
@@ -7605,6 +8090,7 @@ name: measurement - weight of vines per plant planted method
 namespace: SweetpotatoMethod
 def: "Compute the weight of vines per plant planted within the net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000224 ! vine weight
 
 [Term]
 id: CO_331:0002024
@@ -7612,6 +8098,7 @@ name: vistual estimation - overall storage root disease symptoms
 namespace: SweetpotatoMethod
 def: "Observe the overall storage root disease symptoms and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002056 ! overall disease symptoms of the storage root
 
 [Term]
 id: CO_331:0002025
@@ -7619,6 +8106,7 @@ name: visual estimation - starch content
 namespace: SweetpotatoMethod
 def: "Observe and taste the starch content of the raw storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0001073 ! storage root starch content
 
 [Term]
 id: CO_331:0002026
@@ -7626,6 +8114,7 @@ name: visual estimation - vine base color method
 namespace: SweetpotatoMethod
 def: "Observe the base color of the vine and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0001083 ! vine base color
 
 [Term]
 id: CO_331:0002027
@@ -7633,6 +8122,7 @@ name: visual estimation - vine node color method
 namespace: SweetpotatoMethod
 def: "Observe the color of the vine node and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0001088 ! vine node color
 
 [Term]
 id: CO_331:0002028
@@ -7640,6 +8130,7 @@ name: visual estimation - vine tip color method
 namespace: SweetpotatoMethod
 def: "Observe the color of the vine tip and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0001082 ! vine apex color
 
 [Term]
 id: CO_331:0002029
@@ -7647,60 +8138,70 @@ name: visual estimation storage root defects
 namespace: SweetpotatoMethod
 def: "Type and/or name of secondary visible storage root defect" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000811 ! storage root surface secondary defects
 
 [Term]
 id: CO_331:0002030
 name: minutes
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002007 ! measurement - cooking time of the storage root method
 
 [Term]
 id: CO_331:0002031
 name: mm
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000158 ! measurement - vine internode diameter
 
 [Term]
 id: CO_331:0002032
 name: RtSSDef 14 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002029 ! visual estimation storage root defects
 
 [Term]
 id: CO_331:0002033
 name: RtFlsFf 5 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002043 ! estimation - fiber method in raw storage root
 
 [Term]
 id: CO_331:0002034
 name: RwRtSta 5 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002025 ! visual estimation - starch content
 
 [Term]
 id: CO_331:0002035
 name: RwRtTSg 9pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:00001093 ! visual estimation - total sugar content
 
 [Term]
 id: CO_331:0002036
 name: VnBCol 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002026 ! visual estimation - vine base color method
 
 [Term]
 id: CO_331:0002037
 name: VnNCol 3 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002027 ! visual estimation - vine node color method
 
 [Term]
 id: CO_331:0002038
 name: VnTCol 3 pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0002028 ! visual estimation - vine tip color method
 
 [Term]
 id: CO_331:0002039
@@ -7748,6 +8249,7 @@ name: estimation - fiber method in raw storage root
 namespace: SweetpotatoMethod
 def: "Observe and taste the raw storage root flesh and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000130 ! storage root fiber content
 
 [Term]
 id: CO_331:0002044
@@ -7755,6 +8257,7 @@ name: measurement protein- near-infrared spectroscopy (nirs) method of the raw s
 namespace: SweetpotatoMethod
 def: "Measure the protein content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000100 ! storage root protein content in dry weight basis
 
 [Term]
 id: CO_331:0002045
@@ -7762,6 +8265,7 @@ name: counting - number of non-commercial storage roots method
 namespace: SweetpotatoMethod
 def: "Count the number of non-commercial storage roots per net plot and record it. Evaluation of the number of all storage roots that weigh less than 100 g per NET plot" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000215 ! number of non-commercial storage roots
 
 [Term]
 id: CO_331:0002046
@@ -7769,6 +8273,7 @@ name: counting - number of plants established method
 namespace: SweetpotatoMethod
 def: "Count the number of plants established per net plot to be determined 3 weeks after planting and record it" []
 is_a: CO_331:1000012 ! Counting
+relationship: method_of CO_331:0000189 ! number of plants established
 
 [Term]
 id: CO_331:0002047
@@ -7776,6 +8281,7 @@ name: measurement - weight of non-commercial storage root within net plot method
 namespace: SweetpotatoMethod
 def: "Measure the weight of non-commercial storage roots within net plot and record it. Select those that are lighter than 100 g" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000221 ! weight of non-commercial storage roots
 
 [Term]
 id: CO_331:0002048
@@ -7783,6 +8289,7 @@ name: visual estimation - total vine production method
 namespace: SweetpotatoMethod
 def: "Observe the total vine production and record it. Total vine production in estimated number of plants" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:2000014 ! total vine production
 
 [Term]
 id: CO_331:0002049
@@ -7790,6 +8297,7 @@ name: computation - average non-commercial weight of storage roots method
 namespace: SweetpotatoMethod
 def: "Compute the average non-commercial weight of storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0002041 ! average non-commercial storage root weight
 
 [Term]
 id: CO_331:0002050
@@ -7797,6 +8305,7 @@ name: computation - average total weight of storage roots method
 namespace: SweetpotatoMethod
 def: "Compute the average total weight of storage roots per net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0002042 ! average total storage root weight
 
 [Term]
 id: CO_331:0002051
@@ -7988,6 +8497,7 @@ name: visual estimation - texture method
 namespace: SweetpotatoMethod
 def: "Panelist observe the visual texture of boiled leaves and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002064 ! leaf texture
 
 [Term]
 id: CO_331:0002072
@@ -7995,6 +8505,7 @@ name: visual estimation - appearance method
 namespace: SweetpotatoMethod
 def: "Panelist observe the visual appearance of boiled leaves and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002065 ! leaf appearance
 
 [Term]
 id: CO_331:0002073
@@ -8002,6 +8513,7 @@ name: tuber flavor after cooking - method
 namespace: SweetpotatoMethod
 def: "Panelists taste leaves samples after cooking and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002066 ! leaf flavor
 
 [Term]
 id: CO_331:0002074
@@ -8009,6 +8521,7 @@ name: visual estimation farmer preference for genotype tolerant of pest- method
 namespace: SweetpotatoMethod
 def: "Farmer are encouraged to select the materials and rank the ability of a variety to tolerate pests especially weevils relative to the tolerance of pests of his currently preferred variety using the colour cards system" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002067 ! pest damage tolerant
 
 [Term]
 id: CO_331:0002075
@@ -8016,6 +8529,7 @@ name: visual estimation farmer  preference for genotype of the yielding ability
 namespace: SweetpotatoMethod
 def: "Farmer are encouraged to select the materials and rank the yielding ability of his currently preferred variety using the colour cards system" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002068 ! yielding ability
 
 [Term]
 id: CO_331:0002076
@@ -8023,6 +8537,7 @@ name: visual estimation farmer  preference for the attractiveness of the storage
 namespace: SweetpotatoMethod
 def: "Farmer are encouraged to select the materials and rank  for the attractiveness of the storage-root skin color of his currently preferred variety using the colour cards system" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002069 ! attractiveness of the storage-root skin color
 
 [Term]
 id: CO_331:0002077
@@ -8030,6 +8545,7 @@ name: visual estimation farmer preference for the attractiveness of the  storage
 namespace: SweetpotatoMethod
 def: "The farmer is encouraged to rank the attractiveness of the root flesh color of a variety  relative to the root flesh color of their currently preferred variety using the colour cards system" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0002070 ! attractiveness of the storage-root flesh color
 
 [Term]
 id: CO_331:0002078
@@ -8053,6 +8569,7 @@ name: visual estimation - storage root skin color
 namespace: SweetpotatoMethod
 def: "Observe the predominant color of the storage root skin and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000049 ! storage root skin predominant color
 
 [Term]
 id: CO_331:0002081
@@ -8060,6 +8577,7 @@ name: computation - biomass yield in dry weight basis method in tha
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield in dry weight basis within net plot using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0001058 ! biomass yield in dry weight basis
 
 [Term]
 id: CO_331:0002082
@@ -8067,6 +8585,7 @@ name: computation - biomass yield method in th
 namespace: SweetpotatoMethod
 def: "Computation of the biomass yield within net plot using the formula based in tha" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000311 ! biomass yield
 
 [Term]
 id: CO_331:0002083
@@ -8074,6 +8593,7 @@ name: measurement  calcium- inductively coupled plasma atomic emission spectrosc
 namespace: SweetpotatoMethod
 def: "Measure the calcium concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000281 ! storage root calcium concentration in dry weight basis
 
 [Term]
 id: CO_331:0002084
@@ -8081,6 +8601,7 @@ name: measurement  calcium- inductively coupled plasma atomic emission spectrosc
 namespace: SweetpotatoMethod
 def: "Measure the calcium concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002053 ! storage root calcium concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002085
@@ -8088,6 +8609,7 @@ name: measurement  calcium- near-infrared spectroscopy (nirs) method in dry weig
 namespace: SweetpotatoMethod
 def: "Measure the calcium concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000281 ! storage root calcium concentration in dry weight basis
 
 [Term]
 id: CO_331:0002086
@@ -8095,6 +8617,7 @@ name: measurement  calcium- near-infrared spectroscopy (nirs) method in fresh we
 namespace: SweetpotatoMethod
 def: "Measure the calcium concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002053 ! storage root calcium concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002087
@@ -8102,6 +8625,7 @@ name: measurement  the peonidin content- near-infrared spectroscopy (nirs) metho
 namespace: SweetpotatoMethod
 def: "Measure the peonidin content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000432 ! storage root peonidin concentration in dry weight basis
 
 [Term]
 id: CO_331:0002088
@@ -8109,6 +8633,7 @@ name: measurement  the starch content- near-infrared spectroscopy (nirs) method 
 namespace: SweetpotatoMethod
 def: "Measure the starch content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002055 ! storage root starch content in fresh weight basis
 
 [Term]
 id: CO_331:0002089
@@ -8116,6 +8641,7 @@ name: measurement  the starch content- near-infrared spectroscopy (nirs) method 
 namespace: SweetpotatoMethod
 def: "Measure the starch content of the boiled storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000115 ! storage root starch content in dry weight basis
 
 [Term]
 id: CO_331:0002090
@@ -8123,6 +8649,7 @@ name: measurement  the starch content- near-infrared spectroscopy (nirs) method 
 namespace: SweetpotatoMethod
 def: "Measure the starch content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000115 ! storage root starch content in dry weight basis
 
 [Term]
 id: CO_331:0002091
@@ -8130,6 +8657,7 @@ name: measurement - vine internode length method
 namespace: SweetpotatoMethod
 def: "Measure vine internode length and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000153 ! vine internode length
 
 [Term]
 id: CO_331:0002092
@@ -8137,6 +8665,7 @@ name: measurement fructose- near-infrared spectroscopy (nirs) method  of the boi
 namespace: SweetpotatoMethod
 def: "Measure the fructose content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001068 ! storage root fructose content in fresh weight basis
 
 [Term]
 id: CO_331:0002093
@@ -8144,6 +8673,7 @@ name: measurement fructose- near-infrared spectroscopy (nirs) method of the boil
 namespace: SweetpotatoMethod
 def: "Measure the fructose content of the boiled storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001067 ! storage root fructose content in dry weight basis
 
 [Term]
 id: CO_331:0002094
@@ -8151,6 +8681,7 @@ name: measurement fructose- near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the fructose content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001067 ! storage root fructose content in dry weight basis
 
 [Term]
 id: CO_331:0002095
@@ -8158,6 +8689,7 @@ name: measurement fructose- near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the fructose content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001068 ! storage root fructose content in fresh weight basis
 
 [Term]
 id: CO_331:0002096
@@ -8165,6 +8697,7 @@ name: measurement glucose- near-infrared spectroscopy (nirs) method  of the boil
 namespace: SweetpotatoMethod
 def: "Measure the glucose content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001070 ! storage root glucose content in fresh weight basis
 
 [Term]
 id: CO_331:0002097
@@ -8172,6 +8705,7 @@ name: measurement glucose- near-infrared spectroscopy (nirs) method of the boile
 namespace: SweetpotatoMethod
 def: "Measure the glucose content of the boiled storage root in dry weight and record it." []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001069 ! storage root glucose content in dry weight basis
 
 [Term]
 id: CO_331:0002098
@@ -8179,6 +8713,7 @@ name: measurement glucose- near-infrared spectroscopy (nirs) method of the raw s
 namespace: SweetpotatoMethod
 def: "Measure the glucose content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001069 ! storage root glucose content in dry weight basis
 
 [Term]
 id: CO_331:0002099
@@ -8186,6 +8721,7 @@ name: measurement glucose- near-infrared spectroscopy (nirs) method of the raw s
 namespace: SweetpotatoMethod
 def: "Measure the glucose content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001070 ! storage root glucose content in fresh weight basis
 
 [Term]
 id: CO_331:0002100
@@ -8193,6 +8729,7 @@ name: measurement iron- inductively coupled plasma atomic emission spectroscopy 
 namespace: SweetpotatoMethod
 def: "Measure the iron concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000103 ! storage root iron concentration in dry weight basis
 
 [Term]
 id: CO_331:0002101
@@ -8200,6 +8737,7 @@ name: measurement iron- inductively coupled plasma atomic emission spectroscopy 
 namespace: SweetpotatoMethod
 def: "Measure the iron concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002079 ! storage root iron concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002102
@@ -8207,6 +8745,7 @@ name: measurement iron- near-infrared spectroscopy (nirs) method  of the raw sto
 namespace: SweetpotatoMethod
 def: "Measure the iron concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002079 ! storage root iron concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002103
@@ -8214,6 +8753,7 @@ name: measurement iron- near-infrared spectroscopy (nirs) method of the raw stor
 namespace: SweetpotatoMethod
 def: "Measure the iron concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000103 ! storage root iron concentration in dry weight basis
 
 [Term]
 id: CO_331:0002104
@@ -8221,6 +8761,7 @@ name: measurement maltose - near-infrared spectroscopy (nirs) method  of the boi
 namespace: SweetpotatoMethod
 def: "Measure the maltose content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001072 ! storage root maltose content in fresh weight basis
 
 [Term]
 id: CO_331:0002105
@@ -8228,6 +8769,7 @@ name: measurement maltose - near-infrared spectroscopy (nirs) method of the boil
 namespace: SweetpotatoMethod
 def: "Measure the maltose content of the boiled storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001071 ! storage root maltose content in dry weight basis
 
 [Term]
 id: CO_331:0002106
@@ -8235,6 +8777,7 @@ name: measurement maltose - near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the maltose content of the raw storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001071 ! storage root maltose content in dry weight basis
 
 [Term]
 id: CO_331:0002107
@@ -8242,6 +8785,7 @@ name: measurement maltose - near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the maltose content of the raw storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001072 ! storage root maltose content in fresh weight basis
 
 [Term]
 id: CO_331:0002108
@@ -8249,6 +8793,7 @@ name: measurement protein - near-infrared spectroscopy (nirs) method of the boil
 namespace: SweetpotatoMethod
 def: "Measure the protein content of the boiled storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000100 ! storage root protein content in dry weight basis
 
 [Term]
 id: CO_331:0002109
@@ -8256,6 +8801,7 @@ name: measurement protein- near-infrared spectroscopy (nirs) method  of the boil
 namespace: SweetpotatoMethod
 def: "Measure the protein content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002078 ! storage root protein content in fresh weight basis
 
 [Term]
 id: CO_331:0002110
@@ -8263,6 +8809,7 @@ name: measurement protein- near-infrared spectroscopy (nirs) method of the raw s
 namespace: SweetpotatoMethod
 def: "Measure the protein content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002078 ! storage root protein content in fresh weight basis
 
 [Term]
 id: CO_331:0002111
@@ -8270,6 +8817,7 @@ name: measurement sucrose - near-infrared spectroscopy (nirs) method  of the boi
 namespace: SweetpotatoMethod
 def: "Measure the sucrose content of the boiled storage root in fresh weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001075 ! storage root sucrose content in fresh weight basis
 
 [Term]
 id: CO_331:0002112
@@ -8277,6 +8825,7 @@ name: measurement sucrose - near-infrared spectroscopy (nirs) method of the boil
 namespace: SweetpotatoMethod
 def: "Measure the sucrose content of the boiled storage root in dry weight and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001074 ! storage root sucrose content in dry weight basis
 
 [Term]
 id: CO_331:0002113
@@ -8284,6 +8833,7 @@ name: measurement sucrose - near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the sucrose content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001074 ! storage root sucrose content in dry weight basis
 
 [Term]
 id: CO_331:0002114
@@ -8291,6 +8841,7 @@ name: measurement sucrose - near-infrared spectroscopy (nirs) method of the raw 
 namespace: SweetpotatoMethod
 def: "Measure the sucrose content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001075 ! storage root sucrose content in fresh weight basis
 
 [Term]
 id: CO_331:0002115
@@ -8298,6 +8849,7 @@ name: measurement the amylose content - near-infrared spectroscopy (nirs) method
 namespace: SweetpotatoMethod
 def: "Measure the amylose content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000428 ! storage root amylose concentration in dry weight basis
 
 [Term]
 id: CO_331:0002116
@@ -8305,6 +8857,7 @@ name: measurement the anthocyanin content- near-infrared spectroscopy (nirs) met
 namespace: SweetpotatoMethod
 def: "Measure the anthocyanin content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000433 ! storage root anthocyanin concentration in dry weight basis
 
 [Term]
 id: CO_331:0002117
@@ -8312,6 +8865,7 @@ name: measurement the asparagine content- near-infrared spectroscopy (nirs) meth
 namespace: SweetpotatoMethod
 def: "Measure the asparagine content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000429 ! storage root asparagine concentration in dry weight basis
 
 [Term]
 id: CO_331:0002118
@@ -8319,6 +8873,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the boiled storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
 
 [Term]
 id: CO_331:0002119
@@ -8326,6 +8881,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the baked storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002120
@@ -8333,6 +8889,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the baked storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
 
 [Term]
 id: CO_331:0002121
@@ -8340,6 +8897,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the boiled storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002122
@@ -8347,6 +8905,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000109 ! storage root beta-carotene concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002123
@@ -8354,6 +8913,7 @@ name: measurement the beta-carotene- high-performance liquid chromatography (hpl
 namespace: SweetpotatoMethod
 def: "Measure the beta-carotene concentration of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002051 ! storage root beta-carotene concentration in dry weight basis
 
 [Term]
 id: CO_331:0002124
@@ -8361,6 +8921,7 @@ name: measurement the cyanidin content- near-infrared spectroscopy (nirs) method
 namespace: SweetpotatoMethod
 def: "Measure the cyanidin content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000430 ! storage root cyanidin concentration in dry weight basis
 
 [Term]
 id: CO_331:0002125
@@ -8368,6 +8929,7 @@ name: measurement the magnesium- inductively coupled plasma atomic emission spec
 namespace: SweetpotatoMethod
 def: "Measure the magnesium concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000285 ! storage root magnesium concentration in dry weight basis
 
 [Term]
 id: CO_331:0002126
@@ -8375,6 +8937,7 @@ name: measurement the magnesium- inductively coupled plasma atomic emission spec
 namespace: SweetpotatoMethod
 def: "Measure the magnesium concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002057 ! storage root magnesium concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002127
@@ -8382,6 +8945,7 @@ name: measurement the magnesium- near-infrared spectroscopy (nirs) method in dry
 namespace: SweetpotatoMethod
 def: "Measure the magnesium concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000285 ! storage root magnesium concentration in dry weight basis
 
 [Term]
 id: CO_331:0002128
@@ -8389,6 +8953,7 @@ name: measurement the magnesium- near-infrared spectroscopy (nirs) method in fre
 namespace: SweetpotatoMethod
 def: "Measure the magnesium concentration in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002057 ! storage root magnesium concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002129
@@ -8396,6 +8961,7 @@ name: measurement the phenol content- near-infrared spectroscopy (nirs) method
 namespace: SweetpotatoMethod
 def: "Measure the phenol content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000434 ! storage root phenol concentration in dry weight basis
 
 [Term]
 id: CO_331:0002130
@@ -8403,6 +8969,7 @@ name: measurement the starch content- near-infrared spectroscopy (nirs) method o
 namespace: SweetpotatoMethod
 def: "Measure the starch content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002055 ! storage root starch content in fresh weight basis
 
 [Term]
 id: CO_331:0002131
@@ -8410,6 +8977,7 @@ name: measurement the total monomeric anthocyanin content- near-infrared spectro
 namespace: SweetpotatoMethod
 def: "Measure the total monomeric anthocyanin content of the storage root and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000431 ! storage root total monomeric anthocyanin concentration in dry weight basis
 
 [Term]
 id: CO_331:0002132
@@ -8417,6 +8985,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the boiled storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002133
@@ -8424,6 +8993,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the baked storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
 
 [Term]
 id: CO_331:0002134
@@ -8431,6 +9001,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the baked storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002135
@@ -8438,6 +9009,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the boiled storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
 
 [Term]
 id: CO_331:0002136
@@ -8445,6 +9017,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000112 ! storage root total carotenoid concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002137
@@ -8452,6 +9025,7 @@ name: measurement total beta-carotene- high-performance liquid chromatography (h
 namespace: SweetpotatoMethod
 def: "Measure the total beta-carotene concentration of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002052 ! storage root total carotenoid concentration in dry weight basis
 
 [Term]
 id: CO_331:0002138
@@ -8459,6 +9033,7 @@ name: measurement total sugar - near-infrared spectroscopy (nirs) method  of the
 namespace: SweetpotatoMethod
 def: "Measure the total sugar content of the boiled storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001077 ! storage root total sugar content in fresh weight basis
 
 [Term]
 id: CO_331:0002139
@@ -8466,6 +9041,7 @@ name: measurement total sugar - near-infrared spectroscopy (nirs) method of the 
 namespace: SweetpotatoMethod
 def: "Measure the total sugar content of the boiled storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001076 ! storage root total sugar content in dry weight basis
 
 [Term]
 id: CO_331:0002140
@@ -8473,6 +9049,7 @@ name: measurement total sugar - near-infrared spectroscopy (nirs) method of the 
 namespace: SweetpotatoMethod
 def: "Measure the total sugar content of the raw storage root in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001076 ! storage root total sugar content in dry weight basis
 
 [Term]
 id: CO_331:0002141
@@ -8480,6 +9057,7 @@ name: measurement total sugar - near-infrared spectroscopy (nirs) method of the 
 namespace: SweetpotatoMethod
 def: "Measure the total sugar content of the raw storage root in fresh weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0001077 ! storage root total sugar content in fresh weight basis
 
 [Term]
 id: CO_331:0002142
@@ -8487,6 +9065,7 @@ name: measurement zinc- inductively coupled plasma atomic emission spectroscopy 
 namespace: SweetpotatoMethod
 def: "Measure the zinc concentration in dry weight basis and record it" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000106 ! storage root zinc concentration in dry weight basis
 
 [Term]
 id: CO_331:0002143
@@ -8494,6 +9073,7 @@ name: measurement zinc- inductively coupled plasma atomic emission spectroscopy 
 namespace: SweetpotatoMethod
 def: "Measure the zinc concentration in fresh weight basis and record it with ICP" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002054 ! storage root zinc concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002144
@@ -8501,6 +9081,7 @@ name: measurement zinc- near-infrared spectroscopy (nirs) method  of the raw sto
 namespace: SweetpotatoMethod
 def: "Measure the zinc concentration in fresh weight basis and record it  with NIRS" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0002054 ! storage root zinc concentration in fresh weight basis
 
 [Term]
 id: CO_331:0002145
@@ -8508,6 +9089,7 @@ name: measurement zinc- near-infrared spectroscopy (nirs) method of the raw stor
 namespace: SweetpotatoMethod
 def: "Measure the zinc concentration in dry weight basis and record it with NIRS" []
 is_a: CO_331:1000011 ! Measurement
+relationship: method_of CO_331:0000106 ! storage root zinc concentration in dry weight basis
 
 [Term]
 id: CO_331:0002146
@@ -8515,60 +9097,70 @@ name: visual estimation - storage root appearance -method ncsu
 namespace: SweetpotatoMethod
 def: "Observe the appearance of the storage root and rate it" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:0000199 ! storage root appearance
 
 [Term]
 id: CO_331:0002147
 name: RnWR 5 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:0000503 ! visual estimation - reaction of the plant to white rust
 
 [Term]
 id: CO_331:0002148
 name: LfTexAc 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002071 ! visual estimation - texture method
 
 [Term]
 id: CO_331:0002149
 name: LfApAc 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002072 ! visual estimation - appearance method
 
 [Term]
 id: CO_331:0002150
 name: LfTsAc 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002073 ! tuber flavor after cooking - method
 
 [Term]
 id: CO_331:0002151
 name: PlPdt 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002074 ! visual estimation farmer preference for genotype tolerant of pest- method
 
 [Term]
 id: CO_331:0002152
 name: PlYlAb 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002075 ! visual estimation farmer  preference for genotype of the yielding ability
 
 [Term]
 id: CO_331:0002153
 name: SrSkACol 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002076 ! visual estimation farmer  preference for the attractiveness of the storage-root skin color
 
 [Term]
 id: CO_331:0002154
 name: SrFlACol 3pt. Scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0002077 ! visual estimation farmer preference for the attractiveness of the  storage-root flesh color
 
 [Term]
 id: CO_331:0002155
 name: PltsAvail
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:0000885 ! counting - number of plants available
 
 [Term]
 id: CO_331:1000001
@@ -8688,12 +9280,14 @@ name: visual estimation - plant uniformity
 namespace: SweetpotatoMethod
 def: "Observe the plant uniformity and rate it. Estimation of height uniformity of newly emerging vines" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:2000001 ! plant uniformity
 
 [Term]
 id: CO_331:2000003
 name: PltUni 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:2000002 ! visual estimation - plant uniformity
 
 [Term]
 id: CO_331:2000005
@@ -8721,12 +9315,14 @@ name: visual estimation - plant production
 namespace: SweetpotatoMethod
 def: "Observe the plant production the and rate it. Estimation of intensity of new vine production" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:2000006 ! plant production
 
 [Term]
 id: CO_331:2000008
 name: PltProd 6 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000019 ! Numerical
+relationship: scale_of CO_331:2000007 ! visual estimation - plant production
 
 [Term]
 id: CO_331:2000009
@@ -8754,12 +9350,14 @@ name: visual estimation - plant earliness
 namespace: SweetpotatoMethod
 def: "Observe the plant earliness and rate it. Estimation of earliness of new vine production" []
 is_a: CO_331:1000014 ! Estimation
+relationship: method_of CO_331:2000010 ! plant earliness
 
 [Term]
 id: CO_331:2000012
 name: PltEar 3 pt. scale
 namespace: SweetpotatoScale
 is_a: CO_331:1000015 ! Ordinal
+relationship: scale_of CO_331:2000011 ! visual estimation - plant earliness
 
 [Term]
 id: CO_331:2000013
@@ -8820,6 +9418,7 @@ name: measurement - fructose content of the boiled storage root
 namespace: SweetpotatoMethod
 def: "Compute the fructose content of the boiled storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000118 ! storage root fructose content
 
 [Term]
 id: CO_331:2000023
@@ -8827,6 +9426,7 @@ name: measurement - glucose content of the boiled storage root
 namespace: SweetpotatoMethod
 def: "Compute the glucose content of the boiled storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000121 ! storage root glucose content
 
 [Term]
 id: CO_331:2000024
@@ -8834,6 +9434,7 @@ name: measurement - sucrose content of the boiled storage root
 namespace: SweetpotatoMethod
 def: "Compute the sucrose content of the boiled storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000124 ! storage root sucrose content
 
 [Term]
 id: CO_331:2000025
@@ -8841,6 +9442,7 @@ name: measurement - maltose content of the boiled storage root
 namespace: SweetpotatoMethod
 def: "Compute the maltose content of the boiled storage root in percentage using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000127 ! storage root maltose content
 
 [Term]
 id: CO_331:2000027
@@ -8908,6 +9510,7 @@ name: computing - number of commercial storage roots per plant harvested method
 namespace: SweetpotatoMethod
 def: "Compute the number of commercial storage roots per plant harvested using the formula" []
 is_a: CO_331:1000013 ! Computation
+relationship: method_of CO_331:0000212 ! number of commercial storage roots
 
 [Term]
 id: CO_331:2000036

--- a/sweetpotato_trait.obo
+++ b/sweetpotato_trait.obo
@@ -122,7 +122,7 @@ relationship: method_of CO_331:0000013 ! vine secondary color
 id: CO_331:0000015
 name: VnColS 8 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000014 ! visual estimation - vine secondary color method
 
 [Term]
@@ -283,7 +283,7 @@ relationship: method_of CO_331:0000034 ! abaxial leaf vein pigmentation
 id: CO_331:0000036
 name: LfAVP 9 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000035 ! visual estimation - abaxial leaf vein pigmentation
 
 [Term]
@@ -352,7 +352,7 @@ relationship: method_of CO_331:0000043 ! petiole pigmentation
 id: CO_331:0000045
 name: FrPtP 9 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000044 ! visual estimation -petiole pigmentation
 
 [Term]
@@ -505,7 +505,7 @@ relationship: method_of CO_331:0000064 ! storage root flesh distribution of seco
 id: CO_331:0000066
 name: RtFlsColSD 10 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000065 ! visual estimation - storage root flesh distribution of secondary color
 
 [Term]
@@ -621,7 +621,7 @@ relationship: method_of CO_331:0000082 ! total storage roots yield
 id: CO_331:0000085
 name: harvest index
 namespace: SweetpotatoTrait
-def: "The index of the harvest" []
+def: "Harvest index" []
 synonym: "HrvInx" EXACT []
 is_a: CO_331:1000008 ! Agronomic_trait
 
@@ -2660,14 +2660,6 @@ synonym: "RtFrm" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
 
 [Term]
-id: CO_331:0000342
-name: storage root stalk
-namespace: SweetpotatoTrait
-def: "The length of the storage root stalk" []
-synonym: "RtStk" EXACT []
-is_a: CO_331:1000010 ! Morphological_trait
-
-[Term]
 id: CO_331:0000344
 name: storage root size variability
 namespace: SweetpotatoTrait
@@ -3148,6 +3140,14 @@ synonym: "RtShpU" EXACT []
 is_a: CO_331:1000010 ! Morphological_trait
 
 [Term]
+id: CO_331:0000410
+name: storage root stalk
+namespace: SweetpotatoTrait
+def: "The length of the storage root stalk" []
+synonym: "RtStk" EXACT []
+is_a: CO_331:1000010 ! Morphological_trait
+
+[Term]
 id: CO_331:0000411
 name: storage root attachment ability
 namespace: SweetpotatoTrait
@@ -3505,7 +3505,7 @@ name: measurement - storage root stalk length
 namespace: SweetpotatoMethod
 def: "Measure storage root stalk and rate it" []
 is_a: CO_331:1000011 ! Measurement
-relationship: method_of CO_331:0000342 ! storage root stalk
+relationship: method_of CO_331:0000410 ! storage root stalk
 
 [Term]
 id: CO_331:0000460
@@ -4230,7 +4230,7 @@ relationship: scale_of CO_331:0000451 ! visual estimation - sepal pubescence
 id: CO_331:0000570
 name: FrSepCol 7 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000452 ! visual estimation - sepal color
 
 [Term]
@@ -4265,7 +4265,7 @@ relationship: scale_of CO_331:0000456 ! visual estimation - seed capsule set
 id: CO_331:0000575
 name: RtFrm 4 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000457 ! visual estimation - storage root formation
 
 [Term]
@@ -4300,7 +4300,7 @@ relationship: scale_of CO_331:0000462 ! estimation - boiled storage root consist
 id: CO_331:0000581
 name: RtBlCd 10 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000463 ! visual estimation - boiled storage root undesirable color method
 
 [Term]
@@ -4731,7 +4731,7 @@ relationship: scale_of CO_331:0000517 ! visual estimation - reaction of the plan
 id: CO_331:0000644
 name: RtShpP 8 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000526 ! visual estimation - storage root primary shape
 
 [Term]
@@ -4836,7 +4836,7 @@ relationship: scale_of CO_331:0000541 ! visual estimation - reaction to fusarium
 id: CO_331:0000660
 name: RtSPDef 14 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000542 ! visual estimation - storage root defects
 
 [Term]
@@ -5251,19 +5251,6 @@ is_a: CO_331:1000003 ! Variables
 relationship: variable_of CO_331:0000341 ! storage root formation
 relationship: variable_of CO_331:0000457 ! visual estimation - storage root formation
 relationship: variable_of CO_331:0000575 ! RtFrm 4 pt. scale
-
-[Term]
-id: CO_331:0000706
-name: Storage root stalk estimating 0-9
-namespace: SweetpotatoTrait
-def: "The length of the storage root stalk estimating 0-9" []
-synonym: "RTSTALK" EXACT []
-synonym: "RTSTFM" EXACT []
-synonym: "RtStk_Et_0to9" EXACT []
-is_a: CO_331:1000003 ! Variables
-relationship: variable_of CO_331:0000342 ! storage root stalk
-relationship: variable_of CO_331:0000458 ! measurement - storage root stalk length
-relationship: variable_of CO_331:0000576 ! RtStk 6 pt. scale
 
 [Term]
 id: CO_331:0000707
@@ -6022,6 +6009,19 @@ relationship: variable_of CO_331:0000528 ! visual estimation - storage root shap
 relationship: variable_of CO_331:0000646 ! RtShpU 5 pt. scale
 
 [Term]
+id: CO_331:0000777
+name: Storage root stalk estimating 0-9
+namespace: SweetpotatoTrait
+def: "The length of the storage root stalk estimating 0-9" []
+synonym: "RTSTALK" EXACT []
+synonym: "RTSTFM" EXACT []
+synonym: "RtStk_Et_0to9" EXACT []
+is_a: CO_331:1000003 ! Variables
+relationship: variable_of CO_331:0000410 ! storage root stalk
+relationship: variable_of CO_331:0000458 ! measurement - storage root stalk length
+relationship: variable_of CO_331:0000576 ! RtStk 6 pt. scale
+
+[Term]
 id: CO_331:0000778
 name: Storage root attachement estimating 0-9
 namespace: SweetpotatoTrait
@@ -6414,7 +6414,7 @@ relationship: scale_of CO_331:0002024 ! vistual estimation - overall storage roo
 id: CO_331:0000863
 name: RtShp 9 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0000068 ! visual estimation - storage root shape
 
 [Term]
@@ -8158,7 +8158,7 @@ relationship: scale_of CO_331:0000158 ! measurement - vine internode diameter
 id: CO_331:0002032
 name: RtSSDef 14 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002029 ! visual estimation storage root defects
 
 [Term]
@@ -8172,14 +8172,14 @@ relationship: scale_of CO_331:0002043 ! estimation - fiber method in raw storage
 id: CO_331:0002034
 name: RwRtSta 5 pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002025 ! visual estimation - starch content
 
 [Term]
 id: CO_331:0002035
 name: RwRtTSg 9pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000015 ! Ordinal
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:00001093 ! visual estimation - total sugar content
 
 [Term]
@@ -9110,49 +9110,49 @@ relationship: scale_of CO_331:0000503 ! visual estimation - reaction of the plan
 id: CO_331:0002148
 name: LfTexAc 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002071 ! visual estimation - texture method
 
 [Term]
 id: CO_331:0002149
 name: LfApAc 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002072 ! visual estimation - appearance method
 
 [Term]
 id: CO_331:0002150
 name: LfTsAc 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002073 ! tuber flavor after cooking - method
 
 [Term]
 id: CO_331:0002151
 name: PlPdt 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002074 ! visual estimation farmer preference for genotype tolerant of pest- method
 
 [Term]
 id: CO_331:0002152
 name: PlYlAb 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002075 ! visual estimation farmer  preference for genotype of the yielding ability
 
 [Term]
 id: CO_331:0002153
 name: SrSkACol 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002076 ! visual estimation farmer  preference for the attractiveness of the storage-root skin color
 
 [Term]
 id: CO_331:0002154
 name: SrFlACol 3pt. Scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:0002077 ! visual estimation farmer preference for the attractiveness of the  storage-root flesh color
 
 [Term]
@@ -9286,7 +9286,7 @@ relationship: method_of CO_331:2000001 ! plant uniformity
 id: CO_331:2000003
 name: PltUni 6 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:2000002 ! visual estimation - plant uniformity
 
 [Term]
@@ -9321,7 +9321,7 @@ relationship: method_of CO_331:2000006 ! plant production
 id: CO_331:2000008
 name: PltProd 6 pt. scale
 namespace: SweetpotatoScale
-is_a: CO_331:1000019 ! Numerical
+is_a: CO_331:1000030 ! Nominal
 relationship: scale_of CO_331:2000007 ! visual estimation - plant production
 
 [Term]


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
New traits added for PVS and NIRS 
Update of some traits based on Ted Carrey feedback

Changes as agreed by @bellerbrock when we were in Montpellier:
- Trait ID CO_331:0000413 “Predominant Skin color” replaced by CO_331:0000049 “Skin Color of roots” as flagged as duplicate
- Trait ID CO_331:0000069 “Storage Root Shape (primary)” is replaced by CO_331:0000067 “Storage Root Shape”  as flagged as duplicate
- Trait ID CO_331:0000426 “Storage root form” is replaced by CO_331:0000199 “Storage Root Appearance”  as flagged as duplicate
- Trait ID CO_331:0000426 flagged as duplicate, replaced by CO_331:0000423
- The following traits and variables have been deleted as no data was in the database:

1. CO_331:0000404 appearance of flower
2. CO_331:0000768 Flower measuring image
3. CO_331:0000408 appearance of hearbarium
4. CO_331:0000772 Herbarium measuring image
5. CO_331:0000407 appearance of leaves
6. CO_331:0000771 Leaf measuring image
7. CO_331:0000403 appearance of plant
8. CO_331:0000767 Habitus measuring image
9. CO_331:0000405 appearance of roots
10. CO_331:0000769 Root measuring image
11. CO_331:0000406 appearance of seeds
12. CO_331:0000770 Seeds measuring image




<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [x] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [X] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [x] New variables have a parent trait ID 
    - [x ] New variables have methods and scales 
  - [x] The OBO file has been validated
    - [ ] checked in sweetpotatobase
    - [x] checked CropOntology
